### PR TITLE
fix: resolve import error on fresh install and document Python 3.10+ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ## Quickstart (60 seconds)
 
 ```bash
-# 1. Install
+# 1. Install (requires Python 3.10+)
 npm install -g @agentspan-ai/agentspan          # installs the CLI
 pip install agentspan                         # installs the Python SDK
 export OPENAI_API_KEY=sk-...                  # or any supported provider

--- a/sdk/python/src/agentspan/agents/skill.py
+++ b/sdk/python/src/agentspan/agents/skill.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import yaml
-
 from agentspan.agents.agent import Agent
 
 
@@ -18,6 +16,8 @@ class SkillLoadError(Exception):
 
 def parse_frontmatter(content: str) -> Dict[str, Any]:
     """Extract YAML frontmatter from SKILL.md content."""
+    import yaml
+
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
     if not match:
         return {}


### PR DESCRIPTION
## Changes

**`sdk/python/src/agentspan/agents/skill.py`**
- Move `import yaml` from module-level into `parse_frontmatter()`. The top-level import caused `ModuleNotFoundError: No module named 'yaml'` on every `from agentspan.agents import ...`, even when skills are never used. `pyyaml` is not a declared dependency.

**`README.md`**
- Add `requires Python 3.10+` note to quickstart. On Python 3.9, `pip install agentspan` silently resolves to `0.0.8` (the last version without the `>=3.10` constraint) with no warning, giving users a broken install.

## Root cause
Both issues were caught during a fresh install test against `0.0.12`.