### PR TITLE
(WIP) `webhook_tool` - wait for inbound webhook events (WAIT_FOR_WEBHOOK)

### DIFF
--- a/sdk/python/examples/72_wait_for_webhook.py
+++ b/sdk/python/examples/72_wait_for_webhook.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Wait for Webhook — continuously listen for inbound webhook events.
+
+Demonstrates:
+    - webhook_tool: waits for a matching webhook event (Conductor WAIT_FOR_WEBHOOK task)
+    - Mixing a server-side webhook tool with a local Python notification tool
+    - Looping agent that keeps listening indefinitely
+
+The agent loops forever: each iteration waits for a webhook with $['agent'] == "notifier",
+then prints the value of $['message'] from the payload as a console notification.
+
+Requirements:
+    - Conductor server with LLM support
+    - AGENTSPAN_SERVER_URL=http://localhost:8080/api as environment variable
+    - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+"""
+
+from agentspan.agents import Agent, AgentRuntime, tool, webhook_tool
+from settings import settings
+
+
+# Python tool (needs a worker) — prints the notification to the console
+@tool
+def send_notification(message: str) -> str:
+    """Send a notification by printing it to the console."""
+    print(f"\n*** NOTIFICATION: {message} ***\n")
+    return f"Notification sent: {message}"
+
+
+# Server-side tool — waits for a matching webhook event (no worker needed)
+incoming_event = webhook_tool(
+    name="wait_for_event",
+    description="Wait for an inbound webhook event targeted at this notifier agent.",
+    matches={
+        "$['agent']": "notifier",
+    },
+)
+
+agent = Agent(
+    name="webhook_notifier",
+    model=settings.llm_model,
+    tools=[incoming_event, send_notification],
+    max_turns=10000,
+    instructions=(
+        "You are a notification agent that runs forever in a loop. "
+        "Repeat this cycle indefinitely: "
+        "1. Call wait_for_event to wait for the next webhook. "
+        "2. Extract the 'message' field from the webhook payload. "
+        "3. Call send_notification with that message. "
+        "4. Go back to step 1 immediately — never stop."
+    ),
+)
+
+with AgentRuntime() as runtime:
+    result = runtime.run(agent, "Start the notification loop.")
+    result.print_result()

--- a/sdk/python/src/agentspan/agents/__init__.py
+++ b/sdk/python/src/agentspan/agents/__init__.py
@@ -180,6 +180,7 @@ from agentspan.agents.tool import (
     search_tool,
     tool,
     video_tool,
+    webhook_tool,
 )
 
 # Tracing (optional — only activates if opentelemetry is installed)
@@ -207,6 +208,7 @@ __all__ = [
     "http_tool",
     "human_tool",
     "mcp_tool",
+    "webhook_tool",
     "image_tool",
     "audio_tool",
     "video_tool",

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -926,6 +926,55 @@ def search_tool(
     )
 
 
+# ── Webhook wait tool ───────────────────────────────────────────────────
+
+
+def webhook_tool(
+    name: str,
+    description: str,
+    matches: Optional[Dict[str, str]] = None,
+    input_schema: Optional[Dict[str, Any]] = None,
+) -> ToolDef:
+    """Create a tool that waits for an inbound webhook event (Conductor ``WAIT_FOR_WEBHOOK`` task).
+
+    When the LLM calls this tool, the workflow pauses until a webhook arrives
+    whose payload matches all of the provided JSONPath expressions.
+
+    No worker process is needed — the Conductor server handles the
+    ``WAIT_FOR_WEBHOOK`` task directly.
+
+    Args:
+        name: Tool name (shown to the LLM).
+        description: Human-readable description for the LLM.
+        matches: Static JSONPath match conditions baked in at compile time.
+            Keys are JSONPath expressions (e.g. ``"$['event']['type']"``),
+            values are the expected string values.
+        input_schema: JSON Schema for the LLM-provided parameters.
+
+    Example::
+
+        slack_event = webhook_tool(
+            name="wait_for_slack_message",
+            description="Wait for a Slack message webhook event.",
+            matches={
+                "$['event']['type']": "message",
+                "$['event']['text']": "Hello",
+            },
+        )
+    """
+    config: Dict[str, Any] = {}
+    if matches is not None:
+        config["matches"] = matches
+
+    return ToolDef(
+        name=name,
+        description=description,
+        input_schema=input_schema or {"type": "object", "properties": {}},
+        tool_type="wait_for_webhook",
+        config=config,
+    )
+
+
 # ── Human interaction tool ──────────────────────────────────────────────
 
 

--- a/server/src/main/java/dev/agentspan/runtime/compiler/ToolCompiler.java
+++ b/server/src/main/java/dev/agentspan/runtime/compiler/ToolCompiler.java
@@ -68,7 +68,8 @@ public class ToolCompiler {
             Map.entry("generate_audio", "GENERATE_AUDIO"),
             Map.entry("generate_video", "GENERATE_VIDEO"),
             Map.entry("rag_index", "LLM_INDEX_TEXT"),
-            Map.entry("rag_search", "LLM_SEARCH_INDEX")
+            Map.entry("rag_search", "LLM_SEARCH_INDEX"),
+            Map.entry("wait_for_webhook", "WAIT_FOR_WEBHOOK")
     );
 
     // ── Public API ───────────────────────────────────────────────────────
@@ -243,11 +244,12 @@ public class ToolCompiler {
         Map<String, Object> ragConfig = new LinkedHashMap<>();
         Map<String, Object> cliConfig = new LinkedHashMap<>();
         Map<String, Object> humanConfig = new LinkedHashMap<>();
+        Map<String, Object> webhookConfig = new LinkedHashMap<>();
 
         if (tools != null) {
             Set<String> serverSideTypes = Set.of("http", "mcp", "agent_tool", "cli",
                     "generate_image", "generate_audio", "generate_video", "generate_pdf",
-                    "rag_index", "rag_search", "human");
+                    "rag_index", "rag_search", "human", "wait_for_webhook");
 
             for (ToolConfig tool : tools) {
                 String toolType = tool.getToolType() != null ? tool.getToolType() : "worker";
@@ -304,6 +306,10 @@ public class ToolCompiler {
                     humanEntry.put("displayName", agentName + " — " + tool.getName());
                     humanEntry.put("description", tool.getDescription());
                     humanConfig.put(tool.getName(), humanEntry);
+                } else if ("wait_for_webhook".equals(toolType)) {
+                    Map<String, Object> webhookEntry = new LinkedHashMap<>();
+                    webhookEntry.put("matches", cfg.getOrDefault("matches", Collections.emptyMap()));
+                    webhookConfig.put(tool.getName(), webhookEntry);
                 }
             }
         }
@@ -315,8 +321,9 @@ public class ToolCompiler {
         String ragJson = JavaScriptBuilder.toJson(ragConfig);
         String cliJson = JavaScriptBuilder.toJson(cliConfig);
         String humanJson = JavaScriptBuilder.toJson(humanConfig);
+        String webhookJson = JavaScriptBuilder.toJson(webhookConfig);
 
-        String script = JavaScriptBuilder.enrichToolsScript(httpJson, mcpJson, mediaJson, agentToolJson, ragJson, cliJson, humanJson);
+        String script = JavaScriptBuilder.enrichToolsScript(httpJson, mcpJson, mediaJson, agentToolJson, ragJson, cliJson, humanJson, webhookJson);
 
         String enrichRef = agentName + "_" + p + "enrich_tools";
 
@@ -1359,6 +1366,7 @@ public class ToolCompiler {
         Map<String, Object> agentToolConfig = new LinkedHashMap<>();
         Map<String, Object> ragConfig = new LinkedHashMap<>();
         Map<String, Object> humanConfig = new LinkedHashMap<>();
+        Map<String, Object> webhookConfig = new LinkedHashMap<>();
 
         if (tools != null) {
             for (ToolConfig tool : tools) {
@@ -1401,6 +1409,10 @@ public class ToolCompiler {
                     humanEntry.put("displayName", agentName + " — " + tool.getName());
                     humanEntry.put("description", tool.getDescription());
                     humanConfig.put(tool.getName(), humanEntry);
+                } else if ("wait_for_webhook".equals(toolType)) {
+                    Map<String, Object> webhookEntry = new LinkedHashMap<>();
+                    webhookEntry.put("matches", cfg.getOrDefault("matches", Collections.emptyMap()));
+                    webhookConfig.put(tool.getName(), webhookEntry);
                 }
                 // MCP config comes from runtime — skip here
             }
@@ -1411,7 +1423,8 @@ public class ToolCompiler {
         String agentToolJson = JavaScriptBuilder.toJson(agentToolConfig);
         String ragJson = JavaScriptBuilder.toJson(ragConfig);
         String humanJson = JavaScriptBuilder.toJson(humanConfig);
-        String script = JavaScriptBuilder.enrichToolsScriptDynamic(httpJson, mediaJson, agentToolJson, ragJson, humanJson);
+        String webhookJson = JavaScriptBuilder.toJson(webhookConfig);
+        String script = JavaScriptBuilder.enrichToolsScriptDynamic(httpJson, mediaJson, agentToolJson, ragJson, humanJson, webhookJson);
 
         String enrichRef = agentName + "_" + p + "enrich_tools";
 

--- a/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -596,7 +596,8 @@ public class AgentService {
         // Register dispatch task for this agent's tools
         if (config.getTools() != null) {
             for (ToolConfig tool : config.getTools()) {
-                if ("worker".equals(tool.getToolType()) && !registered.contains(tool.getName())) {
+                String tt = tool.getToolType();
+                if (("worker".equals(tt) || "wait_for_webhook".equals(tt)) && !registered.contains(tool.getName())) {
                     registerTaskDef(tool.getName());
                     registered.add(tool.getName());
                 }

--- a/server/src/main/java/dev/agentspan/runtime/util/JavaScriptBuilder.java
+++ b/server/src/main/java/dev/agentspan/runtime/util/JavaScriptBuilder.java
@@ -168,7 +168,7 @@ public class JavaScriptBuilder {
     public static String enrichToolsScript(String httpConfigJson, String mcpConfigJson,
                                               String mediaConfigJson, String agentToolConfigJson,
                                               String ragConfigJson, String cliConfigJson,
-                                              String humanConfigJson) {
+                                              String humanConfigJson, String webhookConfigJson) {
         return iife(
             "  var httpCfg = " + httpConfigJson + ";" +
             "  var mcpCfg = " + mcpConfigJson + ";" +
@@ -177,6 +177,7 @@ public class JavaScriptBuilder {
             "  var ragCfg = " + ragConfigJson + ";" +
             "  var cliCfg = " + cliConfigJson + ";" +
             "  var humanCfg = " + humanConfigJson + ";" +
+            "  var webhookCfg = " + webhookConfigJson + ";" +
             "  var agentState = $.agentState || {};" +
             "  var tcs = $.toolCalls || [];" +
             "  var result = [];" +
@@ -254,6 +255,12 @@ public class JavaScriptBuilder {
             "      for (var k in inp) { hInputs[k] = inp[k]; }" +
             "      if (humanCfg[n].description) hInputs._description = humanCfg[n].description;" +
             "      t.inputParameters = hInputs;" +
+            "      t.optional = false;" +
+            "    } else if (webhookCfg[n]) {" +
+            "      t.type = 'WAIT_FOR_WEBHOOK';" +
+            "      t.name = n;" +
+            "      t.inputParameters = {matches: webhookCfg[n].matches || {}};" +
+            "      t.retryCount = 0;" +
             "      t.optional = false;" +
             "    }" +
             "    if (t.type === 'SIMPLE') {" +
@@ -712,7 +719,7 @@ public class JavaScriptBuilder {
      */
     public static String enrichToolsScriptDynamic(String httpConfigJson, String mediaConfigJson,
                                                      String agentToolConfigJson, String ragConfigJson,
-                                                     String humanConfigJson) {
+                                                     String humanConfigJson, String webhookConfigJson) {
         return iife(
             "  var httpCfg = " + httpConfigJson + ";" +
             "  var mcpCfg = $.mcpConfig || {};" +
@@ -721,6 +728,7 @@ public class JavaScriptBuilder {
             "  var agentToolCfg = " + agentToolConfigJson + ";" +
             "  var ragCfg = " + ragConfigJson + ";" +
             "  var humanCfg = " + humanConfigJson + ";" +
+            "  var webhookCfg = " + webhookConfigJson + ";" +
             "  var agentState = $.agentState || {};" +
             "  var tcs = $.toolCalls || [];" +
             "  var result = [];" +
@@ -831,6 +839,12 @@ public class JavaScriptBuilder {
             "      for (var k in inp) { hInputs[k] = inp[k]; }" +
             "      if (humanCfg[n].description) hInputs._description = humanCfg[n].description;" +
             "      t.inputParameters = hInputs;" +
+            "      t.optional = false;" +
+            "    } else if (webhookCfg[n]) {" +
+            "      t.type = 'WAIT_FOR_WEBHOOK';" +
+            "      t.name = n;" +
+            "      t.inputParameters = {matches: webhookCfg[n].matches || {}};" +
+            "      t.retryCount = 0;" +
             "      t.optional = false;" +
             "    }" +
             "    if (t.type === 'SIMPLE') {" +


### PR DESCRIPTION
Introduces `webhook_tool`, a new server-side tool type that pauses agent execution until a matching inbound webhook arrives, backed by Conductor's `WAIT_FOR_WEBHOOK` system task. No worker process is needed, the Conductor server   handles the task directly.


## Python SDK                                                
- New `webhook_tool()` factory in `tool.py` — accepts a name, description, and optional matches dict of JSONPath expressions that must match the incoming webhook payload.                                                                                                                                                                           
- Example `72_wait_for_webhook.py` demonstrating a notification agent that loops forever waiting for webhook events and printing the payload message.

## Java Server
- ToolCompiler: added `wait_for_webhook` to TYPE_MAP, serverSideTypes, and webhookConfig map construction (both buildEnrichTask and buildEnrichTaskDynamic).
- JavaScriptBuilder: added webhook branch in both enrich scripts — emits a `WAIT_FOR_WEBHOOK` dynamic task with inputParameters.matches populated from the tool config.
- AgentService: registers a task definition for `wait_for_webhook` tools so Conductor can resolve the task by name at runtime.

--- 
<img width="800" height="667" alt="Screenshot 2026-03-24 at 11 14 29" src="https://github.com/user-attachments/assets/b6c882c2-a1f3-4ee0-b4ca-2a5cad800bd8" />

<img width="800" height="945" alt="Screenshot 2026-03-24 at 11 14 40" src="https://github.com/user-attachments/assets/7daaa961-70d4-42da-aaa3-8aafbb35c387" />

--- 

**NOTES**

Conductor OSS is missing webhook support at the moment.
