### PR TITLE
chore: add Orca security scanning workflow

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -6,6 +6,7 @@ on:
       project_key:
         description: Orca Shift Left project key
         required: false
+        default: agentspan
         type: string
 
 permissions:
@@ -13,30 +14,12 @@ permissions:
   security-events: write
 
 env:
-  ORCA_PROJECT_KEY: ${{ vars.ORCA_PROJECT_KEY || github.event.inputs.project_key }}
+  ORCA_PROJECT_KEY: ${{ vars.ORCA_PROJECT_KEY || github.event.inputs.project_key || 'agentspan' }}
 
 jobs:
-  validate-config:
-    name: Validate Orca Config
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate required Orca settings
-        env:
-          ORCA_SECURITY_API_TOKEN: ${{ secrets.ORCA_SECURITY_API_TOKEN }}
-        run: |
-          test -n "${ORCA_PROJECT_KEY}" || {
-            echo "Set repo variable ORCA_PROJECT_KEY or provide the workflow_dispatch project_key input."
-            exit 1
-          }
-          test -n "${ORCA_SECURITY_API_TOKEN}" || {
-            echo "Set repo secret ORCA_SECURITY_API_TOKEN."
-            exit 1
-          }
-
   image-scan:
     name: Orca Image Scan
     runs-on: ubuntu-latest
-    needs: validate-config
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +51,6 @@ jobs:
   sast:
     name: Orca SAST
     runs-on: ubuntu-latest
-    needs: validate-config
     steps:
       - uses: actions/checkout@v4
         with:
@@ -94,7 +76,6 @@ jobs:
   fs-scan:
     name: Orca FS Scan
     runs-on: ubuntu-latest
-    needs: validate-config
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- add a manual Orca security workflow modeled on the `orkes-conductor` setup
- scan the server container image with `orca-cli`
- add Orca SAST and filesystem scanning with SARIF upload to GitHub code scanning

## Setup
- requires repo secret `ORCA_SECURITY_API_TOKEN`
- use the original Orca-provided token bundle string for that secret
- optionally set repo variable `ORCA_PROJECT_KEY`; otherwise the workflow defaults to `agentspan`
- workflow is `workflow_dispatch` only for now

## Validation
- parsed `.github/workflows/orca.yml` successfully with Ruby YAML
- local Orca CLI scans against fresh `main` succeeded for FS and SCA using project key `agentspan`
- local artifacts were written to `/tmp/agentspan-orca-results/fs-retry.json` and `/tmp/agentspan-orca-results/sca.json`
- local image scan remains blocked by a repo build issue in `main`: `server/Dockerfile` fails because `ui/package.json` and `ui/pnpm-lock.yaml` are out of sync under `pnpm install --frozen-lockfile`
- local SAST did not complete in the time allotted and appeared to stall idle after starting analysis
