### PR TITLE
fix: resolve TS build errors in decorator module

### DIFF
--- a/sdk/typescript/decorators/index.ts
+++ b/sdk/typescript/decorators/index.ts
@@ -118,7 +118,7 @@ export function toolsFrom(instance: object): Array<(input: unknown) => Promise<u
     const method = (proto as Record<string, unknown>)[key];
     if (typeof method !== 'function') continue;
 
-    const toolDef = (method as Record<string, unknown>)[TOOL_DEF_KEY] as ToolDef | undefined;
+    const toolDef = (method as unknown as Record<string, unknown>)[TOOL_DEF_KEY] as ToolDef | undefined;
     if (!toolDef) continue;
 
     // Bind to instance so `this` works inside the method

--- a/sdk/typescript/decorators/tsconfig.json
+++ b/sdk/typescript/decorators/tsconfig.json
@@ -14,6 +14,6 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  "include": ["./**/*.ts", "../examples/**/*.ts"],
+  "include": ["./**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Remove examples from decorators/tsconfig.json include (caused rootDir mismatch during build) and fix Function-to-Record cast via unknown to satisfy strict type checking.