### PR TITLE
Change default server port from 8080 to 6767

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      AGENTSPAN_SERVER_URL: http://localhost:8080/api
+      AGENTSPAN_SERVER_URL: http://localhost:6767/api
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -118,7 +118,7 @@ jobs:
       - name: Start server
         run: |
           java -jar server/build/libs/agentspan-runtime-shaded.jar &
-          for i in $(seq 1 30); do curl -sf http://localhost:8080/health && break; sleep 2; done
+          for i in $(seq 1 30); do curl -sf http://localhost:6767/health && break; sleep 2; done
 
       - name: Install Python SDK
         working-directory: sdk/python
@@ -136,7 +136,7 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      AGENTSPAN_SERVER_URL: http://localhost:8080/api
+      AGENTSPAN_SERVER_URL: http://localhost:6767/api
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -156,7 +156,7 @@ jobs:
       - name: Start server
         run: |
           java -jar server/build/libs/agentspan-runtime-shaded.jar &
-          for i in $(seq 1 30); do curl -sf http://localhost:8080/health && break; sleep 2; done
+          for i in $(seq 1 30); do curl -sf http://localhost:6767/health && break; sleep 2; done
 
       - name: Install TypeScript SDK
         working-directory: sdk/typescript

--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -238,7 +238,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	// Port availability
-	port := "8080"
+	port := "6767"
 	if serverPort != "" {
 		port = serverPort
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -39,6 +39,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&serverURL, "server", "", "Runtime server URL (default: http://localhost:8080)")
+	rootCmd.PersistentFlags().StringVar(&serverURL, "server", "", "Runtime server URL (default: http://localhost:6767)")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cli/cmd/server.go
+++ b/cli/cmd/server.go
@@ -58,7 +58,7 @@ var serverLogsCmd = &cobra.Command{
 }
 
 func init() {
-	serverStartCmd.Flags().StringVarP(&serverPort, "port", "p", "8080", "Server port")
+	serverStartCmd.Flags().StringVarP(&serverPort, "port", "p", "6767", "Server port")
 	serverStartCmd.Flags().StringVarP(&serverModel, "model", "m", "", "Default LLM model (e.g. openai/gpt-4o)")
 	serverStartCmd.Flags().StringVar(&serverVersion, "version", "", "Specific server version to download (e.g. 0.1.0)")
 	serverStartCmd.Flags().StringVar(&serverJar, "jar", "", "Path to a local JAR file to use directly")
@@ -158,7 +158,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	javaArgs := []string{"-jar", jarPath}
 
 	env := os.Environ()
-	if serverPort != "8080" {
+	if serverPort != "6767" {
 		env = append(env, "SERVER_PORT="+serverPort)
 	}
 	if serverModel != "" {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -30,7 +30,7 @@ func (c *Config) IsLocalhost() bool {
 
 func DefaultConfig() *Config {
 	return &Config{
-		ServerURL: "http://localhost:8080",
+		ServerURL: "http://localhost:6767",
 	}
 }
 
@@ -73,7 +73,7 @@ func Load() *Config {
 	}
 	var fileCfg Config
 	if json.Unmarshal(data, &fileCfg) == nil {
-		if cfg.ServerURL == "http://localhost:8080" && fileCfg.ServerURL != "" {
+		if cfg.ServerURL == "http://localhost:6767" && fileCfg.ServerURL != "" {
 			cfg.ServerURL = fileCfg.ServerURL
 		}
 		if cfg.AuthKey == "" && fileCfg.AuthKey != "" {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -15,13 +15,13 @@ func TestIsLocalhost(t *testing.T) {
 		url      string
 		expected bool
 	}{
-		{"localhost with port", "http://localhost:8080", true},
+		{"localhost with port", "http://localhost:6767", true},
 		{"localhost no port", "http://localhost", true},
-		{"127.0.0.1 with port", "http://127.0.0.1:8080", true},
+		{"127.0.0.1 with port", "http://127.0.0.1:6767", true},
 		{"127.0.0.1 no port", "http://127.0.0.1", true},
-		{"https localhost with port", "https://localhost:8080", true},
+		{"https localhost with port", "https://localhost:6767", true},
 		{"https 127.0.0.1", "https://127.0.0.1", true},
-		{"ipv6 loopback", "http://[::1]:8080", true},
+		{"ipv6 loopback", "http://[::1]:6767", true},
 		{"remote http", "http://team.agentspan.io", false},
 		{"remote https", "https://team.agentspan.io", false},
 		{"empty string", "", false},

--- a/deployment/docker-compose/compose.yaml
+++ b/deployment/docker-compose/compose.yaml
@@ -26,7 +26,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "${AGENTSPAN_PORT:-8080}:8080"
+      - "${AGENTSPAN_PORT:-6767}:6767"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:

--- a/deployment/helm/agentspan/templates/deployment.yaml
+++ b/deployment/helm/agentspan/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 6767
               protocol: TCP
           env:
             - name: JAVA_TOOL_OPTIONS

--- a/deployment/helm/agentspan/values.yaml
+++ b/deployment/helm/agentspan/values.yaml
@@ -25,7 +25,7 @@ terminationGracePeriodSeconds: 30
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 6767
 
 ingress:
   enabled: false

--- a/deployment/k8s/ingress.yaml
+++ b/deployment/k8s/ingress.yaml
@@ -9,7 +9,7 @@
 # For TLS (recommended), install cert-manager and uncomment the TLS section:
 #   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
 #
-# All traffic → agentspan-server:8080
+# All traffic → agentspan-server:6767
 #   The server JAR includes the built UI served from / (Spring Boot static resources).
 #   API routes (/api, /swagger-ui, /api-docs) are handled by the same server.
 apiVersion: networking.k8s.io/v1
@@ -36,7 +36,7 @@ spec:
               service:
                 name: agentspan-server
                 port:
-                  number: 8080
+                  number: 6767
   # ── TLS (uncomment when cert-manager is set up) ───────────────────────────
   # tls:
   #   - hosts:

--- a/deployment/k8s/server.yaml
+++ b/deployment/k8s/server.yaml
@@ -28,7 +28,7 @@ spec:
           image: agentspan/server:latest
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 6767
               name: http
           # Pass JVM options as JAVA_TOOL_OPTIONS so the JVM picks them up
           # without needing to modify the Dockerfile ENTRYPOINT.
@@ -158,7 +158,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
-              port: 8080
+              port: 6767
             initialDelaySeconds: 45
             periodSeconds: 10
             timeoutSeconds: 5
@@ -166,7 +166,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
-              port: 8080
+              port: 6767
             initialDelaySeconds: 60
             periodSeconds: 20
             timeoutSeconds: 5
@@ -174,7 +174,7 @@ spec:
           startupProbe:
             httpGet:
               path: /actuator/health
-              port: 8080
+              port: 6767
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 12   # Allow up to 2 min for startup
@@ -193,8 +193,8 @@ spec:
   selector:
     app: agentspan-server
   ports:
-    - port: 8080
-      targetPort: 8080
+    - port: 6767
+      targetPort: 6767
       protocol: TCP
       name: http
 

--- a/sdk/python/src/agentspan/agents/run.py
+++ b/sdk/python/src/agentspan/agents/run.py
@@ -59,7 +59,7 @@ def configure(config=None, **kwargs):
             are ignored.
         **kwargs: Individual config fields to override on top of
             :meth:`AgentConfig.from_env` defaults (e.g.
-            ``server_url="https://prod:8080/api"``,
+            ``server_url="https://prod:6767/api"``,
             ``auto_start_server=False``).
 
     Raises:
@@ -71,7 +71,7 @@ def configure(config=None, **kwargs):
 
         import agentspan.agents as ag
 
-        ag.configure(server_url="https://prod:8080/api", auto_start_server=False)
+        ag.configure(server_url="https://prod:6767/api", auto_start_server=False)
         result = ag.run(agent, "Hello!")
     """
     global _default_config, _default_runtime

--- a/sdk/python/src/agentspan/agents/runtime/config.py
+++ b/sdk/python/src/agentspan/agents/runtime/config.py
@@ -9,7 +9,7 @@ Constructor kwargs allow direct overrides (useful for tests).
 Usage::
 
     config = AgentConfig.from_env()                          # load from env
-    config = AgentConfig(server_url="http://custom:8080/api")  # explicit
+    config = AgentConfig(server_url="http://custom:6767/api")  # explicit
 """
 
 from __future__ import annotations
@@ -66,7 +66,7 @@ class AgentConfig:
         log_level: Logging level for the agentspan logger.
     """
 
-    server_url: str = "http://localhost:8080/api"
+    server_url: str = "http://localhost:6767/api"
     api_key: Optional[str] = None
     auth_key: Optional[str] = None
     auth_secret: Optional[str] = None
@@ -101,7 +101,7 @@ class AgentConfig:
         if isinstance(log_level, str) and log_level.strip() == "":
             log_level = "INFO"
         return cls(
-            server_url=_env("AGENTSPAN_SERVER_URL", "http://localhost:8080/api"),
+            server_url=_env("AGENTSPAN_SERVER_URL", "http://localhost:6767/api"),
             api_key=_env("AGENTSPAN_API_KEY"),
             auth_key=_env("AGENTSPAN_AUTH_KEY"),
             auth_secret=_env("AGENTSPAN_AUTH_SECRET"),

--- a/sdk/python/src/agentspan/agents/runtime/credentials/fetcher.py
+++ b/sdk/python/src/agentspan/agents/runtime/credentials/fetcher.py
@@ -29,13 +29,13 @@ class WorkerCredentialFetcher:
     """Fetches credentials for a worker task execution.
 
     Args:
-        server_url: Base URL of the agentspan server API (e.g. ``"http://localhost:8080/api"``).
+        server_url: Base URL of the agentspan server API (e.g. ``"http://localhost:6767/api"``).
         api_key: Optional Bearer token or API key for the Authorization header.
     """
 
     def __init__(
         self,
-        server_url: str = "http://localhost:8080/api",
+        server_url: str = "http://localhost:6767/api",
         strict_mode: bool = False,
         api_key: Optional[str] = None,
     ) -> None:

--- a/sdk/python/tests/e2e/test_credential_e2e.py
+++ b/sdk/python/tests/e2e/test_credential_e2e.py
@@ -9,7 +9,7 @@ Exercises the FULL credential pipeline — no mocks anywhere:
   6. Non-isolated tool receives credentials via context var
   7. Config serializer includes credentials in tool config
 
-Requires: agentspan server running at AGENTSPAN_SERVER_URL (default localhost:8080)
+Requires: agentspan server running at AGENTSPAN_SERVER_URL (default localhost:6767)
 """
 
 import os
@@ -17,7 +17,7 @@ import sys
 
 import httpx
 
-SERVER = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:8080")
+SERVER = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:6767")
 API = f"{SERVER}/api"
 CRED_NAME = "_E2E_TEST_CRED"
 CRED_VALUE = "e2e-test-secret-value-12345"

--- a/sdk/python/tests/e2e/test_framework_credentials.py
+++ b/sdk/python/tests/e2e/test_framework_credentials.py
@@ -5,7 +5,7 @@ import threading
 import httpx
 import pytest
 
-SERVER = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:8080")
+SERVER = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:6767")
 API = f"{SERVER}/api"
 CRED_NAME = "_E2E_FW_CRED"
 CRED_VALUE = "framework-secret-12345"

--- a/sdk/python/tests/integration/conftest.py
+++ b/sdk/python/tests/integration/conftest.py
@@ -21,7 +21,7 @@ from agentspan.agents import AgentRuntime
 from agentspan.agents.runtime.config import AgentConfig
 
 DEFAULT_MODEL = os.environ.get("AGENTSPAN_LLM_MODEL", "openai/gpt-4o-mini")
-_SERVER_URL = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:8080/api")
+_SERVER_URL = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:6767/api")
 
 
 def _conductor_base() -> str:

--- a/sdk/python/tests/integration/test_e2e_streaming.py
+++ b/sdk/python/tests/integration/test_e2e_streaming.py
@@ -7,7 +7,7 @@ These tests require a running Conductor server with LLM and streaming support.
 Skip with: pytest -m "not integration"
 
 Requirements:
-    - export AGENTSPAN_SERVER_URL=http://localhost:8080/api
+    - export AGENTSPAN_SERVER_URL=http://localhost:6767/api
     - LLM provider configured (OpenAI by default)
     - Optionally: export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
 """

--- a/sdk/python/tests/integration/test_guardrail_matrix.py
+++ b/sdk/python/tests/integration/test_guardrail_matrix.py
@@ -13,7 +13,7 @@ Run:
 
 Requirements:
     - Conductor server running
-    - AGENTSPAN_SERVER_URL=http://localhost:8080/api
+    - AGENTSPAN_SERVER_URL=http://localhost:6767/api
     - AGENT_LLM_MODEL set (default: openai/gpt-4o-mini)
 """
 

--- a/sdk/python/tests/integration/test_multi_agent_matrix.py
+++ b/sdk/python/tests/integration/test_multi_agent_matrix.py
@@ -14,7 +14,7 @@ Run:
 
 Requirements:
     - Conductor server running
-    - AGENTSPAN_SERVER_URL=http://localhost:8080/api
+    - AGENTSPAN_SERVER_URL=http://localhost:6767/api
     - AGENT_LLM_MODEL set (default: openai/gpt-4o-mini)
 """
 

--- a/sdk/python/tests/unit/credentials/test_fetcher.py
+++ b/sdk/python/tests/unit/credentials/test_fetcher.py
@@ -19,7 +19,7 @@ from agentspan.agents.runtime.credentials.types import (
 
 
 def _make_fetcher():
-    return WorkerCredentialFetcher(server_url="http://localhost:8080/api")
+    return WorkerCredentialFetcher(server_url="http://localhost:6767/api")
 
 
 class TestFetchWithoutToken:

--- a/sdk/python/tests/unit/test_config_env.py
+++ b/sdk/python/tests/unit/test_config_env.py
@@ -84,7 +84,7 @@ class TestAgentConfigFromEnv:
     def test_defaults_to_localhost_when_nothing_set(self):
         with mock.patch.dict(os.environ, {}, clear=True):
             config = AgentConfig.from_env()
-            assert config.server_url == "http://localhost:8080/api"
+            assert config.server_url == "http://localhost:6767/api"
 
     def test_reads_agentspan_auth_key(self):
         env = {"AGENTSPAN_AUTH_KEY": "mykey", "AGENTSPAN_AUTH_SECRET": "mysecret"}
@@ -143,20 +143,20 @@ class TestServerUrlNormalisation:
     """Tests for BUG-P2-10: auto-append /api when missing."""
 
     def test_appends_api_when_missing(self):
-        config = AgentConfig(server_url="http://localhost:8080")
-        assert config.server_url == "http://localhost:8080/api"
+        config = AgentConfig(server_url="http://localhost:6767")
+        assert config.server_url == "http://localhost:6767/api"
 
     def test_appends_api_with_trailing_slash(self):
-        config = AgentConfig(server_url="http://localhost:8080/")
-        assert config.server_url == "http://localhost:8080/api"
+        config = AgentConfig(server_url="http://localhost:6767/")
+        assert config.server_url == "http://localhost:6767/api"
 
     def test_leaves_correct_url_unchanged(self):
-        config = AgentConfig(server_url="http://localhost:8080/api")
-        assert config.server_url == "http://localhost:8080/api"
+        config = AgentConfig(server_url="http://localhost:6767/api")
+        assert config.server_url == "http://localhost:6767/api"
 
     def test_leaves_correct_url_with_trailing_slash(self):
-        config = AgentConfig(server_url="http://localhost:8080/api/")
-        assert config.server_url == "http://localhost:8080/api"
+        config = AgentConfig(server_url="http://localhost:6767/api/")
+        assert config.server_url == "http://localhost:6767/api"
 
     def test_remote_url_without_api(self):
         config = AgentConfig(server_url="https://play.orkes.io")
@@ -172,7 +172,7 @@ class TestServerUrlNormalisation:
     def test_default_url_has_api(self):
         with mock.patch.dict(os.environ, {}, clear=True):
             config = AgentConfig.from_env()
-            assert config.server_url == "http://localhost:8080/api"
+            assert config.server_url == "http://localhost:6767/api"
 
 
 class TestLogLevelConfig:
@@ -204,7 +204,7 @@ class TestLogLevelConfig:
         import logging
 
         config = AgentConfig(
-            server_url="http://localhost:8080/api",
+            server_url="http://localhost:6767/api",
             log_level="WARNING",
         )
         with mock.patch("conductor.client.orkes_clients.OrkesClients"):

--- a/sdk/python/tests/unit/test_runtime.py
+++ b/sdk/python/tests/unit/test_runtime.py
@@ -277,7 +277,7 @@ class TestAgentConfig:
         from agentspan.agents.runtime.config import AgentConfig
 
         config = AgentConfig()
-        assert config.server_url == "http://localhost:8080/api"
+        assert config.server_url == "http://localhost:6767/api"
         assert config.llm_retry_count == 3
         assert config.worker_poll_interval_ms == 100
 

--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -80,7 +80,7 @@ export class AgentConfig {
     const rawUrl =
       options?.serverUrl ??
       env.AGENTSPAN_SERVER_URL ??
-      'http://localhost:8080/api';
+      'http://localhost:6767/api';
 
     this.serverUrl = normalizeServerUrl(rawUrl);
 

--- a/sdk/typescript/tests/unit/config.test.ts
+++ b/sdk/typescript/tests/unit/config.test.ts
@@ -3,29 +3,29 @@ import { AgentConfig, normalizeServerUrl } from '../../src/config.js';
 
 describe('normalizeServerUrl', () => {
   it('appends /api when missing', () => {
-    expect(normalizeServerUrl('http://localhost:8080')).toBe(
-      'http://localhost:8080/api',
+    expect(normalizeServerUrl('http://localhost:6767')).toBe(
+      'http://localhost:6767/api',
     );
   });
 
   it('does not double-append /api', () => {
-    expect(normalizeServerUrl('http://localhost:8080/api')).toBe(
-      'http://localhost:8080/api',
+    expect(normalizeServerUrl('http://localhost:6767/api')).toBe(
+      'http://localhost:6767/api',
     );
   });
 
   it('strips trailing slashes before appending', () => {
-    expect(normalizeServerUrl('http://localhost:8080/')).toBe(
-      'http://localhost:8080/api',
+    expect(normalizeServerUrl('http://localhost:6767/')).toBe(
+      'http://localhost:6767/api',
     );
-    expect(normalizeServerUrl('http://localhost:8080///')).toBe(
-      'http://localhost:8080/api',
+    expect(normalizeServerUrl('http://localhost:6767///')).toBe(
+      'http://localhost:6767/api',
     );
   });
 
   it('strips trailing slash after /api', () => {
-    expect(normalizeServerUrl('http://localhost:8080/api/')).toBe(
-      'http://localhost:8080/api',
+    expect(normalizeServerUrl('http://localhost:6767/api/')).toBe(
+      'http://localhost:6767/api',
     );
   });
 
@@ -82,7 +82,7 @@ describe('AgentConfig', () => {
     it('uses default values when no options or env vars', () => {
       const config = new AgentConfig();
 
-      expect(config.serverUrl).toBe('http://localhost:8080/api');
+      expect(config.serverUrl).toBe('http://localhost:6767/api');
       expect(config.apiKey).toBe('');
       expect(config.authKey).toBe('');
       expect(config.authSecret).toBe('');
@@ -229,7 +229,7 @@ describe('AgentConfig', () => {
     it('uses defaults when no env vars set', () => {
       const config = AgentConfig.fromEnv();
 
-      expect(config.serverUrl).toBe('http://localhost:8080/api');
+      expect(config.serverUrl).toBe('http://localhost:6767/api');
       expect(config.apiKey).toBe('');
       expect(config.logLevel).toBe('INFO');
     });

--- a/sdk/typescript/tests/unit/runtime.test.ts
+++ b/sdk/typescript/tests/unit/runtime.test.ts
@@ -70,7 +70,7 @@ describe('AgentRuntime', () => {
     it('creates with default config', () => {
       const runtime = new AgentRuntime();
       expect(runtime.config).toBeInstanceOf(AgentConfig);
-      expect(runtime.config.serverUrl).toBe('http://localhost:8080/api');
+      expect(runtime.config.serverUrl).toBe('http://localhost:6767/api');
     });
 
     it('creates with custom config', () => {
@@ -148,7 +148,7 @@ describe('AgentRuntime', () => {
       await runtime._httpRequest('POST', '/agent/start', { prompt: 'hi' });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/agent/start',
+        'http://localhost:6767/api/agent/start',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
@@ -173,7 +173,7 @@ describe('AgentRuntime', () => {
       await runtime._httpRequest('GET', '/test');
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/test',
+        'http://localhost:6767/api/test',
         expect.objectContaining({
           headers: expect.objectContaining({
             'X-Auth-Key': 'my-auth-key',
@@ -265,7 +265,7 @@ describe('AgentRuntime', () => {
         return { ok: true, status: 200, text: async () => '{}' };
       });
 
-      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:8080/api' });
+      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:6767/api' });
       const { Agent } = await import('../../src/agent.js');
       const agent = new Agent({ name: 'test_agent', model: 'gpt-4o' });
 
@@ -278,7 +278,7 @@ describe('AgentRuntime', () => {
 
       // Verify SSE URL uses /agent/stream/{id}
       const sseCall = fetchCalls.find((u) => u.includes('/stream/') || u.includes('/sse'));
-      expect(sseCall).toBe('http://localhost:8080/api/agent/stream/wf-sse-test');
+      expect(sseCall).toBe('http://localhost:6767/api/agent/stream/wf-sse-test');
     });
   });
 
@@ -287,7 +287,7 @@ describe('AgentRuntime', () => {
       const fetchCalls: string[] = [];
       mockAgentServer('wf-native-stream', fetchCalls);
 
-      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:8080/api' });
+      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:6767/api' });
       vi.spyOn((runtime as any).workerManager, 'startPolling').mockImplementation(() => {});
 
       const { Agent } = await import('../../src/agent.js');
@@ -298,14 +298,14 @@ describe('AgentRuntime', () => {
 
       expect(result.status).toBe('COMPLETED');
       expect(result.output).toEqual({ result: 'ok' });
-      expect(fetchCalls).toContain('http://localhost:8080/api/agent/stream/wf-native-stream');
+      expect(fetchCalls).toContain('http://localhost:6767/api/agent/stream/wf-native-stream');
     });
 
     it('streams framework agents through the same SSE endpoint', async () => {
       const fetchCalls: string[] = [];
       mockAgentServer('wf-framework-stream', fetchCalls);
 
-      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:8080/api' });
+      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:6767/api' });
       vi.spyOn((runtime as any).workerManager, 'startPolling').mockImplementation(() => {});
 
       const openAiAgent = {
@@ -321,7 +321,7 @@ describe('AgentRuntime', () => {
 
       expect(result.status).toBe('COMPLETED');
       expect(result.output).toEqual({ result: 'ok' });
-      expect(fetchCalls).toContain('http://localhost:8080/api/agent/stream/wf-framework-stream');
+      expect(fetchCalls).toContain('http://localhost:6767/api/agent/stream/wf-framework-stream');
 
       const startCall = (global.fetch as any).mock.calls.find(([url]: [string]) =>
         url.includes('/agent/start'),
@@ -335,7 +335,7 @@ describe('AgentRuntime', () => {
     it('includes credentials in native run start payload', async () => {
       mockAgentServer('wf-native-cred');
 
-      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:8080/api' });
+      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:6767/api' });
       vi.spyOn((runtime as any).workerManager, 'startPolling').mockImplementation(() => {});
       vi.spyOn((runtime as any).workerManager, 'stopPolling').mockImplementation(() => {});
 
@@ -356,7 +356,7 @@ describe('AgentRuntime', () => {
     it('includes credentials in framework run start payload', async () => {
       mockAgentServer('wf-framework-cred');
 
-      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:8080/api' });
+      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:6767/api' });
       vi.spyOn((runtime as any).workerManager, 'startPolling').mockImplementation(() => {});
       vi.spyOn((runtime as any).workerManager, 'stopPolling').mockImplementation(() => {});
 
@@ -383,7 +383,7 @@ describe('AgentRuntime', () => {
     it('includes credentials in framework start payload', async () => {
       mockAgentServer('wf-framework-start-cred');
 
-      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:8080/api' });
+      const runtime = new AgentRuntime({ serverUrl: 'http://localhost:6767/api' });
       vi.spyOn((runtime as any).workerManager, 'startPolling').mockImplementation(() => {});
 
       const openAiAgent = {

--- a/sdk/typescript/tests/unit/swarm-workers.test.ts
+++ b/sdk/typescript/tests/unit/swarm-workers.test.ts
@@ -30,7 +30,7 @@ async function invokeWorker(
 }
 
 function createRuntime(): AgentRuntime {
-  return new AgentRuntime({ serverUrl: 'http://localhost:8080/api' });
+  return new AgentRuntime({ serverUrl: 'http://localhost:6767/api' });
 }
 
 // ── OnToolResult.shouldHandoff ──────────────────────────

--- a/server/src/main/java/dev/agentspan/runtime/AgentRuntime.java
+++ b/server/src/main/java/dev/agentspan/runtime/AgentRuntime.java
@@ -49,7 +49,7 @@ public class AgentRuntime implements ApplicationRunner {
         String dbType = environment.getProperty("conductor.db.type", "memory");
         String queueType = environment.getProperty("conductor.queue.type", "memory");
         String indexingType = environment.getProperty("conductor.indexing.type", "memory");
-        String port = environment.getProperty("server.port", "8080");
+        String port = environment.getProperty("server.port", "6767");
         String contextPath = environment.getProperty("server.servlet.context-path", "");
 
         String hostname;

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=conductor
 spring.main.allow-bean-definition-overriding=true
-server.port=8080
+server.port=6767
 
 # Graceful shutdown — stop accepting new connections, let in-flight requests finish
 server.shutdown=graceful

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -18,7 +18,7 @@ def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line("markers", "integration: e2e tests requiring a live server")
 
-SERVER_URL = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:8080/api")
+SERVER_URL = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:6767/api")
 BASE_URL = SERVER_URL.rstrip("/").replace("/api", "")
 
 @pytest.fixture(scope="session", autouse=True)

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -102,15 +102,15 @@ export default defineConfig(({ mode }) => {
       port: 1234,
       proxy: {
         "/api": {
-          target: env.VITE_WF_SERVER || "http://localhost:8080",
+          target: env.VITE_WF_SERVER || "http://localhost:6767",
           changeOrigin: true,
         },
         "/swagger-ui": {
-          target: env.VITE_WF_SERVER || "http://localhost:8080",
+          target: env.VITE_WF_SERVER || "http://localhost:6767",
           changeOrigin: true,
         },
         "/api-docs": {
-          target: env.VITE_WF_SERVER || "http://localhost:8080",
+          target: env.VITE_WF_SERVER || "http://localhost:6767",
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
## Summary

- Changes the default server port from **8080** to **6767** across all layers

## Changes

### Server
- `application.properties`: `server.port=6767`
- `AgentRuntime.java`: fallback port updated

### CLI
- Default `--port` flag, config defaults, doctor checks, help text

### SDKs
- Python SDK: `AgentConfig.server_url` default, credential fetcher default
- TypeScript SDK: `config.ts` default URL

### UI
- Vite dev proxy targets

### CI/CD
- `ci.yml`: env vars and health check URLs
- k8s, Helm, docker-compose deployment configs

### Tests
- CLI config tests, Python config/runtime tests, TypeScript config/runtime tests, e2e conftest

## Test plan
- [x] Server compiles (`./gradlew compileJava`)
- [x] CLI tests pass (`go test ./... -race`)
- [x] UI builds (`npm run build`)
- [x] Python SDK tests pass (`uv run pytest tests/unit/`)
- [x] TypeScript SDK tests pass (`npx vitest run tests/unit/`)
- [x] UI Playwright e2e tests pass (58/58)

🤖 Generated with [Claude Code](https://claude.com/claude-code)