### PR TITLE
Fix Kubernetes datasource env interpolation order

### DIFF
--- a/deployment/k8s/server.yaml
+++ b/deployment/k8s/server.yaml
@@ -44,8 +44,6 @@ spec:
                   name: agentspan-config
                   key: SPRING_PROFILES_ACTIVE
             # PostgreSQL connection
-            - name: SPRING_DATASOURCE_URL
-              value: "jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)"
             - name: POSTGRES_HOST
               valueFrom:
                 configMapKeyRef:
@@ -61,6 +59,9 @@ spec:
                 configMapKeyRef:
                   name: agentspan-config
                   key: POSTGRES_DB
+            # Kubernetes expands $(VAR) in env values only after prior env vars are set.
+            - name: SPRING_DATASOURCE_URL
+              value: "jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)"
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
Fixes a Kubernetes rollout issue where `agentspan-server` crash-loops because `SPRING_DATASOURCE_URL` is rendered literally as `jdbc:postgresql://$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)`.

## Root Cause
In `deployment/k8s/server.yaml`, `SPRING_DATASOURCE_URL` was defined before `POSTGRES_HOST`, `POSTGRES_PORT`, and `POSTGRES_DB`.
Kubernetes env interpolation is order-dependent for `$(VAR)` references in the `env` list.

## Changes
- Move `SPRING_DATASOURCE_URL` to after `POSTGRES_HOST`, `POSTGRES_PORT`, and `POSTGRES_DB`.
- Add a brief inline comment documenting the ordering requirement.

## Why this is safe
No behavior change beyond making the existing intended datasource URL expansion actually work in Kubernetes.

## Verification
- Reproduced CrashLoopBackOff prior to fix with JDBC URL literal in runtime env.
- Verified rollout succeeds when datasource URL is correctly resolved (hotfix validation on test cluster).
