### PR TITLE
feat: testing examples, eval capture, and multi-agent mock support

### DIFF
--- a/docs/design/TESTING_FRAMEWORK_STATUS.md
+++ b/docs/design/TESTING_FRAMEWORK_STATUS.md
@@ -1,0 +1,285 @@
+# Testing Framework — Current State
+
+> Last updated: 2026-04-07
+> Branch: `feat/testing-examples-and-capture`
+> Status: **Full Python ↔ TypeScript parity achieved**
+
+This document captures the complete current state of the Agentspan testing framework across both SDKs.
+
+---
+
+## Architecture Overview
+
+The testing framework has two layers:
+
+1. **Mock layer** — deterministic, local, no LLM. Used for unit testing agent orchestration.
+2. **Eval layer** — runs agents via server, checks structural expectations. Used for behavioral/quality testing.
+
+Both SDKs use the same **scripted event model** and share the same assertion/fluent API surface.
+
+```python
+# Python
+from agentspan.agents.testing import mock_run, MockEvent, expect, ...
+```
+
+```typescript
+// TypeScript
+import { mockRun, MockEvent, expect, ... } from "@agentspan-ai/sdk/testing";
+```
+
+---
+
+## Python SDK — Testing Module
+
+**Location**: `sdk/python/src/agentspan/agents/testing/`
+**Files**: 9
+**Unit tests**: 81 tests across 4 test files
+**Status**: Fully implemented
+
+### Files
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `__init__.py` | Public exports (24 symbols) | Complete |
+| `mock.py` | `MockEvent` factory + `mock_run()` | Complete |
+| `assertions.py` | 17 assertion functions | Complete |
+| `expect.py` | Fluent `expect()` API (18 chainable methods) | Complete |
+| `recording.py` | `record()` / `replay()` JSON serialization | Complete |
+| `eval_runner.py` | `CorrectnessEval`, `EvalCase`, auto-capture | Complete |
+| `semantic.py` | `assert_output_satisfies()` LLM judge (litellm) | Complete |
+| `strategy_validators.py` | 6 strategy validators + constrained transitions | Complete |
+| `pytest_plugin.py` | Fixtures (`mock_agent_run`, `event`) + markers | Complete |
+
+---
+
+## TypeScript SDK — Testing Module
+
+**Location**: `sdk/typescript/src/testing/`
+**Files**: 8
+**Unit tests**: 109 tests across 4 test files + 49 example tests across 5 files
+**Status**: Fully implemented — **full parity with Python**
+
+### Files
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `index.ts` | Public exports | Complete |
+| `mock.ts` | `MockEvent` factory (10 methods) + synchronous `mockRun()` | Complete |
+| `assertions.ts` | 17 assertion functions | Complete |
+| `expect.ts` | Fluent `expect()` API (18 chainable methods) | Complete |
+| `recording.ts` | `record()` / `replay()` JSON serialization | Complete |
+| `eval.ts` | `CorrectnessEval` with `EvalCase` structural checks | Complete |
+| `capture.ts` | `evalCaseFromResult()`, `captureEvalCase()` | Complete |
+| `strategy.ts` | 6 strategy validators + constrained transitions | Complete |
+
+### Mock System
+
+TypeScript now uses the same **scripted event model** as Python: you provide a list of `MockEvent` objects that define exactly what the agent "does", and `mockRun()` builds an `AgentResult` from them.
+
+```typescript
+const result = mockRun(agent, "Search for laptops", {
+  events: [
+    MockEvent.toolCall("search_products", { query: "laptops" }),
+    MockEvent.toolResult("search_products", [{ name: "MacBook Pro" }]),
+    MockEvent.done({ result: "Found 1 laptop." }),
+  ],
+});
+```
+
+**MockEvent factory methods** (10):
+
+| Method | Description |
+|--------|-------------|
+| `MockEvent.done(output)` | Final output, completes run |
+| `MockEvent.toolCall(name, args?)` | Agent invokes a tool |
+| `MockEvent.toolResult(name, result)` | Tool return value |
+| `MockEvent.handoff(target)` | Delegation to sub-agent |
+| `MockEvent.thinking(content)` | LLM reasoning step |
+| `MockEvent.message(content)` | Conversational message |
+| `MockEvent.error(content)` | Error, marks run as FAILED |
+| `MockEvent.waiting(content?)` | HITL pause |
+| `MockEvent.guardrailPass(name, content?)` | Guardrail passed |
+| `MockEvent.guardrailFail(name, content?)` | Guardrail blocked |
+
+**`autoExecuteTools`**: When `true` (default), real tool functions execute on `tool_call` events. When `false`, you must script both `toolCall` and `toolResult`.
+
+### Assertions (17 functions)
+
+| Category | Functions |
+|----------|-----------|
+| **Tool** | `assertToolUsed`, `assertToolNotUsed`, `assertToolCalledWith` (subset match), `assertToolCallOrder` (subsequence), `assertToolsUsedExactly` (set equality) |
+| **Output** | `assertOutputContains` (substring, case flag), `assertOutputMatches` (regex), `assertOutputType` (typeof) |
+| **Status** | `assertStatus`, `assertNoErrors` |
+| **Events** | `assertEventsContain` (with attr filter), `assertEventSequence` (subsequence) |
+| **Multi-agent** | `assertHandoffTo`, `assertAgentRan` |
+| **Guardrails** | `assertGuardrailPassed`, `assertGuardrailFailed` |
+| **Budget** | `assertMaxTurns` (counts tool_call + done events) |
+
+### Fluent API (18 chainable methods)
+
+```typescript
+expect(result)
+  .completed()
+  .usedTool("search", { args: { q: "test" } })
+  .didNotUseTool("delete")
+  .toolCallOrder(["search", "checkout"])
+  .outputContains("answer")
+  .outputMatches(/ORD-\d+/)
+  .handoffTo("specialist")
+  .guardrailPassed("pii_check")
+  .guardrailFailed("rate_limit")
+  .maxTurns(10)
+  .noErrors();
+```
+
+### Strategy Validators (6 + constrained transitions)
+
+| Strategy | What it validates |
+|----------|-------------------|
+| `validateSequential` | All agents ran, in definition order, exactly once |
+| `validateParallel` | All agents ran (order irrelevant) |
+| `validateRoundRobin` | Correct alternation, no consecutive repeats, respects `maxTurns` |
+| `validateRouter` | Exactly one sub-agent selected |
+| `validateHandoff` | At least one handoff to a valid sub-agent |
+| `validateSwarm` | Valid transfers, no infinite loops (pair repeat > 2), respects `maxTurns` |
+| `validateConstrainedTransitions` | Every `(src → dst)` in `allowedTransitions[src]` |
+
+Dispatched via `validateStrategy(agent, result)` which reads `agent.strategy`.
+
+### Record / Replay
+
+```typescript
+record(result, "fixtures/run.json");           // AgentResult → JSON
+const replayed = replay("fixtures/run.json");  // JSON → AgentResult
+```
+
+### Eval Runner (CorrectnessEval)
+
+Runs agents against a runtime and checks structural expectations.
+
+```typescript
+const evaluator = new CorrectnessEval(runtime);
+const results = await evaluator.run([
+  {
+    name: "billing_routes_correctly",
+    agent: support,
+    prompt: "I need a refund",
+    expectHandoffTo: "billing",
+    expectTools: ["lookup_order"],
+    expectOutputContains: ["refund"],
+  },
+]);
+results.printSummary();
+```
+
+**EvalCase fields** (15):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Test case name |
+| `agent` | `Agent` | Agent to test |
+| `prompt` | `string` | User message |
+| `expectTools` | `string[]?` | Tools that MUST be used |
+| `expectToolsNotUsed` | `string[]?` | Tools that MUST NOT be used |
+| `expectToolArgs` | `Record<string, Record<string, unknown>>?` | Tool arg expectations (subset match) |
+| `expectHandoffTo` | `string?` | Required handoff target |
+| `expectNoHandoffTo` | `string[]?` | Disallowed handoff targets |
+| `expectOutputContains` | `string[]?` | Required output substrings |
+| `expectOutputMatches` | `string?` | Output regex pattern |
+| `expectStatus` | `string` | Expected status (default: `"COMPLETED"`) |
+| `expectNoErrors` | `boolean` | No error events (default: `true`) |
+| `validateOrchestration` | `boolean` | Run `validateStrategy()` (default: `true`) |
+| `customAssertions` | `Array<(result) => void>` | Extra assertion functions |
+| `tags` | `string[]` | For filtering eval cases |
+
+### Eval Capture (auto-generation)
+
+```typescript
+// From an existing result
+const evalCase = evalCaseFromResult(result, { agent, prompt: "..." });
+
+// One-liner: run + generate
+const [evalCase, result] = await captureEvalCase(runtime, agent, "Check stock");
+```
+
+---
+
+## SDK Parity Matrix
+
+| Feature | Python | TypeScript | Status |
+|---------|--------|------------|--------|
+| MockEvent factory (10 methods) | Yes | Yes | Parity |
+| Scripted mockRun | Yes | Yes | Parity |
+| autoExecuteTools | Yes | Yes | Parity |
+| 17 assertion functions | Yes | Yes | Parity |
+| Fluent API (18 methods) | Yes | Yes | Parity |
+| 6 strategy validators | Yes | Yes | Parity |
+| Constrained transitions | Yes | Yes | Parity |
+| CorrectnessEval (server execution) | Yes | Yes | Parity |
+| EvalCase (15 fields) | Yes | Yes | Parity |
+| Record / Replay | Yes | Yes | Parity |
+| Eval capture | Yes | Yes | Parity |
+| Semantic assertions (litellm) | Yes | No | Python-only (litellm dep) |
+| Pytest plugin | Yes | N/A | Python-only (framework-specific) |
+
+### Python-only features (by design)
+
+- **Semantic assertions** (`assert_output_satisfies`) — requires `litellm`, a Python-specific dependency
+- **Pytest plugin** — framework-specific fixtures and markers
+
+---
+
+## Test Coverage
+
+### Python
+
+| Test file | Tests | What it covers |
+|-----------|-------|----------------|
+| `test_testing_mock.py` | 14 | MockEvent, mock_run, auto-execute, errors |
+| `test_testing_assertions.py` | 43 | All 17 assertion functions, pass + fail cases |
+| `test_testing_recording.py` | 8 | Record/replay roundtrip, token usage, events |
+| `test_testing_eval_runner.py` | 16 | CorrectnessEval, EvalCase, suite results, tags |
+| **Total** | **81** | |
+
+### TypeScript
+
+| Test file | Tests | What it covers |
+|-----------|-------|----------------|
+| `mock.test.ts` | 20 | MockEvent factory, mockRun, auto-execute, errors |
+| `assertions.test.ts` | 40 | All 17 assertion functions, pass + fail cases |
+| `expect.test.ts` | 25 | Fluent API, all 18 methods, chaining |
+| `strategy.test.ts` | 24 | All 6 validators, constrained transitions, StrategyViolation |
+| **Total** | **109** | |
+
+### Example Tests (TypeScript)
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `01-basic-agent.test.ts` | 7 | MockEvent + mockRun, basic assertions, fluent API |
+| `02-tool-assertions.test.ts` | 9 | Tool assertions, full shopping flow, output validation |
+| `03-multi-agent-strategies.test.ts` | 8 | Handoff, sequential, parallel, router strategies |
+| `04-guardrails-and-errors.test.ts` | 10 | Guardrails, errors, thinking/waiting, multi-agent guardrails |
+| `05-advanced-patterns.test.ts` | 15 | Record/replay, strategy validation, nested strategies |
+| **Total** | **49** | |
+
+---
+
+## Known Issues
+
+### Resolved (from previous version)
+
+- ~~TypeScript only has 6 assertions~~ → Now has all 17
+- ~~TypeScript uses mockTools model instead of MockEvent~~ → Now uses MockEvent scripted model
+- ~~TypeScript validateStrategy only compares strings~~ → Now has 6 trace-level validators
+- ~~TypeScript CorrectnessEval uses LLM judge~~ → Now uses structural checks like Python
+
+### Current
+
+1. **`assertToolCalledWith` uses shallow equality** — `===` comparison fails for nested objects/arrays. Same issue in `assertEventsContain` attrs check. Should use deep equality.
+2. **`assertOutputContains` searches JSON string** — `JSON.stringify(result.output)` always contains key names like "result", causing potential false positives.
+3. **`mockRun` async tool handling** — `autoExecuteTools` calls tool functions synchronously, but SDK tools are async. Promise objects stored as results instead of resolved values.
+4. **`evalCaseFromResult` captures only first handoff** — Multi-agent strategies with multiple handoffs get incomplete expectations.
+5. **`validateRouter` Rule 3 is dead code** — Filters to expected set then checks if not in expected set (always empty).
+6. **`assertMaxTurns` counts `done` as a turn** — Inflates count by 1 vs intuitive expectation.
+7. **No TERMINATED/TIMED_OUT mock support** — `mockRun` only produces COMPLETED or FAILED statuses.
+8. **Missing unit tests** for `eval.ts`, `capture.ts`, `recording.ts` — other modules have thorough coverage.

--- a/docs/design/specs/2026-04-07-ts-testing-parity-design.md
+++ b/docs/design/specs/2026-04-07-ts-testing-parity-design.md
@@ -1,0 +1,285 @@
+# TypeScript Testing Module — Python Parity Rewrite
+
+> Date: 2026-04-07
+> Status: Approved
+> Branch: `feat/testing-examples-and-capture`
+
+## Goal
+
+Replace the TypeScript testing module with a Python-aligned implementation. Full API parity with `sdk/python/src/agentspan/agents/testing/`. No backwards compatibility constraints — no existing users.
+
+## Scope
+
+Rewrite all 8 files in `sdk/typescript/src/testing/`:
+
+| File | Change |
+|------|--------|
+| `mock.ts` | Full rewrite — MockEvent factory + scripted mockRun |
+| `assertions.ts` | Full rewrite — 17 assertion functions |
+| `expect.ts` | Full rewrite — 18 chainable methods, `expect()` entry point |
+| `strategy.ts` | Full rewrite — 6 trace-level validators + StrategyViolation |
+| `eval.ts` | Full rewrite — CorrectnessEval with EvalCase server-execution model |
+| `recording.ts` | Full rewrite — record(result, path) / replay(path) |
+| `capture.ts` | Update — align with new types |
+| `index.ts` | Update — new exports |
+
+Rewrite all 4 unit test files in `sdk/typescript/tests/unit/testing/`.
+
+## Design
+
+### 1. MockEvent + mockRun (mock.ts)
+
+**MockEvent** — static factory class. Each method returns an `AgentEvent`.
+
+```typescript
+class MockEvent {
+  static done(output: unknown): AgentEvent
+  static toolCall(name: string, args?: Record<string, unknown>): AgentEvent
+  static toolResult(name: string, result: unknown): AgentEvent
+  static handoff(target: string): AgentEvent
+  static thinking(content: string): AgentEvent
+  static message(content: string): AgentEvent
+  static error(content: string): AgentEvent
+  static waiting(content: string): AgentEvent
+  static guardrailPass(name: string, content?: string): AgentEvent
+  static guardrailFail(name: string, content: string): AgentEvent
+}
+```
+
+**mockRun** — synchronous. Builds AgentResult from scripted events.
+
+```typescript
+function mockRun(
+  agent: Agent,
+  prompt: string,
+  options: {
+    events: AgentEvent[];
+    autoExecuteTools?: boolean; // default: true
+  }
+): AgentResult
+```
+
+Behavior:
+- Walks the events list sequentially
+- Collects tool_call events into `toolCalls` array
+- When `autoExecuteTools=true` and a `tool_call` event is encountered, resolves the tool function from `agent.tools` and executes it (result becomes the tool_result)
+- When `autoExecuteTools=false`, expects explicit `toolResult` events
+- Last `done` event sets `output`; `error` event sets status to `FAILED`
+- Builds `messages` from prompt + output
+- Returns `AgentResult` via `makeAgentResult`
+
+### 2. Assertions (assertions.ts)
+
+17 functions, all taking `AgentResult` as first arg, all throwing `Error` on failure.
+
+**Tool assertions:**
+- `assertToolUsed(result, name)` — at least one tool_call with name
+- `assertToolNotUsed(result, name)` — no tool_call with name
+- `assertToolCalledWith(result, name, args)` — subset arg match (every key in `args` must match)
+- `assertToolCallOrder(result, names)` — subsequence: names appear in this order (gaps OK)
+- `assertToolsUsedExactly(result, names)` — set equality of tool names used
+
+**Output assertions:**
+- `assertOutputContains(result, text, opts?)` — substring match, `opts.caseSensitive` default true
+- `assertOutputMatches(result, pattern)` — regex on stringified output
+- `assertOutputType(result, typeName)` — typeof check (e.g. "string", "object")
+
+**Status assertions:**
+- `assertStatus(result, status)` — exact match
+- `assertNoErrors(result)` — no events with type "error"
+
+**Event assertions:**
+- `assertEventsContain(result, eventType, opts?)` — event type exists, `opts.expected` default true
+- `assertEventSequence(result, types)` — subsequence of event types
+
+**Multi-agent assertions:**
+- `assertHandoffTo(result, agentName)` — handoff event with target
+- `assertAgentRan(result, agentName)` — delegates to assertHandoffTo
+
+**Guardrail assertions:**
+- `assertGuardrailPassed(result, name)` — guardrail_pass event with name
+- `assertGuardrailFailed(result, name)` — guardrail_fail event with name
+
+**Budget assertion:**
+- `assertMaxTurns(result, n)` — count of tool_call + done events ≤ n
+
+### 3. Fluent API (expect.ts)
+
+```typescript
+class AgentResultExpectation {
+  constructor(result: AgentResult)
+
+  // Status
+  completed(): this
+  failed(): this
+  status(s: string): this
+  noErrors(): this
+
+  // Tools
+  usedTool(name: string, opts?: { args?: Record<string, unknown> }): this
+  didNotUseTool(name: string): this
+  toolCallOrder(names: string[]): this
+  toolsUsedExactly(names: string[]): this
+
+  // Output
+  outputContains(text: string, opts?: { caseSensitive?: boolean }): this
+  outputMatches(pattern: string | RegExp): this
+  outputType(typeName: string): this
+
+  // Events
+  eventsContain(eventType: string, opts?: { expected?: boolean }): this
+  eventSequence(types: string[]): this
+
+  // Multi-agent
+  handoffTo(agentName: string): this
+  agentRan(agentName: string): this
+
+  // Guardrails
+  guardrailPassed(name: string): this
+  guardrailFailed(name: string): this
+
+  // Budget
+  maxTurns(n: number): this
+}
+
+function expect(result: AgentResult): AgentResultExpectation
+```
+
+### 4. Strategy Validators (strategy.ts)
+
+**StrategyViolation** — custom error class:
+
+```typescript
+class StrategyViolation extends Error {
+  strategy: string;
+  violations: string[];
+}
+```
+
+**6 validators** — each takes (agent, result), throws StrategyViolation:
+
+- `validateSequential` — all agents ran, in definition order, exactly once
+- `validateParallel` — all agents ran (order irrelevant)
+- `validateRoundRobin` — correct alternation, no consecutive repeats, respects maxTurns
+- `validateRouter` — exactly one sub-agent selected
+- `validateHandoff` — at least one handoff to valid sub-agent
+- `validateSwarm` — valid transfers, no loops (pair > 2), respects maxTurns
+
+**Constrained transitions:**
+- `validateConstrainedTransitions(agent, result)` — every (src → dst) in allowedTransitions
+
+**Dispatcher:**
+- `validateStrategy(agent, result)` — reads agent.strategy, dispatches to correct validator, also runs constrained transitions if agent.allowedTransitions exists
+
+### 5. CorrectnessEval (eval.ts)
+
+Replace LLM judge with Python's server-execution model.
+
+```typescript
+interface EvalCase {
+  name: string;
+  agent: Agent;
+  prompt: string;
+  expectTools?: string[];
+  expectToolsNotUsed?: string[];
+  expectToolArgs?: Record<string, Record<string, unknown>>;
+  expectHandoffTo?: string;
+  expectNoHandoffTo?: string[];
+  expectOutputContains?: string[];
+  expectOutputMatches?: string;
+  expectStatus?: string;           // default: "COMPLETED"
+  expectNoErrors?: boolean;        // default: true
+  validateOrchestration?: boolean; // default: true
+  customAssertions?: Array<(result: AgentResult) => void>;
+  tags?: string[];
+}
+
+interface EvalCheckResult {
+  check: string;
+  passed: boolean;
+  message: string;
+}
+
+interface EvalCaseResult {
+  name: string;
+  passed: boolean;
+  checks: EvalCheckResult[];
+  result?: AgentResult;
+  error?: string;
+  tags: string[];
+}
+
+interface EvalSuiteResult {
+  cases: EvalCaseResult[];
+  allPassed: boolean;
+  passCount: number;
+  failCount: number;
+  total: number;
+  failedCases(): EvalCaseResult[];
+  printSummary(): void;
+}
+
+class CorrectnessEval {
+  constructor(runtime: { run(agent: Agent, prompt: string): Promise<AgentResult> })
+  async run(cases: EvalCase[], opts?: { tags?: string[] }): Promise<EvalSuiteResult>
+}
+```
+
+### 6. Recording (recording.ts)
+
+```typescript
+function record(result: AgentResult, path: string): void   // serialize to JSON
+function replay(path: string): AgentResult                  // deserialize from JSON
+```
+
+Handles all event types, token usage, finish reasons, metadata.
+
+### 7. Capture (capture.ts)
+
+```typescript
+function evalCaseFromResult(result: AgentResult, opts: {
+  agent: Agent;
+  prompt: string;
+  name?: string;
+  includeToolArgs?: boolean;
+  tags?: string[];
+}): EvalCase
+
+async function captureEvalCase(runtime: any, agent: Agent, prompt: string, opts?: {
+  name?: string;
+  includeToolArgs?: boolean;
+  tags?: string[];
+}): Promise<[EvalCase, AgentResult]>
+```
+
+### 8. Exports (index.ts)
+
+```typescript
+// Mock
+export { MockEvent, mockRun } from './mock.js';
+
+// Assertions (17)
+export { assertToolUsed, assertToolNotUsed, assertToolCalledWith, ... } from './assertions.js';
+
+// Fluent
+export { expect, AgentResultExpectation } from './expect.js';
+
+// Strategy
+export { validateStrategy, StrategyViolation } from './strategy.js';
+export { validateSequential, validateParallel, ... } from './strategy.js';
+
+// Eval
+export { CorrectnessEval, EvalCase, EvalCaseResult, EvalSuiteResult } from './eval.js';
+
+// Recording
+export { record, replay } from './recording.js';
+
+// Capture
+export { evalCaseFromResult, captureEvalCase, CapturedEvalCase } from './capture.js';
+```
+
+## Non-goals
+
+- Updating the example test files (those can be updated separately)
+- Semantic assertions via litellm (Python-specific dep)
+- Pytest plugin (Python-specific)

--- a/sdk/python/examples/claude_agent_sdk/06_github_issue_swarm.py
+++ b/sdk/python/examples/claude_agent_sdk/06_github_issue_swarm.py
@@ -103,7 +103,7 @@ def shell(command: str) -> str:
 
 architect = Agent(
     name="architect",
-    model="google/gemini-2.5-pro",
+    model="google_gemini/gemini-2.5-pro",
     instructions="""\
 You are a senior architect and lead engineer. You design minimal, targeted solutions for GitHub issues.
 

--- a/sdk/python/examples/mock_tests/01_basic_agent.py
+++ b/sdk/python/examples/mock_tests/01_basic_agent.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+01 — Basic Agent Mock Tests
+============================
+
+The simplest possible mock tests. No server, no LLM, no API keys needed.
+
+Covers:
+  - Creating a single agent with tools
+  - mock_run() with scripted events
+  - Basic status and output assertions
+  - Tool usage assertions
+  - The fluent expect() API
+
+Run:
+    pytest examples/mock_tests/01_basic_agent.py -v
+"""
+
+import pytest
+
+from agentspan.agents import Agent, tool
+from agentspan.agents.testing import (
+    MockEvent,
+    assert_no_errors,
+    assert_output_contains,
+    assert_status,
+    assert_tool_not_used,
+    assert_tool_used,
+    expect,
+    mock_run,
+)
+
+
+# ── Tools ────────────────────────────────────────────────────────────
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    return f"Sunny, 72°F in {city}"
+
+
+@tool
+def get_time(timezone: str) -> str:
+    """Get current time in a timezone."""
+    return f"2:30 PM in {timezone}"
+
+
+# ── Agent ────────────────────────────────────────────────────────────
+
+assistant = Agent(
+    name="assistant",
+    model="openai/gpt-4o",
+    instructions="You are a helpful assistant. Use tools when needed.",
+    tools=[get_weather, get_time],
+)
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestBasicCompletion:
+    """Agent completes successfully and returns output."""
+
+    def test_simple_response(self):
+        """Agent answers without using any tools."""
+        result = mock_run(
+            assistant,
+            "Hello, how are you?",
+            events=[
+                MockEvent.done("I'm doing well! How can I help you today?"),
+            ],
+        )
+
+        assert_status(result, "COMPLETED")
+        assert_no_errors(result)
+        assert_output_contains(result, "help", case_sensitive=False)
+
+    def test_tool_call_and_response(self):
+        """Agent calls a tool and incorporates the result."""
+        result = mock_run(
+            assistant,
+            "What's the weather in Tokyo?",
+            events=[
+                MockEvent.tool_call("get_weather", args={"city": "Tokyo"}),
+                MockEvent.tool_result("get_weather", result="Sunny, 72°F in Tokyo"),
+                MockEvent.done("It's currently sunny and 72°F in Tokyo."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_status(result, "COMPLETED")
+        assert_tool_used(result, "get_weather")
+        assert_tool_not_used(result, "get_time")
+        assert_output_contains(result, "Tokyo")
+
+    def test_multiple_tool_calls(self):
+        """Agent calls multiple tools in sequence."""
+        result = mock_run(
+            assistant,
+            "What's the weather and time in London?",
+            events=[
+                MockEvent.tool_call("get_weather", args={"city": "London"}),
+                MockEvent.tool_result("get_weather", result="Rainy, 55°F in London"),
+                MockEvent.tool_call("get_time", args={"timezone": "Europe/London"}),
+                MockEvent.tool_result("get_time", result="7:30 PM in Europe/London"),
+                MockEvent.done("In London it's rainy at 55°F, and the time is 7:30 PM."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_tool_used(result, "get_weather")
+        assert_tool_used(result, "get_time")
+        assert_no_errors(result)
+
+
+class TestFluentExpectAPI:
+    """Same assertions using the chainable expect() API."""
+
+    def test_expect_completed_with_output(self):
+        """Fluent syntax for status + output checks."""
+        result = mock_run(
+            assistant,
+            "What's the weather in Paris?",
+            events=[
+                MockEvent.tool_call("get_weather", args={"city": "Paris"}),
+                MockEvent.tool_result("get_weather", result="Cloudy, 60°F"),
+                MockEvent.done("It's cloudy and 60°F in Paris."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        (
+            expect(result)
+            .completed()
+            .used_tool("get_weather")
+            .did_not_use_tool("get_time")
+            .output_contains("Paris")
+            .no_errors()
+        )
+
+    def test_expect_with_tool_args(self):
+        """Verify the exact arguments passed to a tool."""
+        result = mock_run(
+            assistant,
+            "Weather in Berlin please",
+            events=[
+                MockEvent.tool_call("get_weather", args={"city": "Berlin"}),
+                MockEvent.tool_result("get_weather", result="Snowy, 28°F"),
+                MockEvent.done("Berlin is snowy at 28°F."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        (
+            expect(result)
+            .completed()
+            .used_tool("get_weather", args={"city": "Berlin"})
+            .no_errors()
+        )
+
+
+class TestAutoExecuteTools:
+    """When auto_execute_tools=True (default), real tool functions run."""
+
+    def test_auto_execute(self):
+        """Tool functions execute automatically — no need for tool_result events."""
+        result = mock_run(
+            assistant,
+            "Weather in NYC?",
+            events=[
+                MockEvent.tool_call("get_weather", args={"city": "NYC"}),
+                # No tool_result needed — get_weather() runs automatically
+                MockEvent.done("It's sunny and 72°F in NYC."),
+            ],
+            # auto_execute_tools=True is the default
+        )
+
+        assert_tool_used(result, "get_weather")
+        assert_status(result, "COMPLETED")
+
+
+class TestErrorScenarios:
+    """Agent encounters errors during execution."""
+
+    def test_error_event(self):
+        """An error event marks the result as failed."""
+        result = mock_run(
+            assistant,
+            "Do something impossible",
+            events=[
+                MockEvent.error("Something went wrong"),
+            ],
+        )
+
+        assert_status(result, "FAILED")
+
+        # expect() can assert failure too
+        expect(result).failed()
+
+    def test_thinking_then_response(self):
+        """Thinking events are recorded but don't affect the result."""
+        result = mock_run(
+            assistant,
+            "What's 2+2?",
+            events=[
+                MockEvent.thinking("Let me think about this..."),
+                MockEvent.done("2 + 2 = 4"),
+            ],
+        )
+
+        (
+            expect(result)
+            .completed()
+            .output_contains("4")
+            .no_errors()
+        )

--- a/sdk/python/examples/mock_tests/02_tool_assertions.py
+++ b/sdk/python/examples/mock_tests/02_tool_assertions.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+02 — Tool Assertion Deep-Dive
+==============================
+
+Thorough testing of tool usage: argument validation, call ordering,
+exact tool sets, regex output matching, and output type checking.
+
+Covers:
+  - assert_tool_called_with (subset arg matching)
+  - assert_tool_call_order (subsequence ordering)
+  - assert_tools_used_exactly (set equality)
+  - assert_output_matches (regex)
+  - assert_output_type (type checking)
+  - assert_max_turns (turn budget)
+  - assert_event_sequence (event ordering)
+
+Run:
+    pytest examples/mock_tests/02_tool_assertions.py -v
+"""
+
+import pytest
+
+from agentspan.agents import Agent, tool
+from agentspan.agents.result import EventType
+from agentspan.agents.testing import (
+    MockEvent,
+    assert_event_sequence,
+    assert_max_turns,
+    assert_output_contains,
+    assert_output_matches,
+    assert_output_type,
+    assert_tool_call_order,
+    assert_tool_called_with,
+    assert_tool_not_used,
+    assert_tool_used,
+    assert_tools_used_exactly,
+    expect,
+    mock_run,
+)
+
+
+# ── Tools ────────────────────────────────────────────────────────────
+
+
+@tool
+def search_products(query: str, max_results: int = 5) -> list:
+    """Search the product catalog."""
+    return [{"name": f"Product {i}", "price": 9.99 * i} for i in range(1, max_results + 1)]
+
+
+@tool
+def get_product_details(product_id: str) -> dict:
+    """Get detailed info for a product."""
+    return {"id": product_id, "name": "Widget", "stock": 42}
+
+
+@tool
+def add_to_cart(product_id: str, quantity: int) -> str:
+    """Add a product to the shopping cart."""
+    return f"Added {quantity}x {product_id} to cart"
+
+
+@tool
+def checkout(payment_method: str) -> dict:
+    """Process checkout."""
+    return {"order_id": "ORD-001", "status": "confirmed", "payment": payment_method}
+
+
+# ── Agent ────────────────────────────────────────────────────────────
+
+shop_agent = Agent(
+    name="shop-assistant",
+    model="openai/gpt-4o",
+    instructions="Help customers find and purchase products.",
+    tools=[search_products, get_product_details, add_to_cart, checkout],
+)
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestToolArgValidation:
+    """Verify tools are called with the expected arguments."""
+
+    def test_exact_args(self):
+        """Tool must be called with exactly these args."""
+        result = mock_run(
+            shop_agent,
+            "Search for red shoes",
+            events=[
+                MockEvent.tool_call(
+                    "search_products", args={"query": "red shoes", "max_results": 10}
+                ),
+                MockEvent.tool_result("search_products", result=[{"name": "Red Shoe"}]),
+                MockEvent.done("I found Red Shoe for you."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_tool_called_with(
+            result, "search_products", args={"query": "red shoes", "max_results": 10}
+        )
+
+    def test_subset_arg_match(self):
+        """assert_tool_called_with does subset matching — extra args are OK."""
+        result = mock_run(
+            shop_agent,
+            "Search for hats",
+            events=[
+                MockEvent.tool_call(
+                    "search_products", args={"query": "hats", "max_results": 5}
+                ),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.done("No hats found."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        # Only check the query arg — max_results is ignored
+        assert_tool_called_with(result, "search_products", args={"query": "hats"})
+
+    def test_wrong_args_fails(self):
+        """Mismatched args raise AssertionError."""
+        result = mock_run(
+            shop_agent,
+            "Search for boots",
+            events=[
+                MockEvent.tool_call("search_products", args={"query": "boots"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.done("No boots."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        with pytest.raises(AssertionError):
+            assert_tool_called_with(
+                result, "search_products", args={"query": "sneakers"}
+            )
+
+
+class TestToolCallOrdering:
+    """Verify tools are called in the expected sequence."""
+
+    def test_full_shopping_flow(self):
+        """Search → details → add to cart → checkout must happen in order."""
+        result = mock_run(
+            shop_agent,
+            "Find me a widget and buy it",
+            events=[
+                MockEvent.tool_call("search_products", args={"query": "widget"}),
+                MockEvent.tool_result("search_products", result=[{"id": "W-1"}]),
+                MockEvent.tool_call("get_product_details", args={"product_id": "W-1"}),
+                MockEvent.tool_result(
+                    "get_product_details", result={"id": "W-1", "stock": 42}
+                ),
+                MockEvent.tool_call(
+                    "add_to_cart", args={"product_id": "W-1", "quantity": 1}
+                ),
+                MockEvent.tool_result("add_to_cart", result="Added 1x W-1 to cart"),
+                MockEvent.tool_call("checkout", args={"payment_method": "credit_card"}),
+                MockEvent.tool_result(
+                    "checkout", result={"order_id": "ORD-001", "status": "confirmed"}
+                ),
+                MockEvent.done("Your order ORD-001 is confirmed!"),
+            ],
+            auto_execute_tools=False,
+        )
+
+        # Subsequence check: these must appear in this order
+        assert_tool_call_order(
+            result, ["search_products", "get_product_details", "add_to_cart", "checkout"]
+        )
+
+    def test_partial_order(self):
+        """Subsequence — only check that search comes before checkout."""
+        result = mock_run(
+            shop_agent,
+            "Quick buy",
+            events=[
+                MockEvent.tool_call("search_products", args={"query": "gadget"}),
+                MockEvent.tool_result("search_products", result=[{"id": "G-1"}]),
+                MockEvent.tool_call("get_product_details", args={"product_id": "G-1"}),
+                MockEvent.tool_result("get_product_details", result={"id": "G-1"}),
+                MockEvent.tool_call("checkout", args={"payment_method": "paypal"}),
+                MockEvent.tool_result("checkout", result={"order_id": "ORD-002"}),
+                MockEvent.done("Done!"),
+            ],
+            auto_execute_tools=False,
+        )
+
+        # Only check partial order
+        assert_tool_call_order(result, ["search_products", "checkout"])
+
+
+class TestExactToolSet:
+    """Verify the exact set of tools used (no more, no less)."""
+
+    def test_exactly_these_tools(self):
+        """Only search and details were used — nothing else."""
+        result = mock_run(
+            shop_agent,
+            "Just browse products",
+            events=[
+                MockEvent.tool_call("search_products", args={"query": "all"}),
+                MockEvent.tool_result("search_products", result=[{"id": "P-1"}]),
+                MockEvent.tool_call("get_product_details", args={"product_id": "P-1"}),
+                MockEvent.tool_result("get_product_details", result={"id": "P-1"}),
+                MockEvent.done("Here's what I found."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_tools_used_exactly(result, ["search_products", "get_product_details"])
+
+    def test_exact_set_fails_when_extra_tool_used(self):
+        """Fails if an unexpected tool was also called."""
+        result = mock_run(
+            shop_agent,
+            "Browse and buy",
+            events=[
+                MockEvent.tool_call("search_products", args={"query": "item"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.tool_call("checkout", args={"payment_method": "cash"}),
+                MockEvent.tool_result("checkout", result={}),
+                MockEvent.done("Done."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        # Expects ONLY search_products — but checkout was also used
+        with pytest.raises(AssertionError):
+            assert_tools_used_exactly(result, ["search_products"])
+
+
+class TestOutputAssertions:
+    """Validate the final output content and type."""
+
+    def test_output_regex(self):
+        """Output matches a regex pattern."""
+        result = mock_run(
+            shop_agent,
+            "Place my order",
+            events=[
+                MockEvent.done("Your order ORD-12345 has been confirmed."),
+            ],
+        )
+
+        assert_output_matches(result, r"ORD-\d{5}")
+
+    def test_output_type_string(self):
+        """Output is a string."""
+        result = mock_run(
+            shop_agent,
+            "Hello",
+            events=[MockEvent.done("Hi there!")],
+        )
+
+        assert_output_type(result, str)
+
+    def test_output_type_dict(self):
+        """Output can be a structured dict."""
+        result = mock_run(
+            shop_agent,
+            "Order summary",
+            events=[
+                MockEvent.done({"order_id": "ORD-001", "total": 29.99}),
+            ],
+        )
+
+        assert_output_type(result, dict)
+        assert_output_contains(result, "ORD-001")
+
+
+class TestEventSequence:
+    """Verify the order of event types in the execution trace."""
+
+    def test_think_then_act(self):
+        """Thinking → tool call → tool result → done."""
+        result = mock_run(
+            shop_agent,
+            "Find a product",
+            events=[
+                MockEvent.thinking("I should search for products..."),
+                MockEvent.tool_call("search_products", args={"query": "widget"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.done("No products found."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_event_sequence(
+            result,
+            [
+                EventType.THINKING,
+                EventType.TOOL_CALL,
+                EventType.TOOL_RESULT,
+                EventType.DONE,
+            ],
+        )
+
+    def test_event_sequence_is_subsequence(self):
+        """Sequence check is a subsequence — extra events in between are OK."""
+        result = mock_run(
+            shop_agent,
+            "Buy something",
+            events=[
+                MockEvent.thinking("Let me search..."),
+                MockEvent.tool_call("search_products", args={"query": "thing"}),
+                MockEvent.tool_result("search_products", result=[{"id": "T-1"}]),
+                MockEvent.thinking("Found one, let me add to cart..."),
+                MockEvent.tool_call(
+                    "add_to_cart", args={"product_id": "T-1", "quantity": 1}
+                ),
+                MockEvent.tool_result("add_to_cart", result="Added"),
+                MockEvent.done("Added to cart!"),
+            ],
+            auto_execute_tools=False,
+        )
+
+        # Only check the tool calls — thinking events are skipped
+        assert_event_sequence(
+            result, [EventType.TOOL_CALL, EventType.TOOL_CALL, EventType.DONE]
+        )
+
+
+class TestTurnBudget:
+    """Verify the agent doesn't exceed turn limits."""
+
+    def test_within_budget(self):
+        """Agent uses 2 tool calls — within budget of 5."""
+        result = mock_run(
+            shop_agent,
+            "Quick search",
+            events=[
+                MockEvent.tool_call("search_products", args={"query": "shoes"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.tool_call("search_products", args={"query": "boots"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.done("No results."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_max_turns(result, 5)
+
+    def test_over_budget_fails(self):
+        """Agent exceeds the allowed turn count."""
+        result = mock_run(
+            shop_agent,
+            "Keep searching",
+            events=[
+                MockEvent.tool_call("search_products", args={"query": "a"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.tool_call("search_products", args={"query": "b"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.tool_call("search_products", args={"query": "c"}),
+                MockEvent.tool_result("search_products", result=[]),
+                MockEvent.done("Gave up."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        # Budget is 2, but agent used 3 tool calls
+        with pytest.raises(AssertionError):
+            assert_max_turns(result, 2)

--- a/sdk/python/examples/mock_tests/03_multi_agent_strategies.py
+++ b/sdk/python/examples/mock_tests/03_multi_agent_strategies.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""
+03 — Multi-Agent Strategy Tests
+=================================
+
+Test every orchestration strategy: handoff, sequential, parallel,
+router, round-robin. Each section defines agents, scripts the
+expected behavior with MockEvent, and asserts correctness.
+
+Covers:
+  - Strategy.HANDOFF — parent delegates to the right specialist
+  - Strategy.SEQUENTIAL — pipeline with >> operator
+  - Strategy.PARALLEL — concurrent execution, all agents must run
+  - Strategy.ROUTER — dedicated planner picks one agent
+  - Strategy.ROUND_ROBIN — agents alternate in fixed order
+
+Run:
+    pytest examples/mock_tests/03_multi_agent_strategies.py -v
+"""
+
+import pytest
+
+from agentspan.agents import Agent, Strategy, tool
+from agentspan.agents.result import EventType
+from agentspan.agents.testing import (
+    MockEvent,
+    assert_agent_ran,
+    assert_event_sequence,
+    assert_handoff_to,
+    assert_no_errors,
+    assert_output_contains,
+    assert_tool_call_order,
+    assert_tool_not_used,
+    assert_tool_used,
+    expect,
+    mock_run,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Shared tools
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@tool
+def search_docs(query: str) -> str:
+    """Search documentation."""
+    return f"Docs for: {query}"
+
+
+@tool
+def run_query(sql: str) -> list:
+    """Execute a database query."""
+    return [{"id": 1, "name": "result"}]
+
+
+@tool
+def send_notification(channel: str, message: str) -> str:
+    """Send a notification."""
+    return f"Sent to {channel}: {message}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. HANDOFF — parent picks the right specialist
+# ═══════════════════════════════════════════════════════════════════════
+
+docs_agent = Agent(
+    name="docs_specialist",
+    model="openai/gpt-4o",
+    instructions="Answer documentation questions.",
+    tools=[search_docs],
+)
+
+db_agent = Agent(
+    name="db_specialist",
+    model="openai/gpt-4o",
+    instructions="Answer database questions.",
+    tools=[run_query],
+)
+
+triage_agent = Agent(
+    name="triage",
+    model="openai/gpt-4o",
+    instructions="Route questions to the right specialist.",
+    agents=[docs_agent, db_agent],
+    strategy=Strategy.HANDOFF,
+)
+
+
+class TestHandoff:
+    """Parent LLM delegates to the right sub-agent."""
+
+    def test_docs_question_routes_to_docs(self):
+        result = mock_run(
+            triage_agent,
+            "How do I configure logging?",
+            events=[
+                MockEvent.handoff("docs_specialist"),
+                MockEvent.tool_call("search_docs", args={"query": "configure logging"}),
+                MockEvent.tool_result("search_docs", result="Set LOG_LEVEL=debug..."),
+                MockEvent.done("Set LOG_LEVEL=debug in your config file."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_handoff_to(result, "docs_specialist")
+        assert_tool_used(result, "search_docs")
+        assert_tool_not_used(result, "run_query")
+
+    def test_db_question_routes_to_db(self):
+        result = mock_run(
+            triage_agent,
+            "How many users signed up today?",
+            events=[
+                MockEvent.handoff("db_specialist"),
+                MockEvent.tool_call(
+                    "run_query",
+                    args={"sql": "SELECT count(*) FROM users WHERE created_at = today()"},
+                ),
+                MockEvent.tool_result("run_query", result=[{"count": 150}]),
+                MockEvent.done("150 users signed up today."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_handoff_to(result, "db_specialist")
+        assert_tool_used(result, "run_query")
+        assert_tool_not_used(result, "search_docs")
+
+    def test_no_cross_contamination(self):
+        """DB specialist should never use docs tools."""
+        result = mock_run(
+            triage_agent,
+            "Show me the user table schema",
+            events=[
+                MockEvent.handoff("db_specialist"),
+                MockEvent.tool_call(
+                    "run_query", args={"sql": "DESCRIBE users"}
+                ),
+                MockEvent.tool_result("run_query", result=[{"col": "id"}, {"col": "name"}]),
+                MockEvent.done("The users table has columns: id, name."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        (
+            expect(result)
+            .completed()
+            .handoff_to("db_specialist")
+            .used_tool("run_query")
+            .did_not_use_tool("search_docs")
+            .did_not_use_tool("send_notification")
+            .no_errors()
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. SEQUENTIAL — agents run in order, output feeds forward
+# ═══════════════════════════════════════════════════════════════════════
+
+researcher = Agent(
+    name="researcher",
+    model="openai/gpt-4o",
+    instructions="Research the topic thoroughly.",
+    tools=[search_docs],
+)
+
+drafter = Agent(
+    name="drafter",
+    model="openai/gpt-4o",
+    instructions="Write a draft based on the research.",
+)
+
+reviewer = Agent(
+    name="reviewer",
+    model="openai/gpt-4o",
+    instructions="Review and polish the draft.",
+)
+
+# >> operator composes a sequential pipeline
+content_pipeline = researcher >> drafter >> reviewer
+
+
+class TestSequential:
+    """Agents execute in order: researcher → drafter → reviewer."""
+
+    def test_all_agents_run_in_order(self):
+        result = mock_run(
+            content_pipeline,
+            "Write a guide on API testing",
+            events=[
+                MockEvent.handoff("researcher"),
+                MockEvent.tool_call("search_docs", args={"query": "API testing"}),
+                MockEvent.tool_result("search_docs", result="API testing best practices..."),
+                MockEvent.handoff("drafter"),
+                MockEvent.thinking("Organizing the research into a guide..."),
+                MockEvent.handoff("reviewer"),
+                MockEvent.done("# API Testing Guide\n\n...polished content..."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_agent_ran(result, "researcher")
+        assert_agent_ran(result, "drafter")
+        assert_agent_ran(result, "reviewer")
+
+        # Verify ordering
+        assert_event_sequence(
+            result,
+            [
+                EventType.HANDOFF,   # researcher
+                EventType.TOOL_CALL, # researcher uses search_docs
+                EventType.HANDOFF,   # drafter
+                EventType.HANDOFF,   # reviewer
+                EventType.DONE,
+            ],
+        )
+
+    def test_pipeline_order_is_correct(self):
+        """Handoff targets appear in definition order."""
+        result = mock_run(
+            content_pipeline,
+            "Write about microservices",
+            events=[
+                MockEvent.handoff("researcher"),
+                MockEvent.handoff("drafter"),
+                MockEvent.handoff("reviewer"),
+                MockEvent.done("Final article."),
+            ],
+        )
+
+        handoff_targets = [
+            ev.target for ev in result.events if ev.type == EventType.HANDOFF
+        ]
+        assert handoff_targets == ["researcher", "drafter", "reviewer"]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. PARALLEL — all agents run concurrently
+# ═══════════════════════════════════════════════════════════════════════
+
+security_auditor = Agent(
+    name="security_auditor",
+    model="openai/gpt-4o",
+    instructions="Audit for security vulnerabilities.",
+)
+
+performance_auditor = Agent(
+    name="performance_auditor",
+    model="openai/gpt-4o",
+    instructions="Audit for performance bottlenecks.",
+)
+
+accessibility_auditor = Agent(
+    name="accessibility_auditor",
+    model="openai/gpt-4o",
+    instructions="Audit for accessibility compliance.",
+)
+
+audit_team = Agent(
+    name="audit",
+    model="openai/gpt-4o",
+    agents=[security_auditor, performance_auditor, accessibility_auditor],
+    strategy=Strategy.PARALLEL,
+)
+
+
+class TestParallel:
+    """All agents in the group must run — order doesn't matter."""
+
+    def test_all_auditors_run(self):
+        result = mock_run(
+            audit_team,
+            "Audit the checkout page",
+            events=[
+                MockEvent.handoff("security_auditor"),
+                MockEvent.handoff("performance_auditor"),
+                MockEvent.handoff("accessibility_auditor"),
+                MockEvent.done(
+                    "Security: No XSS issues. "
+                    "Performance: Page loads in 1.2s. "
+                    "Accessibility: Missing alt tags on 3 images."
+                ),
+            ],
+        )
+
+        assert_agent_ran(result, "security_auditor")
+        assert_agent_ran(result, "performance_auditor")
+        assert_agent_ran(result, "accessibility_auditor")
+        assert_no_errors(result)
+
+    def test_missing_agent_is_detectable(self):
+        """If an agent is missing from events, assert_agent_ran catches it."""
+        result = mock_run(
+            audit_team,
+            "Audit the login page",
+            events=[
+                MockEvent.handoff("security_auditor"),
+                MockEvent.handoff("performance_auditor"),
+                # accessibility_auditor is MISSING
+                MockEvent.done("Partial audit."),
+            ],
+        )
+
+        assert_agent_ran(result, "security_auditor")
+        assert_agent_ran(result, "performance_auditor")
+
+        with pytest.raises(AssertionError, match="accessibility_auditor"):
+            assert_agent_ran(result, "accessibility_auditor")
+
+    def test_output_reflects_all_perspectives(self):
+        result = mock_run(
+            audit_team,
+            "Audit dashboard",
+            events=[
+                MockEvent.handoff("security_auditor"),
+                MockEvent.handoff("performance_auditor"),
+                MockEvent.handoff("accessibility_auditor"),
+                MockEvent.done(
+                    "Security: clean. Performance: fast. Accessibility: compliant."
+                ),
+            ],
+        )
+
+        (
+            expect(result)
+            .completed()
+            .output_contains("Security")
+            .output_contains("Performance")
+            .output_contains("Accessibility")
+            .no_errors()
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. ROUTER — dedicated planner picks one specialist
+# ═══════════════════════════════════════════════════════════════════════
+
+planner = Agent(
+    name="planner",
+    model="openai/gpt-4o",
+    instructions="Route bugs to backend, UI issues to frontend.",
+)
+
+backend_dev = Agent(
+    name="backend",
+    model="openai/gpt-4o",
+    instructions="Fix backend/API bugs.",
+    tools=[run_query],
+)
+
+frontend_dev = Agent(
+    name="frontend",
+    model="openai/gpt-4o",
+    instructions="Fix frontend/UI bugs.",
+)
+
+bug_triage = Agent(
+    name="bug_triage",
+    model="openai/gpt-4o",
+    agents=[backend_dev, frontend_dev],
+    strategy=Strategy.ROUTER,
+    router=planner,
+)
+
+
+class TestRouter:
+    """Dedicated router agent picks exactly one specialist."""
+
+    def test_api_bug_routes_to_backend(self):
+        result = mock_run(
+            bug_triage,
+            "The /users endpoint returns 500",
+            events=[
+                MockEvent.handoff("backend"),
+                MockEvent.tool_call("run_query", args={"sql": "SELECT * FROM error_log"}),
+                MockEvent.tool_result("run_query", result=[{"error": "null pointer"}]),
+                MockEvent.done("Fixed the null pointer in the users endpoint."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_handoff_to(result, "backend")
+        assert_tool_used(result, "run_query")
+
+    def test_ui_bug_routes_to_frontend(self):
+        result = mock_run(
+            bug_triage,
+            "The submit button is invisible on mobile",
+            events=[
+                MockEvent.handoff("frontend"),
+                MockEvent.done("Added responsive CSS for the submit button."),
+            ],
+        )
+
+        assert_handoff_to(result, "frontend")
+        assert_tool_not_used(result, "run_query")
+
+    def test_only_one_specialist_runs(self):
+        """Router must pick ONE agent, not both."""
+        result = mock_run(
+            bug_triage,
+            "Fix the login page",
+            events=[
+                MockEvent.handoff("frontend"),
+                MockEvent.done("Fixed the CSS."),
+            ],
+        )
+
+        assert_handoff_to(result, "frontend")
+        with pytest.raises(AssertionError):
+            assert_handoff_to(result, "backend")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. ROUND_ROBIN — agents alternate in fixed rotation
+# ═══════════════════════════════════════════════════════════════════════
+
+proposer = Agent(
+    name="proposer",
+    model="openai/gpt-4o",
+    instructions="Propose solutions to the problem.",
+)
+
+critic = Agent(
+    name="critic",
+    model="openai/gpt-4o",
+    instructions="Find flaws in the proposed solution.",
+)
+
+debate = Agent(
+    name="design_review",
+    model="openai/gpt-4o",
+    agents=[proposer, critic],
+    strategy=Strategy.ROUND_ROBIN,
+    max_turns=4,
+)
+
+
+class TestRoundRobin:
+    """Agents alternate: proposer → critic → proposer → critic."""
+
+    def test_alternating_pattern(self):
+        result = mock_run(
+            debate,
+            "How should we handle rate limiting?",
+            events=[
+                MockEvent.handoff("proposer"),
+                MockEvent.message("Use a token bucket with 100 req/min."),
+                MockEvent.handoff("critic"),
+                MockEvent.message("What about burst traffic? 100 is too low."),
+                MockEvent.handoff("proposer"),
+                MockEvent.message("OK, 100 sustained + 200 burst with sliding window."),
+                MockEvent.handoff("critic"),
+                MockEvent.message("Better. But add per-user limits too."),
+                MockEvent.done("Agreed: token bucket, 100/min sustained, 200 burst, per-user."),
+            ],
+        )
+
+        handoffs = [ev.target for ev in result.events if ev.type == EventType.HANDOFF]
+        assert handoffs == ["proposer", "critic", "proposer", "critic"]
+
+    def test_both_agents_participate(self):
+        result = mock_run(
+            debate,
+            "Should we use GraphQL or REST?",
+            events=[
+                MockEvent.handoff("proposer"),
+                MockEvent.handoff("critic"),
+                MockEvent.done("Decision made."),
+            ],
+        )
+
+        assert_agent_ran(result, "proposer")
+        assert_agent_ran(result, "critic")
+
+    def test_respects_max_turns(self):
+        """Should not exceed max_turns=4 handoffs."""
+        result = mock_run(
+            debate,
+            "Debate caching strategy",
+            events=[
+                MockEvent.handoff("proposer"),
+                MockEvent.handoff("critic"),
+                MockEvent.handoff("proposer"),
+                MockEvent.handoff("critic"),
+                MockEvent.done("4 turns completed."),
+            ],
+        )
+
+        handoffs = [ev for ev in result.events if ev.type == EventType.HANDOFF]
+        assert len(handoffs) <= 4

--- a/sdk/python/examples/mock_tests/04_guardrails_and_errors.py
+++ b/sdk/python/examples/mock_tests/04_guardrails_and_errors.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+04 — Guardrails, Errors, and Edge Cases
+=========================================
+
+Test safety features: input/output guardrails, error handling,
+human-in-the-loop (HITL) pauses, and edge-case scenarios.
+
+Covers:
+  - Guardrail pass/fail events
+  - Input guardrails blocking before agent runs
+  - Output guardrails catching and retrying
+  - Error events and failed status
+  - HITL waiting events
+  - Message events in conversation flow
+  - assert_guardrail_passed / assert_guardrail_failed
+  - assert_events_contain
+
+Run:
+    pytest examples/mock_tests/04_guardrails_and_errors.py -v
+"""
+
+import pytest
+
+from agentspan.agents import Agent, Strategy, tool
+from agentspan.agents.result import EventType
+from agentspan.agents.testing import (
+    MockEvent,
+    assert_event_sequence,
+    assert_guardrail_failed,
+    assert_guardrail_passed,
+    assert_handoff_to,
+    assert_no_errors,
+    assert_output_contains,
+    assert_status,
+    assert_tool_not_used,
+    assert_tool_used,
+    assert_events_contain,
+    expect,
+    mock_run,
+)
+
+
+# ── Tools ────────────────────────────────────────────────────────────
+
+
+@tool
+def query_user_data(user_id: str) -> dict:
+    """Fetch user data from the database."""
+    return {"user_id": user_id, "name": "Alice", "email": "alice@example.com"}
+
+
+@tool
+def update_user(user_id: str, field: str, value: str) -> str:
+    """Update a user field."""
+    return f"Updated {field} to {value} for user {user_id}"
+
+
+@tool
+def delete_account(user_id: str) -> str:
+    """Permanently delete a user account."""
+    return f"Account {user_id} deleted"
+
+
+# ── Agents ───────────────────────────────────────────────────────────
+
+support_agent = Agent(
+    name="support",
+    model="openai/gpt-4o",
+    instructions="Help users manage their accounts. Never share raw PII.",
+    tools=[query_user_data, update_user, delete_account],
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. GUARDRAIL TESTS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestInputGuardrails:
+    """Input guardrails block bad requests before the agent acts."""
+
+    def test_pii_request_blocked(self):
+        """Asking for raw PII triggers the input guardrail."""
+        result = mock_run(
+            support_agent,
+            "Give me Alice's SSN and credit card number",
+            events=[
+                MockEvent.guardrail_fail(
+                    "pii_detector", "Request asks for sensitive PII"
+                ),
+                MockEvent.done(
+                    "I cannot share sensitive personal information like SSNs or credit cards."
+                ),
+            ],
+        )
+
+        assert_guardrail_failed(result, "pii_detector")
+
+        # No tools should have been called — guardrail blocked first
+        assert_tool_not_used(result, "query_user_data")
+        assert_tool_not_used(result, "update_user")
+
+        # No handoffs happened
+        handoffs = [ev for ev in result.events if ev.type == EventType.HANDOFF]
+        assert len(handoffs) == 0
+
+    def test_safe_request_passes(self):
+        """Normal requests pass the guardrail and proceed."""
+        result = mock_run(
+            support_agent,
+            "What's my account status?",
+            events=[
+                MockEvent.guardrail_pass("pii_detector"),
+                MockEvent.tool_call("query_user_data", args={"user_id": "U-123"}),
+                MockEvent.tool_result(
+                    "query_user_data", result={"status": "active"}
+                ),
+                MockEvent.done("Your account is active."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_guardrail_passed(result, "pii_detector")
+        assert_tool_used(result, "query_user_data")
+        assert_no_errors(result)
+
+
+class TestOutputGuardrails:
+    """Output guardrails catch inappropriate responses and trigger retries."""
+
+    def test_first_attempt_fails_retry_passes(self):
+        """Agent's first response is too informal, gets retried."""
+        result = mock_run(
+            support_agent,
+            "Update my email address",
+            events=[
+                MockEvent.tool_call(
+                    "update_user",
+                    args={"user_id": "U-123", "field": "email", "value": "new@example.com"},
+                ),
+                MockEvent.tool_result("update_user", result="Updated email"),
+                # First response fails the tone guardrail
+                MockEvent.guardrail_fail("tone_check", "Response too casual"),
+                # Retry produces a professional response
+                MockEvent.guardrail_pass("tone_check"),
+                MockEvent.done(
+                    "Your email has been successfully updated to new@example.com."
+                ),
+            ],
+            auto_execute_tools=False,
+        )
+
+        (
+            expect(result)
+            .completed()
+            .guardrail_failed("tone_check")
+            .guardrail_passed("tone_check")
+            .used_tool("update_user")
+            .no_errors()
+        )
+
+    def test_multiple_guardrails(self):
+        """Multiple guardrails can pass/fail independently."""
+        result = mock_run(
+            support_agent,
+            "Delete my account",
+            events=[
+                MockEvent.guardrail_pass("auth_check"),
+                MockEvent.guardrail_pass("rate_limit"),
+                MockEvent.tool_call("delete_account", args={"user_id": "U-123"}),
+                MockEvent.tool_result("delete_account", result="Deleted"),
+                MockEvent.guardrail_pass("pii_scrubber"),
+                MockEvent.done("Your account has been permanently deleted."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_guardrail_passed(result, "auth_check")
+        assert_guardrail_passed(result, "rate_limit")
+        assert_guardrail_passed(result, "pii_scrubber")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. ERROR HANDLING
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestErrorHandling:
+    """Agent encounters errors during execution."""
+
+    def test_tool_error(self):
+        """A tool call results in an error event."""
+        result = mock_run(
+            support_agent,
+            "Look up user XYZ",
+            events=[
+                MockEvent.tool_call("query_user_data", args={"user_id": "XYZ"}),
+                MockEvent.error("User XYZ not found in database"),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_status(result, "FAILED")
+        expect(result).failed()
+
+    def test_error_contains_message(self):
+        """The error event has a descriptive message."""
+        result = mock_run(
+            support_agent,
+            "Crash please",
+            events=[
+                MockEvent.error("Internal server error: connection timeout"),
+            ],
+        )
+
+        assert_events_contain(result, EventType.ERROR)
+
+    def test_no_errors_assertion_catches_errors(self):
+        """assert_no_errors raises when an error event exists."""
+        result = mock_run(
+            support_agent,
+            "Do something broken",
+            events=[
+                MockEvent.tool_call("query_user_data", args={"user_id": "bad"}),
+                MockEvent.error("Database connection failed"),
+            ],
+            auto_execute_tools=False,
+        )
+
+        with pytest.raises(AssertionError):
+            assert_no_errors(result)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. HUMAN-IN-THE-LOOP (HITL)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestHumanInTheLoop:
+    """Agent pauses for human approval before taking destructive actions."""
+
+    def test_waiting_event_before_delete(self):
+        """Agent pauses for human confirmation before deleting an account."""
+        result = mock_run(
+            support_agent,
+            "Delete my account permanently",
+            events=[
+                MockEvent.waiting("Confirm: permanently delete account U-123?"),
+                # Human approves
+                MockEvent.tool_call("delete_account", args={"user_id": "U-123"}),
+                MockEvent.tool_result("delete_account", result="Account deleted"),
+                MockEvent.done("Your account has been permanently deleted."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        # Waiting event was recorded
+        assert_events_contain(result, EventType.WAITING)
+
+        # After approval, the action proceeded
+        assert_tool_used(result, "delete_account")
+        assert_status(result, "COMPLETED")
+
+    def test_waiting_then_rejection(self):
+        """Human rejects — agent does NOT proceed with the action."""
+        result = mock_run(
+            support_agent,
+            "Delete everything",
+            events=[
+                MockEvent.waiting("Confirm: delete all data?"),
+                MockEvent.done("Action cancelled. Your data is safe."),
+            ],
+        )
+
+        assert_events_contain(result, EventType.WAITING)
+        assert_tool_not_used(result, "delete_account")
+        assert_output_contains(result, "cancelled", case_sensitive=False)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. GUARDRAILS IN MULTI-AGENT SCENARIOS
+# ═══════════════════════════════════════════════════════════════════════
+
+safe_agent = Agent(
+    name="safe_handler",
+    model="openai/gpt-4o",
+    instructions="Handle safe requests.",
+    tools=[query_user_data],
+)
+
+risky_agent = Agent(
+    name="risky_handler",
+    model="openai/gpt-4o",
+    instructions="Handle requests requiring elevated permissions.",
+    tools=[update_user, delete_account],
+)
+
+gated_support = Agent(
+    name="gated_support",
+    model="openai/gpt-4o",
+    instructions="Route requests. Risky actions require guardrail approval.",
+    agents=[safe_agent, risky_agent],
+    strategy=Strategy.HANDOFF,
+)
+
+
+class TestGuardrailsInMultiAgent:
+    """Guardrails interact with multi-agent routing."""
+
+    def test_guardrail_blocks_before_routing(self):
+        """A blocked input should never reach any sub-agent."""
+        result = mock_run(
+            gated_support,
+            "Hack into admin account",
+            events=[
+                MockEvent.guardrail_fail("intent_classifier", "Malicious intent detected"),
+                MockEvent.done("I cannot assist with unauthorized access."),
+            ],
+        )
+
+        assert_guardrail_failed(result, "intent_classifier")
+
+        # No agent was invoked
+        handoffs = [ev for ev in result.events if ev.type == EventType.HANDOFF]
+        assert len(handoffs) == 0
+
+    def test_guardrail_passes_then_routes(self):
+        """Safe requests pass guardrail, then route to the right agent."""
+        result = mock_run(
+            gated_support,
+            "Update my display name",
+            events=[
+                MockEvent.guardrail_pass("intent_classifier"),
+                MockEvent.handoff("risky_handler"),
+                MockEvent.tool_call(
+                    "update_user",
+                    args={"user_id": "U-123", "field": "name", "value": "Bob"},
+                ),
+                MockEvent.tool_result("update_user", result="Updated"),
+                MockEvent.done("Your display name has been updated to Bob."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_guardrail_passed(result, "intent_classifier")
+        assert_handoff_to(result, "risky_handler")
+        assert_tool_used(result, "update_user")
+
+    def test_output_guardrail_on_sub_agent(self):
+        """Output guardrail catches sub-agent leaking raw PII."""
+        result = mock_run(
+            gated_support,
+            "Show me my profile",
+            events=[
+                MockEvent.handoff("safe_handler"),
+                MockEvent.tool_call("query_user_data", args={"user_id": "U-123"}),
+                MockEvent.tool_result(
+                    "query_user_data",
+                    result={"name": "Alice", "email": "alice@example.com", "ssn": "123-45-6789"},
+                ),
+                # Output guardrail catches the SSN leak
+                MockEvent.guardrail_fail("pii_scrubber", "Response contains SSN"),
+                MockEvent.guardrail_pass("pii_scrubber"),
+                MockEvent.done("Your profile: Name: Alice, Email: alice@example.com."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        (
+            expect(result)
+            .completed()
+            .handoff_to("safe_handler")
+            .guardrail_failed("pii_scrubber")
+            .guardrail_passed("pii_scrubber")
+            .output_contains("Alice")
+            .no_errors()
+        )
+
+        # SSN should NOT be in the final output
+        assert "123-45-6789" not in str(result.output)

--- a/sdk/python/examples/mock_tests/05_advanced_patterns.py
+++ b/sdk/python/examples/mock_tests/05_advanced_patterns.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""
+05 — Advanced Patterns
+=======================
+
+Swarm strategy, constrained transitions, nested strategies,
+strategy validation, record/replay, and the CorrectnessEval runner.
+
+Covers:
+  - Strategy.SWARM — LLM-driven transfers with OnTextMention conditions
+  - Constrained transitions with allowed_transitions
+  - Nested strategies (parallel >> sequential)
+  - validate_strategy() for structural correctness
+  - StrategyViolation detection (skipped agents, wrong order, loops)
+  - record() / replay() for regression testing
+  - CorrectnessEval + EvalCase for live evaluation (integration)
+
+Run:
+    pytest examples/mock_tests/05_advanced_patterns.py -v
+"""
+
+import pytest
+
+from agentspan.agents import Agent, OnTextMention, Strategy, tool
+from agentspan.agents.result import EventType
+from agentspan.agents.testing import (
+    MockEvent,
+    StrategyViolation,
+    assert_agent_ran,
+    assert_event_sequence,
+    assert_handoff_to,
+    assert_no_errors,
+    assert_tool_not_used,
+    assert_tool_used,
+    expect,
+    mock_run,
+    record,
+    replay,
+    validate_strategy,
+)
+
+
+# ── Tools ────────────────────────────────────────────────────────────
+
+
+@tool
+def check_inventory(product_id: str) -> dict:
+    """Check product inventory."""
+    return {"product_id": product_id, "in_stock": True, "quantity": 50}
+
+
+@tool
+def process_return(order_id: str, reason: str) -> str:
+    """Process a product return."""
+    return f"Return initiated for {order_id}: {reason}"
+
+
+@tool
+def track_shipment(tracking_id: str) -> dict:
+    """Track a shipment."""
+    return {"tracking_id": tracking_id, "status": "in_transit", "eta": "2 days"}
+
+
+@tool
+def escalate_to_manager(issue: str) -> str:
+    """Escalate an issue to a human manager."""
+    return f"Escalated: {issue}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. SWARM STRATEGY — dynamic transfers with condition-based handoffs
+# ═══════════════════════════════════════════════════════════════════════
+
+inventory_agent = Agent(
+    name="inventory_specialist",
+    model="openai/gpt-4o",
+    instructions="Handle inventory and stock questions.",
+    tools=[check_inventory],
+)
+
+returns_agent = Agent(
+    name="returns_specialist",
+    model="openai/gpt-4o",
+    instructions="Handle returns and refunds.",
+    tools=[process_return],
+)
+
+shipping_agent = Agent(
+    name="shipping_specialist",
+    model="openai/gpt-4o",
+    instructions="Handle shipping and tracking questions.",
+    tools=[track_shipment],
+)
+
+swarm_support = Agent(
+    name="ecommerce_support",
+    model="openai/gpt-4o",
+    instructions="Front-line support. Transfer to the right specialist.",
+    agents=[inventory_agent, returns_agent, shipping_agent],
+    strategy=Strategy.SWARM,
+    handoffs=[
+        OnTextMention(text="stock", target="inventory_specialist"),
+        OnTextMention(text="return", target="returns_specialist"),
+        OnTextMention(text="tracking", target="shipping_specialist"),
+    ],
+    max_turns=5,
+)
+
+
+class TestSwarmStrategy:
+    """LLM-driven transfers with OnTextMention condition fallbacks."""
+
+    def test_transfer_via_tool(self):
+        """Agent uses transfer_to_* tool to route explicitly."""
+        result = mock_run(
+            swarm_support,
+            "I need to return order #456",
+            events=[
+                MockEvent.tool_call("transfer_to_returns_specialist", args={}),
+                MockEvent.tool_result("transfer_to_returns_specialist", result="Transferred"),
+                MockEvent.handoff("returns_specialist"),
+                MockEvent.tool_call(
+                    "process_return",
+                    args={"order_id": "456", "reason": "defective"},
+                ),
+                MockEvent.tool_result("process_return", result="Return initiated"),
+                MockEvent.done("Your return for order #456 has been initiated."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_tool_used(result, "transfer_to_returns_specialist")
+        assert_handoff_to(result, "returns_specialist")
+        assert_tool_used(result, "process_return")
+        assert_tool_not_used(result, "check_inventory")
+        assert_tool_not_used(result, "track_shipment")
+
+    def test_condition_based_fallback(self):
+        """OnTextMention triggers when transfer tool isn't used."""
+        result = mock_run(
+            swarm_support,
+            "Is item X in stock?",
+            events=[
+                # No transfer tool — "stock" keyword triggers OnTextMention
+                MockEvent.handoff("inventory_specialist"),
+                MockEvent.tool_call("check_inventory", args={"product_id": "X"}),
+                MockEvent.tool_result(
+                    "check_inventory", result={"in_stock": True, "quantity": 50}
+                ),
+                MockEvent.done("Yes, item X is in stock with 50 units available."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_handoff_to(result, "inventory_specialist")
+        assert_tool_not_used(result, "transfer_to_inventory_specialist")
+
+    def test_shipping_transfer(self):
+        """Tracking question routes to shipping specialist."""
+        result = mock_run(
+            swarm_support,
+            "Where's my package? Tracking number TRK-789",
+            events=[
+                MockEvent.handoff("shipping_specialist"),
+                MockEvent.tool_call("track_shipment", args={"tracking_id": "TRK-789"}),
+                MockEvent.tool_result(
+                    "track_shipment",
+                    result={"status": "in_transit", "eta": "2 days"},
+                ),
+                MockEvent.done("Your package is in transit. ETA: 2 days."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        (
+            expect(result)
+            .completed()
+            .handoff_to("shipping_specialist")
+            .used_tool("track_shipment")
+            .did_not_use_tool("check_inventory")
+            .did_not_use_tool("process_return")
+            .no_errors()
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. CONSTRAINED TRANSITIONS
+# ═══════════════════════════════════════════════════════════════════════
+
+l1_support = Agent(
+    name="l1_support",
+    model="openai/gpt-4o",
+    instructions="First-line support. Handle simple questions, escalate complex ones.",
+)
+
+l2_engineer = Agent(
+    name="l2_engineer",
+    model="openai/gpt-4o",
+    instructions="Handle technical issues escalated from L1.",
+    tools=[track_shipment],
+)
+
+l3_manager = Agent(
+    name="l3_manager",
+    model="openai/gpt-4o",
+    instructions="Handle escalations requiring management approval.",
+    tools=[escalate_to_manager],
+)
+
+escalation_flow = Agent(
+    name="escalation",
+    model="openai/gpt-4o",
+    agents=[l1_support, l2_engineer, l3_manager],
+    strategy=Strategy.ROUND_ROBIN,
+    max_turns=6,
+    allowed_transitions={
+        "l1_support": ["l2_engineer"],         # L1 can only escalate to L2
+        "l2_engineer": ["l1_support", "l3_manager"],  # L2 can go back or escalate
+        "l3_manager": ["l2_engineer"],         # L3 can only send back to L2
+    },
+)
+
+
+class TestConstrainedTransitions:
+    """allowed_transitions restricts which agent can follow which."""
+
+    def test_valid_escalation_path(self):
+        """L1 → L2 → L3 is a valid escalation path."""
+        result = mock_run(
+            escalation_flow,
+            "Complex billing issue",
+            events=[
+                MockEvent.handoff("l1_support"),
+                MockEvent.message("This needs engineering review."),
+                MockEvent.handoff("l2_engineer"),
+                MockEvent.message("This needs manager approval."),
+                MockEvent.handoff("l3_manager"),
+                MockEvent.tool_call(
+                    "escalate_to_manager", args={"issue": "Complex billing dispute"}
+                ),
+                MockEvent.tool_result("escalate_to_manager", result="Escalated"),
+                MockEvent.done("Your issue has been escalated to management."),
+            ],
+            auto_execute_tools=False,
+        )
+
+        assert_agent_ran(result, "l1_support")
+        assert_agent_ran(result, "l2_engineer")
+        assert_agent_ran(result, "l3_manager")
+
+        # Verify transition sequence respects constraints
+        handoffs = [ev.target for ev in result.events if ev.type == EventType.HANDOFF]
+        allowed = {
+            "l1_support": {"l2_engineer"},
+            "l2_engineer": {"l1_support", "l3_manager"},
+            "l3_manager": {"l2_engineer"},
+        }
+        for i in range(len(handoffs) - 1):
+            src, dst = handoffs[i], handoffs[i + 1]
+            assert dst in allowed[src], f"Invalid: {src} → {dst}"
+
+    def test_bounce_back_from_l2(self):
+        """L2 sends it back to L1 — valid transition."""
+        result = mock_run(
+            escalation_flow,
+            "Simple question mistakenly escalated",
+            events=[
+                MockEvent.handoff("l1_support"),
+                MockEvent.handoff("l2_engineer"),
+                MockEvent.message("This is simple, sending back to L1."),
+                MockEvent.handoff("l1_support"),
+                MockEvent.done("Here's your answer."),
+            ],
+        )
+
+        handoffs = [ev.target for ev in result.events if ev.type == EventType.HANDOFF]
+        assert handoffs == ["l1_support", "l2_engineer", "l1_support"]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. NESTED STRATEGIES — parallel into sequential
+# ═══════════════════════════════════════════════════════════════════════
+
+market_researcher = Agent(
+    name="market_researcher",
+    model="openai/gpt-4o",
+    instructions="Research market trends.",
+)
+
+competitor_analyst = Agent(
+    name="competitor_analyst",
+    model="openai/gpt-4o",
+    instructions="Analyze competitors.",
+)
+
+parallel_research = Agent(
+    name="research_phase",
+    model="openai/gpt-4o",
+    agents=[market_researcher, competitor_analyst],
+    strategy=Strategy.PARALLEL,
+)
+
+report_writer = Agent(
+    name="report_writer",
+    model="openai/gpt-4o",
+    instructions="Write a synthesis report from multiple analyses.",
+)
+
+# Nested: parallel research → sequential report writing
+research_pipeline = parallel_research >> report_writer
+
+
+class TestNestedStrategies:
+    """Compose strategies: parallel research feeds into sequential summary."""
+
+    def test_parallel_then_sequential(self):
+        result = mock_run(
+            research_pipeline,
+            "Analyze the cloud computing market",
+            events=[
+                # Parallel phase — both researchers run
+                MockEvent.handoff("market_researcher"),
+                MockEvent.handoff("competitor_analyst"),
+                # Sequential phase — report writer synthesizes
+                MockEvent.handoff("report_writer"),
+                MockEvent.done(
+                    "Market is growing 20% YoY. "
+                    "Top competitor: AWS with 32% share. "
+                    "Opportunity: edge computing niche."
+                ),
+            ],
+        )
+
+        assert_agent_ran(result, "market_researcher")
+        assert_agent_ran(result, "competitor_analyst")
+        assert_agent_ran(result, "report_writer")
+
+        # Report writer comes AFTER both researchers
+        assert_event_sequence(
+            result,
+            [
+                EventType.HANDOFF,  # market_researcher
+                EventType.HANDOFF,  # competitor_analyst
+                EventType.HANDOFF,  # report_writer (must be after both)
+                EventType.DONE,
+            ],
+        )
+
+        (
+            expect(result)
+            .completed()
+            .output_contains("Market")
+            .output_contains("competitor")
+            .no_errors()
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. STRATEGY VALIDATION — structural correctness
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestStrategyValidation:
+    """
+    validate_strategy() checks that the execution trace matches
+    the strategy rules — catches bugs the individual assertions miss.
+    """
+
+    # ── Sequential: all agents, in order ──────────────────────────
+
+    def test_sequential_valid(self):
+        result = mock_run(
+            research_pipeline,
+            "Research topic",
+            events=[
+                MockEvent.handoff("market_researcher"),
+                MockEvent.handoff("competitor_analyst"),
+                MockEvent.handoff("report_writer"),
+                MockEvent.done("Report complete."),
+            ],
+        )
+        validate_strategy(research_pipeline, result)  # No exception = pass
+
+    def test_sequential_catches_skipped_agent(self):
+        """Report writer was skipped — validation catches it."""
+        result = mock_run(
+            research_pipeline,
+            "Research",
+            events=[
+                MockEvent.handoff("market_researcher"),
+                MockEvent.handoff("competitor_analyst"),
+                # report_writer is MISSING
+                MockEvent.done("Incomplete."),
+            ],
+        )
+        with pytest.raises(StrategyViolation, match="skipped"):
+            validate_strategy(research_pipeline, result)
+
+    # ── Parallel: all agents must run ─────────────────────────────
+
+    def test_parallel_valid(self):
+        result = mock_run(
+            parallel_research,
+            "Research",
+            events=[
+                MockEvent.handoff("competitor_analyst"),
+                MockEvent.handoff("market_researcher"),
+                MockEvent.done("Done."),
+            ],
+        )
+        validate_strategy(parallel_research, result)
+
+    def test_parallel_catches_missing_agent(self):
+        result = mock_run(
+            parallel_research,
+            "Research",
+            events=[
+                MockEvent.handoff("market_researcher"),
+                # competitor_analyst is MISSING
+                MockEvent.done("Partial."),
+            ],
+        )
+        with pytest.raises(StrategyViolation, match="competitor_analyst"):
+            validate_strategy(parallel_research, result)
+
+    # ── Swarm: valid transfers, no loops ──────────────────────────
+
+    def test_swarm_valid(self):
+        result = mock_run(
+            swarm_support,
+            "I need to return something",
+            events=[
+                MockEvent.handoff("returns_specialist"),
+                MockEvent.done("Return processed."),
+            ],
+        )
+        validate_strategy(swarm_support, result)
+
+    def test_swarm_catches_transfer_loop(self):
+        """Agents ping-pong back and forth — loop detected."""
+        result = mock_run(
+            swarm_support,
+            "Confusing request",
+            events=[
+                MockEvent.handoff("inventory_specialist"),
+                MockEvent.handoff("returns_specialist"),
+                MockEvent.handoff("inventory_specialist"),
+                MockEvent.handoff("returns_specialist"),
+                MockEvent.handoff("inventory_specialist"),
+                MockEvent.handoff("returns_specialist"),
+                MockEvent.done("Finally resolved."),
+            ],
+        )
+        with pytest.raises(StrategyViolation, match="loop"):
+            validate_strategy(swarm_support, result)
+
+    # ── Constrained transitions ───────────────────────────────────
+
+    def test_constrained_catches_invalid_transition(self):
+        """L1 → L3 is invalid (must go through L2)."""
+        from agentspan.agents.testing.strategy_validators import (
+            validate_constrained_transitions,
+        )
+
+        result = mock_run(
+            escalation_flow,
+            "Quick escalation",
+            events=[
+                MockEvent.handoff("l1_support"),
+                MockEvent.handoff("l3_manager"),  # INVALID: L1 can only go to L2
+                MockEvent.done("Done."),
+            ],
+        )
+        with pytest.raises(StrategyViolation, match="Invalid transition"):
+            validate_constrained_transitions(escalation_flow, result)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. RECORD / REPLAY — fixture-based regression tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRecordReplay:
+    """Save an execution to a file, replay it later for regression tests."""
+
+    def test_record_and_replay(self, tmp_path):
+        """Record a mock result to JSON, replay it, re-assert."""
+        fixture_path = tmp_path / "support_run.json"
+
+        # Record
+        result = mock_run(
+            swarm_support,
+            "Track my package TRK-001",
+            events=[
+                MockEvent.handoff("shipping_specialist"),
+                MockEvent.tool_call("track_shipment", args={"tracking_id": "TRK-001"}),
+                MockEvent.tool_result(
+                    "track_shipment", result={"status": "delivered"}
+                ),
+                MockEvent.done("Your package has been delivered!"),
+            ],
+            auto_execute_tools=False,
+        )
+        record(result, fixture_path)
+
+        # Replay
+        replayed = replay(fixture_path)
+
+        # Same assertions pass on the replayed result
+        (
+            expect(replayed)
+            .completed()
+            .handoff_to("shipping_specialist")
+            .used_tool("track_shipment")
+            .output_contains("delivered")
+            .no_errors()
+        )

--- a/sdk/python/examples/mock_tests/README.md
+++ b/sdk/python/examples/mock_tests/README.md
@@ -1,0 +1,535 @@
+# Mock Tests — Python SDK
+
+## Table of Contents
+
+- [What Is This?](#what-is-this)
+- [Why Mock Test Agents?](#why-mock-test-agents)
+- [When to Use Mock Tests](#when-to-use-mock-tests)
+- [Setup](#setup)
+- [Run](#run)
+- [Examples](#examples)
+- [Quick Reference](#quick-reference)
+  - [mock_run](#mock_run)
+  - [MockEvent Types](#mockevent-types)
+  - [auto_execute_tools](#auto_execute_tools)
+  - [Assertions](#assertions)
+  - [Fluent API](#fluent-api)
+  - [AgentResult](#agentresult)
+- [Strategy Validation](#strategy-validation)
+- [Record / Replay](#record--replay)
+- [CorrectnessEval — Live Agent Evaluation](#correctnesseval--live-agent-evaluation)
+- [Testing Pyramid for Agents](#testing-pyramid-for-agents)
+- [FAQ](#faq)
+
+---
+
+## What Is This?
+
+The Agentspan testing framework lets you write **deterministic, reproducible tests for AI agents** — without calling an LLM, connecting to a server, or spending API credits. You script the exact sequence of events an agent would produce (tool calls, handoffs, guardrail checks, etc.) and then assert that the agent's structure and behavior are correct.
+
+This is the agent equivalent of unit testing. Just as you wouldn't hit a real database to test your request handler logic, you don't need a real LLM to test that your agent routes to the right specialist, calls tools in the right order, or respects guardrail boundaries.
+
+## Why Mock Test Agents?
+
+**Fast feedback loop.** Mock tests run in milliseconds. No network calls, no token costs, no flaky LLM responses. You can run hundreds of test cases in seconds as part of CI.
+
+**Test orchestration logic, not LLM quality.** The hardest bugs in multi-agent systems aren't about what the LLM says — they're about *routing*: did the right agent get picked? Did tools fire in the right order? Did the guardrail block before the agent acted? Did the pipeline skip a stage? Mock tests catch these structural bugs deterministically.
+
+**Catch regressions early.** When you refactor agent definitions, change tool signatures, or restructure your agent hierarchy, mock tests tell you immediately if the orchestration contract broke — before you burn time on expensive live runs.
+
+**Test edge cases you can't reproduce with an LLM.** What happens when a guardrail fails and retries? When two agents transfer back and forth in a loop? When a tool throws an error mid-pipeline? Mock tests let you script exact scenarios that would be nearly impossible to trigger reliably with a real model.
+
+**Complement live evals, don't replace them.** Mock tests verify *structure* (correct routing, tool usage, event ordering). Live evals with `CorrectnessEval` verify *quality* (did the LLM make good decisions?). Use both: mock tests in CI for fast structural checks, live evals periodically for behavioral validation.
+
+## When to Use Mock Tests
+
+- **CI/CD pipelines** — run on every commit, zero cost, sub-second execution
+- **Developing new agents** — validate orchestration logic before wiring up real LLMs
+- **Refactoring** — ensure agent restructuring doesn't break routing or tool contracts
+- **Edge case coverage** — guardrail failures, error recovery, HITL flows, transfer loops
+- **Strategy validation** — verify sequential order, parallel completeness, round-robin alternation, transition constraints
+- **Regression testing** — record a known-good run, replay and re-assert later
+
+## Setup
+
+The testing module is included with the SDK. No extra dependencies needed for mock tests.
+
+```bash
+# Install the SDK (if not already installed)
+uv add agentspan
+
+# The testing module is available at:
+#   from agentspan.agents.testing import mock_run, MockEvent, expect, ...
+```
+
+For running tests, use `pytest`:
+
+```bash
+uv add --dev pytest
+```
+
+## Run
+
+```bash
+# All mock tests
+pytest examples/mock_tests/ -v
+
+# Single file
+pytest examples/mock_tests/01_basic_agent.py -v
+
+# Only a specific test class
+pytest examples/mock_tests/03_multi_agent_strategies.py::TestHandoff -v
+
+# Only a specific test
+pytest examples/mock_tests/01_basic_agent.py::TestBasicCompletion::test_simple_response -v
+```
+
+## Examples
+
+| # | File | Topics |
+|---|------|--------|
+| 01 | `01_basic_agent.py` | `mock_run`, status/output assertions, `expect()` fluent API, `auto_execute_tools`, error and thinking events |
+| 02 | `02_tool_assertions.py` | Arg validation (exact + subset), call ordering, exact tool sets, regex output, output type, event sequence, turn budget |
+| 03 | `03_multi_agent_strategies.py` | Handoff, Sequential (`>>`), Parallel, Router, Round Robin — routing, handoff targets, agent participation |
+| 04 | `04_guardrails_and_errors.py` | Input/output guardrails, guardrail retry, error events, HITL waiting, guardrails in multi-agent flows |
+| 05 | `05_advanced_patterns.py` | Swarm + `OnTextMention`, constrained transitions, nested strategies, `validate_strategy`, `record`/`replay` |
+
+Start with `01_basic_agent.py` and work through in order — each file builds on concepts from the previous one.
+
+## Quick Reference
+
+### mock_run
+
+`mock_run()` takes an agent, a prompt, and a scripted list of events, then builds an `AgentResult` you can assert against. No LLM or server is involved.
+
+```python
+from agentspan.agents.testing import mock_run, MockEvent
+
+result = mock_run(
+    agent,
+    "user prompt",
+    events=[
+        MockEvent.tool_call("search", args={"query": "test"}),
+        MockEvent.tool_result("search", result="found it"),
+        MockEvent.done("Here's your answer."),
+    ],
+    auto_execute_tools=False,
+)
+```
+
+### MockEvent Types
+
+Each factory method creates one event in the scripted execution trace:
+
+| Factory Method | Description |
+|---------------|-------------|
+| `MockEvent.done(output)` | Final output — completes the run. Every event list must end with this (or `error`). |
+| `MockEvent.tool_call(name, args)` | Agent invokes a tool. Pair with `tool_result` when `auto_execute_tools=False`. |
+| `MockEvent.tool_result(name, result)` | The return value of a tool call. Not needed when `auto_execute_tools=True`. |
+| `MockEvent.handoff(target)` | Agent delegates to a sub-agent by name. |
+| `MockEvent.thinking(content)` | LLM reasoning step. Recorded in events but doesn't affect the result status. |
+| `MockEvent.message(content)` | Agent sends a message (used in conversational strategies like round-robin). |
+| `MockEvent.error(content)` | Error — marks the result status as `FAILED`. |
+| `MockEvent.waiting(content)` | Human-in-the-loop pause — agent waits for human approval. |
+| `MockEvent.guardrail_pass(name)` | A named guardrail passed validation. |
+| `MockEvent.guardrail_fail(name, content)` | A named guardrail blocked the request. |
+
+### auto_execute_tools
+
+Controls whether real tool functions run during `mock_run()`:
+
+| Value | Behavior | When to use |
+|-------|----------|-------------|
+| `True` (default) | Your `@tool` functions execute for real. You only need `MockEvent.tool_call` — the result is computed automatically. | When you want to test tool *implementations* alongside orchestration. |
+| `False` | Tools don't execute. You must provide both `MockEvent.tool_call` and `MockEvent.tool_result` for every call. | When you want to control exact inputs/outputs and test orchestration *logic* in isolation. |
+
+### Assertions
+
+All assertion functions take an `AgentResult` as the first argument and raise `AssertionError` on failure:
+
+| Function | What it checks |
+|----------|---------------|
+| `assert_status(result, status)` | Result status matches (e.g. `"COMPLETED"`, `"FAILED"`) |
+| `assert_no_errors(result)` | No `ERROR` events in the trace |
+| `assert_tool_used(result, name)` | Tool was called at least once |
+| `assert_tool_not_used(result, name)` | Tool was never called |
+| `assert_tool_called_with(result, name, args=...)` | Tool was called with specific args (subset match — extra args OK) |
+| `assert_tool_call_order(result, names)` | Tools appeared in this subsequence order (other calls in between OK) |
+| `assert_tools_used_exactly(result, names)` | Exactly these tools were used — no more, no less (set equality) |
+| `assert_output_contains(result, text, case_sensitive=True)` | Final output contains substring |
+| `assert_output_matches(result, pattern)` | Final output matches regex pattern |
+| `assert_output_type(result, type_)` | Final output is an instance of the given type |
+| `assert_handoff_to(result, agent_name)` | A handoff to this agent occurred |
+| `assert_agent_ran(result, agent_name)` | Agent participated (appeared in a handoff event) |
+| `assert_guardrail_passed(result, name)` | Named guardrail passed |
+| `assert_guardrail_failed(result, name)` | Named guardrail failed/blocked |
+| `assert_event_sequence(result, types)` | Event types appear in this subsequence order |
+| `assert_events_contain(result, event_type, expected=True)` | Event type exists (or doesn't) in the trace |
+| `assert_max_turns(result, n)` | Agent didn't exceed `n` turns (tool calls + done events) |
+
+```python
+from agentspan.agents.testing import (
+    assert_status, assert_no_errors,
+    assert_tool_used, assert_tool_not_used,
+    assert_tool_called_with, assert_tool_call_order,
+    assert_tools_used_exactly,
+    assert_output_contains, assert_output_matches, assert_output_type,
+    assert_handoff_to, assert_agent_ran,
+    assert_guardrail_passed, assert_guardrail_failed,
+    assert_event_sequence, assert_events_contain,
+    assert_max_turns,
+)
+```
+
+### Fluent API
+
+The `expect()` API chains multiple assertions in a single expression. Every method returns `self`, so you keep chaining. It raises on the first failure.
+
+```python
+from agentspan.agents.testing import expect
+
+(expect(result)
+    .completed()                                    # status == "COMPLETED"
+    .used_tool("search", args={"query": "test"})    # tool called with these args
+    .did_not_use_tool("delete")                     # tool was NOT called
+    .handoff_to("specialist")                       # handoff occurred
+    .agent_ran("researcher")                        # agent participated
+    .output_contains("answer")                      # output has substring
+    .output_matches(r"order #\d+")                  # output matches regex
+    .guardrail_passed("pii_check")                  # guardrail passed
+    .max_turns(10)                                  # didn't exceed 10 turns
+    .no_errors())                                   # no ERROR events
+```
+
+You can also assert failure:
+
+```python
+expect(result).failed()  # status != "COMPLETED"
+```
+
+### AgentResult
+
+`mock_run()` returns an `AgentResult` with these key properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `result.output` | `Any` | The final answer (string, dict, or structured type) |
+| `result.status` | `Status` | `COMPLETED`, `FAILED`, `TERMINATED`, or `TIMED_OUT` |
+| `result.events` | `list[AgentEvent]` | Full execution trace — every tool call, handoff, guardrail, etc. |
+| `result.tool_calls` | `list[dict]` | All tool invocations with names and arguments |
+| `result.messages` | `list[dict]` | Conversation history |
+| `result.error` | `str | None` | Error message if the run failed |
+| `result.is_success` | `bool` | `True` if status is `COMPLETED` |
+| `result.is_failed` | `bool` | `True` if status is `FAILED`, `TERMINATED`, or `TIMED_OUT` |
+| `result.finish_reason` | `FinishReason` | Why the agent stopped: `STOP`, `ERROR`, `GUARDRAIL`, `TIMEOUT`, etc. |
+
+Each `AgentEvent` has:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `event.type` | `EventType` | `TOOL_CALL`, `HANDOFF`, `DONE`, `ERROR`, `GUARDRAIL_PASS`, etc. |
+| `event.target` | `str` | Agent name (for `HANDOFF` events) |
+| `event.name` | `str` | Tool or guardrail name (for `TOOL_CALL`, `GUARDRAIL_*` events) |
+| `event.content` | `Any` | Event payload (tool args, output text, error message, etc.) |
+
+---
+
+## Strategy Validation
+
+`validate_strategy(agent, result)` inspects the full execution trace and verifies that the orchestration rules for the agent's declared strategy were actually followed. Unlike individual assertions that check one property at a time, strategy validation checks the **structural correctness of the entire run** — catching bugs where agents were skipped, ran out of order, looped, or violated transition constraints.
+
+It works on both mock and live results. When used with live results from `CorrectnessEval`, it catches real orchestration bugs that would be invisible to output-only checks.
+
+```python
+from agentspan.agents.testing import validate_strategy, StrategyViolation
+
+# Passes silently if the trace matches the strategy rules
+validate_strategy(agent, result)
+
+# Raises StrategyViolation with a descriptive message on failure
+# e.g. "Sequential violation: agent 'writer' was skipped"
+```
+
+Each strategy has specific rules that are validated:
+
+| Strategy | What it checks |
+|----------|---------------|
+| **Sequential** | All agents ran, in definition order, exactly once each. Catches skipped agents and wrong ordering. |
+| **Parallel** | All agents ran (order doesn't matter). Catches any agent that was skipped. |
+| **Round Robin** | Agents alternate in the correct rotation pattern. Catches wrong starting agent, same agent running twice in a row, and exceeded `max_turns`. |
+| **Router** | Exactly one sub-agent was selected. Catches zero selections (router handled it itself) and multiple selections. |
+| **Handoff** | At least one handoff occurred to a valid sub-agent. |
+| **Swarm** | At least one agent handled the request, no transfer loops (same pair ping-ponging >2 times), respects `max_turns`. |
+| **Constrained** | Every transition in the trace is present in the `allowed_transitions` dict. Catches illegal jumps (e.g. L1 directly to L3 when only L1→L2 is allowed). |
+
+You can also call individual validators directly:
+
+```python
+from agentspan.agents.testing.strategy_validators import (
+    validate_sequential,
+    validate_parallel,
+    validate_round_robin,
+    validate_router,
+    validate_handoff,
+    validate_swarm,
+    validate_constrained_transitions,
+)
+
+# Useful when an agent uses round_robin + allowed_transitions
+# and you want to check the constraint rules specifically
+validate_constrained_transitions(agent, result)
+```
+
+---
+
+## Record / Replay
+
+Record/replay lets you capture an `AgentResult` to a JSON file, then load it back later to re-run assertions against it. **Replay does not re-execute anything** — no server, no LLM, no mock run. It simply deserializes the saved result into an `AgentResult` object so you can assert against the same frozen snapshot.
+
+This is the foundation for **regression testing** — you record a known-good result once, commit the fixture to version control, and your CI re-asserts against it on every build. If someone changes the agent definition and the assertions start failing, you know the contract broke.
+
+**How it works:**
+
+```
+record(result, path)  →  serializes AgentResult to JSON on disk
+replay(path)          →  deserializes JSON back into an AgentResult (no execution)
+```
+
+The execution happens *before* recording — either via `mock_run()` (deterministic, no server) or a real live run with `CorrectnessEval` (real LLM). `record()` saves whatever result you give it. `replay()` loads it back. That's it.
+
+**Why this matters:** Agent definitions evolve — you add tools, restructure sub-agents, change instructions. Without regression fixtures, the only way to know if you broke something is to run a live eval (slow, expensive, non-deterministic). With record/replay, you get instant deterministic regression checks.
+
+**Typical workflow:**
+
+1. Run your agent (mock or live) and verify it behaves correctly
+2. `record()` the result to a JSON fixture file
+3. Commit the fixture to version control
+4. In CI, `replay()` the fixture and re-assert — if assertions fail, the agent's contract changed
+
+```python
+from agentspan.agents.testing import mock_run, record, replay, expect, MockEvent
+
+# Step 1: Run the agent and record the result
+result = mock_run(agent, "Track order #123", events=[
+    MockEvent.handoff("shipping_specialist"),
+    MockEvent.tool_call("track_shipment", args={"tracking_id": "TRK-001"}),
+    MockEvent.tool_result("track_shipment", result={"status": "delivered"}),
+    MockEvent.done("Your package has been delivered!"),
+])
+record(result, "fixtures/track_order.json")
+
+# Step 2: Later (in CI, after refactoring, etc.)
+# replay() just loads the JSON — nothing is executed
+replayed = replay("fixtures/track_order.json")
+
+(expect(replayed)
+    .completed()
+    .handoff_to("shipping_specialist")
+    .used_tool("track_shipment")
+    .output_contains("delivered")
+    .no_errors())
+```
+
+The fixture JSON contains the full execution snapshot: agent metadata, prompt, all events, tool calls, messages, status, and output. It's human-readable and diffable, so you can review what changed when a regression test fails.
+
+**Recording live runs:** You can also record results from real `CorrectnessEval` executions (with actual LLM calls). This captures the real LLM behavior as a fixture, so future CI runs can replay and re-assert without spending API credits or needing a running server.
+
+---
+
+## CorrectnessEval — Live Agent Evaluation
+
+`CorrectnessEval` is the **live counterpart to mock tests**. While `mock_run()` scripts behavior without an LLM, `CorrectnessEval` runs your agents against a **real Agentspan server with real LLM calls** and checks whether the agent's actual behavior matches your expectations.
+
+This is where you test that the LLM actually makes the right decisions — not just that the orchestration wiring is correct.
+
+**What it requires:**
+- A running Agentspan server (`CONDUCTOR_SERVER_URL` env var)
+- An `AgentRuntime` instance connected to it
+- API keys for the LLM providers your agents use (e.g. `OPENAI_API_KEY`)
+- Real token costs (each eval case makes live LLM calls)
+
+**How it works:**
+
+1. You define `EvalCase` objects describing: what prompt to send, what correct behavior looks like
+2. `CorrectnessEval` runs each case through `runtime.run()` — real LLM, real tools, real orchestration
+3. It checks every expectation and produces a pass/fail report
+
+```python
+from agentspan.agents import Agent, AgentRuntime, Strategy, tool
+from agentspan.agents.testing import CorrectnessEval, EvalCase
+
+# Define your agents (same ones you'd mock test)
+billing_agent = Agent(name="billing", model="openai/gpt-4o", ...)
+technical_agent = Agent(name="technical", model="openai/gpt-4o", ...)
+support = Agent(
+    name="support",
+    agents=[billing_agent, technical_agent],
+    strategy=Strategy.HANDOFF,
+)
+
+# Connect to a real server
+with AgentRuntime() as runtime:
+    eval = CorrectnessEval(runtime)
+
+    results = eval.run([
+        EvalCase(
+            name="billing_routes_correctly",
+            agent=support,
+            prompt="I need a refund for order #123",
+            expect_handoff_to="billing",
+            expect_tools=["lookup_order"],
+            expect_output_contains=["refund"],
+            expect_tools_not_used=["search_web"],
+        ),
+        EvalCase(
+            name="tech_routes_correctly",
+            agent=support,
+            prompt="My app keeps crashing on startup",
+            expect_handoff_to="technical",
+            expect_tools=["search_web"],
+            expect_tools_not_used=["lookup_order", "process_refund"],
+        ),
+        EvalCase(
+            name="sequential_pipeline_all_stages",
+            agent=content_pipeline,
+            prompt="Write about quantum computing",
+            validate_orchestration=True,  # auto-runs validate_strategy()
+        ),
+    ])
+
+    results.print_summary()
+    assert results.all_passed, f"{results.fail_count} eval(s) failed"
+```
+
+**EvalCase fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | `""` | Descriptive name for the test case |
+| `agent` | `Agent` | — | The agent to test |
+| `prompt` | `str` | `""` | The user message to send |
+| `expect_tools` | `list[str]` | `None` | Tools that MUST be used |
+| `expect_tools_not_used` | `list[str]` | `None` | Tools that must NOT be used |
+| `expect_tool_args` | `dict[str, dict]` | `None` | Tool must be called with specific args (`{tool_name: {arg: val}}`) |
+| `expect_handoff_to` | `str` | `None` | Agent name that should receive the handoff |
+| `expect_no_handoff_to` | `list[str]` | `None` | Agent names that should NOT receive handoffs |
+| `expect_output_contains` | `list[str]` | `None` | Substrings the output must contain (case-insensitive) |
+| `expect_output_matches` | `str` | `None` | Regex pattern the output must match |
+| `expect_status` | `str` | `"COMPLETED"` | Expected terminal status |
+| `expect_no_errors` | `bool` | `True` | Assert no error events in the trace |
+| `validate_orchestration` | `bool` | `True` | Run `validate_strategy()` on the result |
+| `custom_assertions` | `list[Callable]` | `[]` | Extra assertion functions `(result) -> None` |
+| `tags` | `list[str]` | `[]` | Tags for filtering (`eval.run(cases, tags=["smoke"])`) |
+
+**Sample output:**
+
+```
+============================================================
+ Agent Correctness Eval Results
+============================================================
+
+  [PASS] billing_routes_correctly
+  [PASS] tech_routes_correctly
+  [FAIL] sequential_pipeline_all_stages
+         x strategy_validation: Sequential violation: agent 'editor' was skipped
+
+────────────────────────────────────────────────────────────
+  2/3 passed, 1 failed
+============================================================
+```
+
+---
+
+## Testing Pyramid for Agents
+
+| Layer | Tool | Runs against | Cost | Speed | What it catches | CI cadence |
+|-------|------|-------------|------|-------|-----------------|------------|
+| **Unit** | `mock_run` | Nothing — scripted events | Free | Milliseconds | Broken routing, wrong tool order, missing agents, constraint violations | Every commit |
+| **Structural** | `validate_strategy` | Mock or live `AgentResult` | Free | Milliseconds | Strategy-level bugs: skipped pipeline stages, broken rotation, transfer loops | Every commit |
+| **Regression** | `record` / `replay` | Saved JSON fixture | Free | Milliseconds | Changes to orchestration contracts after refactoring | Every commit |
+| **Integration** | `CorrectnessEval` | Real server + real LLM | API credits | Seconds per case | LLM picking wrong agent, bad tool args, poor output quality | Nightly / weekly |
+
+Start from the bottom — write mock tests first, add strategy validation, record fixtures, and run live evals periodically.
+
+---
+
+## FAQ
+
+### Do I need a running server for mock tests?
+
+No. `mock_run()` is entirely local. No server, no LLM, no network calls, no API keys. That's the whole point.
+
+### Do I need a running server for `record()` / `replay()`?
+
+No. `record()` takes an `AgentResult` you already have (from `mock_run()`) and saves it to JSON. `replay()` reads it back. Neither touches a server.
+
+The only time a server is involved is if you first run an agent with `CorrectnessEval` (live execution), then pass *that* result to `record()`. But that's your choice — `record()` itself is just serialization.
+
+### What's the difference between `assert_tool_called_with` and `assert_tools_used_exactly`?
+
+- `assert_tool_called_with(result, "search", args={"query": "test"})` — checks that `search` was called with at least these args (subset match). Other args and other tool calls are ignored.
+- `assert_tools_used_exactly(result, ["search", "fetch"])` — checks that *exactly* these tools were used, no more, no less. Doesn't check args.
+
+### What does `auto_execute_tools=True` actually do?
+
+When `True` (default), `mock_run()` calls your real `@tool` functions when it encounters a `MockEvent.tool_call`. The return value becomes the tool result automatically — you don't need `MockEvent.tool_result` events.
+
+When `False`, tools are not executed. You must script both `MockEvent.tool_call` and `MockEvent.tool_result` for every tool invocation. This gives you full control over inputs and outputs.
+
+### Can I mix assertions and the fluent `expect()` API?
+
+Yes. They use the same underlying checks. Use whichever style you prefer, or mix them in the same test:
+
+```python
+assert_tool_used(result, "search")
+expect(result).completed().output_contains("found").no_errors()
+```
+
+### How do I test that an agent does NOT hand off to a specific agent?
+
+Use `pytest.raises`:
+
+```python
+with pytest.raises(AssertionError):
+    assert_handoff_to(result, "wrong_agent")
+```
+
+Or use `assert_events_contain` with `expected=False`:
+
+```python
+assert_events_contain(result, EventType.HANDOFF, expected=False, target="wrong_agent")
+```
+
+### How does `assert_event_sequence` work?
+
+It checks a **subsequence** — the listed event types must appear in this order, but other events can appear in between. For example:
+
+```python
+# This passes even if there are THINKING events between the TOOL_CALLs
+assert_event_sequence(result, [EventType.TOOL_CALL, EventType.TOOL_CALL, EventType.DONE])
+```
+
+### Can I run `CorrectnessEval` with pytest?
+
+Yes. Mark your live tests with `@pytest.mark.integration` and skip them by default:
+
+```python
+@pytest.mark.integration
+class TestLiveEvals:
+    @pytest.fixture
+    def runtime(self):
+        from agentspan.agents import AgentRuntime
+        with AgentRuntime() as rt:
+            yield rt
+
+    def test_routing(self, runtime):
+        eval = CorrectnessEval(runtime)
+        results = eval.run([...])
+        assert results.all_passed
+```
+
+Run with: `pytest -m integration`
+
+### What happens if my events list doesn't end with `MockEvent.done()` or `MockEvent.error()`?
+
+The result will still be constructed from whatever events you provide, but the status may not be set correctly. Always end with `done()` for success or `error()` for failure.

--- a/sdk/python/examples/mock_tests/live_correctness_eval.py
+++ b/sdk/python/examples/mock_tests/live_correctness_eval.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Live CorrectnessEval — run eval cases against a real server.
+
+Demonstrates two approaches:
+
+  1. **Manual** — hand-write EvalCase definitions with explicit expectations.
+  2. **Auto-capture** — run the agent once, auto-generate EvalCase from the
+     observed behavior, then replay as a regression test.
+
+Unlike mock tests, this sends real prompts through the LLM and validates
+the agent's behavior end-to-end.
+
+Requirements:
+    - A running Agentspan server (default: http://localhost:6767/api)
+    - An LLM API key (e.g. OPENAI_API_KEY)
+    - AGENTSPAN_LLM_MODEL env var (default: openai/gpt-4o-mini)
+
+Run:
+    cd sdk/python
+    uv run python examples/mock_tests/live_correctness_eval.py
+"""
+
+import sys
+import os
+
+# Ensure the examples directory is on the path for settings import
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agentspan.agents import Agent, AgentRuntime, tool
+from agentspan.agents.testing import (
+    CorrectnessEval,
+    EvalCase,
+    capture_eval_case,
+    eval_case_from_result,
+    record,
+)
+from settings import settings
+
+
+# ── Tools ────────────────────────────────────────────────────────────
+
+
+@tool
+def get_weather(city: str) -> dict:
+    """Get the current weather for a city."""
+    return {"city": city, "temp_f": 72, "condition": "Sunny"}
+
+
+@tool
+def get_stock_price(symbol: str) -> dict:
+    """Get the current stock price for a ticker symbol."""
+    return {"symbol": symbol, "price": 182.50, "change": "+1.2%"}
+
+
+# ── Agent ────────────────────────────────────────────────────────────
+
+agent = Agent(
+    name="weather_stock_agent",
+    model=settings.llm_model,
+    tools=[get_weather, get_stock_price],
+    instructions="You are a helpful assistant. Use tools to answer questions about weather and stocks.",
+)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 1. MANUAL — hand-written eval cases
+# ═════════════════════════════════════════════════════════════════════
+
+manual_cases = [
+    EvalCase(
+        name="weather_uses_correct_tool",
+        agent=agent,
+        prompt="What's the weather in San Francisco?",
+        expect_tools=["get_weather"],
+        expect_tools_not_used=["get_stock_price"],
+        expect_output_contains=["72", "sunny"],
+    ),
+    EvalCase(
+        name="stock_uses_correct_tool",
+        agent=agent,
+        prompt="What's the stock price for AAPL?",
+        expect_tools=["get_stock_price"],
+        expect_tools_not_used=["get_weather"],
+        expect_output_contains=["182"],
+    ),
+    EvalCase(
+        name="weather_passes_correct_args",
+        agent=agent,
+        prompt="What's the weather like in Tokyo?",
+        expect_tools=["get_weather"],
+        expect_tool_args={"get_weather": {"city": "Tokyo"}},
+    ),
+]
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 2. AUTO-CAPTURE — generate eval cases from observed behavior
+# ═════════════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    with AgentRuntime() as runtime:
+        evaluator = CorrectnessEval(runtime)
+
+        # ── Run manual cases ─────────────────────────────────────
+        print(">>> Running manual eval cases...")
+        manual_results = evaluator.run(manual_cases)
+        manual_results.print_summary()
+
+        # ── Auto-capture: run once, generate case, re-run as regression ──
+        print(">>> Auto-capturing eval cases...")
+
+        # Option A: capture_eval_case() — one-liner, runs + generates
+        case1, result1 = capture_eval_case(
+            runtime, agent, "What's the weather in Paris?"
+        )
+        print(f"  Captured: {case1.name}")
+        print(f"    expect_tools={case1.expect_tools}")
+        print(f"    expect_tool_args={case1.expect_tool_args}")
+        print(f"    expect_status={case1.expect_status}")
+
+        # Option B: eval_case_from_result() — from an existing result
+        result2 = runtime.run(agent, "Check the stock price of TSLA")
+        case2 = eval_case_from_result(
+            result2,
+            agent=agent,
+            prompt="Check the stock price of TSLA",
+            name="tsla_stock_check",
+            tags=["captured", "stock"],
+        )
+        print(f"  Captured: {case2.name}")
+        print(f"    expect_tools={case2.expect_tools}")
+        print(f"    expect_tool_args={case2.expect_tool_args}")
+
+        # Optionally save the result as a fixture for replay
+        record(result2, "tests/recordings/tsla_stock.json")
+        print("  Saved fixture: tests/recordings/tsla_stock.json")
+
+        # ── Re-run captured cases as regression tests ────────────
+        print("\n>>> Running captured cases as regression tests...")
+        captured_results = evaluator.run([case1, case2])
+        captured_results.print_summary()
+
+        all_passed = manual_results.all_passed and captured_results.all_passed
+        if not all_passed:
+            sys.exit(1)

--- a/sdk/python/src/agentspan/agents/testing/__init__.py
+++ b/sdk/python/src/agentspan/agents/testing/__init__.py
@@ -42,6 +42,8 @@ from agentspan.agents.testing.eval_runner import (
     EvalCase,
     EvalCaseResult,
     EvalSuiteResult,
+    capture_eval_case,
+    eval_case_from_result,
 )
 
 # Fluent API
@@ -95,4 +97,6 @@ __all__ = [
     "EvalCase",
     "EvalCaseResult",
     "EvalSuiteResult",
+    "eval_case_from_result",
+    "capture_eval_case",
 ]

--- a/sdk/python/src/agentspan/agents/testing/eval_runner.py
+++ b/sdk/python/src/agentspan/agents/testing/eval_runner.py
@@ -352,3 +352,148 @@ def _assert_no_handoff(result: AgentResult, agent_name: str) -> None:
         raise AssertionError(
             f"Expected NO handoff to '{agent_name}', but {len(handoffs)} occurred."
         )
+
+
+# ── Eval case generation from observed results ───────────────────────
+
+
+def _slugify(text: str, max_len: int = 60) -> str:
+    """Turn a prompt into a snake_case name."""
+    import re
+
+    slug = re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+    return slug[:max_len].rstrip("_")
+
+
+# Keys injected by the runtime that should not be captured in eval expectations.
+_INTERNAL_ARG_KEYS = frozenset({"__agentspan_ctx__", "_agent_state", "method"})
+
+
+def eval_case_from_result(
+    result: AgentResult,
+    *,
+    agent: Any,
+    prompt: str,
+    name: str = "",
+    include_tool_args: bool = True,
+    tags: Optional[List[str]] = None,
+) -> EvalCase:
+    """Generate an :class:`EvalCase` from an observed :class:`AgentResult`.
+
+    Inspects the result's tool calls, handoff events, status, and output
+    to build expectations automatically — no manual case authoring needed.
+
+    Typical workflow::
+
+        # 1. Run agent against a live server
+        result = runtime.run(agent, "What's the weather in Tokyo?")
+
+        # 2. Auto-generate an eval case from the observed behavior
+        case = eval_case_from_result(result, agent=agent, prompt="What's the weather in Tokyo?")
+
+        # 3. Use it in future regression runs
+        evaluator = CorrectnessEval(runtime)
+        suite = evaluator.run([case])
+
+    Args:
+        result: The :class:`AgentResult` to build expectations from.
+        agent: The Agent that produced this result (stored in the case).
+        prompt: The prompt that was sent to the agent.
+        name: Optional descriptive name. Auto-generated from prompt if empty.
+        include_tool_args: If True (default), capture tool call arguments
+            in ``expect_tool_args``.
+        tags: Optional tags for filtering.
+
+    Returns:
+        A fully-populated :class:`EvalCase`.
+    """
+    if not name:
+        name = _slugify(prompt)
+
+    # Extract tools used
+    tool_names = []
+    tool_args: Dict[str, Dict[str, Any]] = {}
+    for tc in result.tool_calls:
+        tool_name = tc.get("name", "")
+        if tool_name and tool_name not in tool_names:
+            tool_names.append(tool_name)
+        if include_tool_args and tool_name and tc.get("args"):
+            # Strip internal runtime keys that change per-execution
+            cleaned = {
+                k: v for k, v in tc["args"].items() if k not in _INTERNAL_ARG_KEYS
+            }
+            if cleaned:
+                tool_args[tool_name] = cleaned
+
+    # Extract handoff target from events
+    handoff_target = None
+    for ev in result.events:
+        if ev.type == EventType.HANDOFF and ev.target:
+            handoff_target = ev.target
+            break  # Use first handoff
+
+    # Check for errors
+    has_errors = any(ev.type == EventType.ERROR for ev in result.events)
+
+    return EvalCase(
+        name=name,
+        agent=agent,
+        prompt=prompt,
+        expect_tools=tool_names if tool_names else None,
+        expect_tool_args=tool_args if tool_args else None,
+        expect_handoff_to=handoff_target,
+        expect_status=str(result.status.value) if hasattr(result.status, "value") else str(result.status),
+        expect_no_errors=not has_errors,
+        validate_orchestration=True,
+        tags=list(tags) if tags else ["captured"],
+    )
+
+
+def capture_eval_case(
+    runtime: Any,
+    agent: Any,
+    prompt: str,
+    *,
+    name: str = "",
+    include_tool_args: bool = True,
+    tags: Optional[List[str]] = None,
+) -> tuple:
+    """Run an agent and auto-generate an :class:`EvalCase` from the result.
+
+    Convenience wrapper that combines ``runtime.run()`` with
+    :func:`eval_case_from_result`.  Returns both the generated case and
+    the original result for inspection.
+
+    Example::
+
+        with AgentRuntime() as runtime:
+            case, result = capture_eval_case(runtime, agent, "Check stock for AAPL")
+            result.print_result()  # inspect what happened
+
+            # Replay later as a regression test
+            evaluator = CorrectnessEval(runtime)
+            suite = evaluator.run([case])
+            suite.print_summary()
+
+    Args:
+        runtime: An :class:`AgentRuntime` instance (or any object with a
+            ``run(agent, prompt)`` method).
+        agent: The Agent to run.
+        prompt: The user message to send.
+        name: Optional descriptive name. Auto-generated from prompt if empty.
+        include_tool_args: If True (default), capture tool call arguments.
+        tags: Optional tags for filtering.
+
+    Returns:
+        A tuple of ``(EvalCase, AgentResult)``.
+    """
+    result = runtime.run(agent, prompt)
+    case = eval_case_from_result(
+        result,
+        agent=agent,
+        prompt=prompt,
+        name=name,
+        include_tool_args=include_tool_args,
+        tags=tags,
+    )
+    return case, result

--- a/sdk/typescript/examples/mock_tests/01-basic-agent.test.ts
+++ b/sdk/typescript/examples/mock_tests/01-basic-agent.test.ts
@@ -5,10 +5,10 @@
  *
  * Covers:
  *   - Creating a single agent with tools
- *   - mockRun() with mock tool implementations
+ *   - MockEvent factory + mockRun with scripted events
  *   - Basic status and output assertions
  *   - Tool usage assertions
- *   - The fluent expectResult() API
+ *   - The fluent expect() API
  *
  * Run:
  *   npx vitest run examples/mock_tests/01-basic-agent.test.ts
@@ -18,8 +18,9 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { Agent, tool } from "@agentspan-ai/sdk";
 import {
+  MockEvent,
   mockRun,
-  expectResult,
+  expect as agentExpect,
   assertStatus,
   assertNoErrors,
   assertToolUsed,
@@ -64,15 +65,17 @@ const assistant = new Agent({
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("Basic Completion", () => {
-  it("completes successfully with mock tools", async () => {
-    const result = await mockRun(assistant, "What's the weather in Tokyo?", {
-      mockTools: {
-        get_weather: async (args: { city: string }) => ({
+  it("completes successfully with scripted tool events", () => {
+    const result = mockRun(assistant, "What's the weather in Tokyo?", {
+      events: [
+        MockEvent.toolCall("get_weather", { city: "Tokyo" }),
+        MockEvent.toolResult("get_weather", {
           temperature: 72,
           condition: "Sunny",
-          city: args.city,
+          city: "Tokyo",
         }),
-      },
+        MockEvent.done({ result: "It's 72°F and Sunny in Tokyo." }),
+      ],
     });
 
     assertStatus(result, "COMPLETED");
@@ -80,19 +83,25 @@ describe("Basic Completion", () => {
     assertToolUsed(result, "get_weather");
   });
 
-  it("handles multiple tool calls", async () => {
-    const result = await mockRun(
+  it("handles multiple tool calls", () => {
+    const result = mockRun(
       assistant,
       "What's the weather and time in London?",
       {
-        mockTools: {
-          get_weather: async () => ({
+        events: [
+          MockEvent.toolCall("get_weather", { city: "London" }),
+          MockEvent.toolResult("get_weather", {
             temperature: 55,
             condition: "Rainy",
             city: "London",
           }),
-          get_time: async () => ({ time: "7:30 PM", timezone: "Europe/London" }),
-        },
+          MockEvent.toolCall("get_time", { timezone: "Europe/London" }),
+          MockEvent.toolResult("get_time", {
+            time: "7:30 PM",
+            timezone: "Europe/London",
+          }),
+          MockEvent.done({ result: "London: 55°F Rainy, 7:30 PM" }),
+        ],
       },
     );
 
@@ -101,68 +110,76 @@ describe("Basic Completion", () => {
     assertNoErrors(result);
   });
 
-  it("completes without using any tools", async () => {
-    const result = await mockRun(assistant, "Hello, how are you?");
+  it("completes without using any tools", () => {
+    const result = mockRun(assistant, "Hello, how are you?", {
+      events: [MockEvent.done("Hello! I'm doing great.")],
+    });
 
     assertStatus(result, "COMPLETED");
     assertNoErrors(result);
   });
 });
 
-describe("Fluent expectResult API", () => {
-  it("chains status + output + tool checks", async () => {
-    const result = await mockRun(assistant, "Weather in Paris?", {
-      mockTools: {
-        get_weather: async () => ({
+describe("Fluent expect API", () => {
+  it("chains status + tool checks", () => {
+    const result = mockRun(assistant, "Weather in Paris?", {
+      events: [
+        MockEvent.toolCall("get_weather", { city: "Paris" }),
+        MockEvent.toolResult("get_weather", {
           temperature: 60,
           condition: "Cloudy",
           city: "Paris",
         }),
-      },
+        MockEvent.done({ result: "It's 60°F and Cloudy in Paris." }),
+      ],
     });
 
-    expectResult(result).toBeCompleted().toHaveUsedTool("get_weather");
+    agentExpect(result).completed().usedTool("get_weather");
   });
 
-  it("verifies output contains text", async () => {
-    const result = await mockRun(assistant, "What time is it in NYC?", {
-      mockTools: {
-        get_time: async () => ({ time: "2:30 PM", timezone: "America/New_York" }),
-      },
+  it("verifies output contains text", () => {
+    const result = mockRun(assistant, "What time is it in NYC?", {
+      events: [
+        MockEvent.toolCall("get_time", { timezone: "America/New_York" }),
+        MockEvent.toolResult("get_time", {
+          time: "2:30 PM",
+          timezone: "America/New_York",
+        }),
+        MockEvent.done({ result: "It's 2:30 PM in NYC." }),
+      ],
     });
 
-    expectResult(result).toBeCompleted().toHaveUsedTool("get_time");
+    agentExpect(result).completed().usedTool("get_time").outputContains("2:30 PM");
   });
 });
 
 describe("Error Scenarios", () => {
-  it("detects failed status", async () => {
+  it("detects failed status via error event", () => {
     const failAgent = new Agent({
       name: "fail-agent",
       model: "openai/gpt-4o",
       instructions: "You always fail.",
     });
 
-    const result = await mockRun(failAgent, "Do something impossible", {
-      mockTools: {},
+    const result = mockRun(failAgent, "Do something impossible", {
+      events: [MockEvent.error("Cannot process request")],
     });
 
-    // The result status depends on execution — verify it's not undefined
-    expect(result.status).toBeDefined();
+    assertStatus(result, "FAILED");
   });
 });
 
-describe("Mock Credentials", () => {
-  it("injects mock credentials into tool context", async () => {
-    const result = await mockRun(assistant, "Weather check", {
-      mockTools: {
-        get_weather: async () => ({ temperature: 70, city: "Test" }),
-      },
-      mockCredentials: {
-        WEATHER_API_KEY: "test-key-123",
-      },
+describe("Auto-Execute Tools", () => {
+  it("auto-executes tool functions when available", () => {
+    const result = mockRun(assistant, "Weather check", {
+      events: [
+        MockEvent.toolCall("get_weather", { city: "Test" }),
+        MockEvent.done({ result: "Weather checked." }),
+      ],
+      // autoExecuteTools defaults to true — tool func will run
     });
 
-    expectResult(result).toBeCompleted();
+    assertToolUsed(result, "get_weather");
+    agentExpect(result).completed();
   });
 });

--- a/sdk/typescript/examples/mock_tests/01-basic-agent.test.ts
+++ b/sdk/typescript/examples/mock_tests/01-basic-agent.test.ts
@@ -1,0 +1,168 @@
+/**
+ * 01 — Basic Agent Mock Tests
+ *
+ * The simplest possible mock tests. No server, no LLM, no API keys.
+ *
+ * Covers:
+ *   - Creating a single agent with tools
+ *   - mockRun() with mock tool implementations
+ *   - Basic status and output assertions
+ *   - Tool usage assertions
+ *   - The fluent expectResult() API
+ *
+ * Run:
+ *   npx vitest run examples/mock_tests/01-basic-agent.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { Agent, tool } from "@agentspan-ai/sdk";
+import {
+  mockRun,
+  expectResult,
+  assertStatus,
+  assertNoErrors,
+  assertToolUsed,
+} from "@agentspan-ai/sdk/testing";
+
+// ── Tools ────────────────────────────────────────────────────────────
+
+const getWeather = tool(
+  async (args: { city: string }) => ({
+    temperature: 72,
+    condition: "Sunny",
+    city: args.city,
+  }),
+  {
+    name: "get_weather",
+    description: "Get current weather for a city.",
+    inputSchema: z.object({ city: z.string() }),
+  },
+);
+
+const getTime = tool(
+  async (args: { timezone: string }) => ({
+    time: "2:30 PM",
+    timezone: args.timezone,
+  }),
+  {
+    name: "get_time",
+    description: "Get current time in a timezone.",
+    inputSchema: z.object({ timezone: z.string() }),
+  },
+);
+
+// ── Agent ────────────────────────────────────────────────────────────
+
+const assistant = new Agent({
+  name: "assistant",
+  model: "openai/gpt-4o",
+  instructions: "You are a helpful assistant. Use tools when needed.",
+  tools: [getWeather, getTime],
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("Basic Completion", () => {
+  it("completes successfully with mock tools", async () => {
+    const result = await mockRun(assistant, "What's the weather in Tokyo?", {
+      mockTools: {
+        get_weather: async (args: { city: string }) => ({
+          temperature: 72,
+          condition: "Sunny",
+          city: args.city,
+        }),
+      },
+    });
+
+    assertStatus(result, "COMPLETED");
+    assertNoErrors(result);
+    assertToolUsed(result, "get_weather");
+  });
+
+  it("handles multiple tool calls", async () => {
+    const result = await mockRun(
+      assistant,
+      "What's the weather and time in London?",
+      {
+        mockTools: {
+          get_weather: async () => ({
+            temperature: 55,
+            condition: "Rainy",
+            city: "London",
+          }),
+          get_time: async () => ({ time: "7:30 PM", timezone: "Europe/London" }),
+        },
+      },
+    );
+
+    assertToolUsed(result, "get_weather");
+    assertToolUsed(result, "get_time");
+    assertNoErrors(result);
+  });
+
+  it("completes without using any tools", async () => {
+    const result = await mockRun(assistant, "Hello, how are you?");
+
+    assertStatus(result, "COMPLETED");
+    assertNoErrors(result);
+  });
+});
+
+describe("Fluent expectResult API", () => {
+  it("chains status + output + tool checks", async () => {
+    const result = await mockRun(assistant, "Weather in Paris?", {
+      mockTools: {
+        get_weather: async () => ({
+          temperature: 60,
+          condition: "Cloudy",
+          city: "Paris",
+        }),
+      },
+    });
+
+    expectResult(result).toBeCompleted().toHaveUsedTool("get_weather");
+  });
+
+  it("verifies output contains text", async () => {
+    const result = await mockRun(assistant, "What time is it in NYC?", {
+      mockTools: {
+        get_time: async () => ({ time: "2:30 PM", timezone: "America/New_York" }),
+      },
+    });
+
+    expectResult(result).toBeCompleted().toHaveUsedTool("get_time");
+  });
+});
+
+describe("Error Scenarios", () => {
+  it("detects failed status", async () => {
+    const failAgent = new Agent({
+      name: "fail-agent",
+      model: "openai/gpt-4o",
+      instructions: "You always fail.",
+    });
+
+    const result = await mockRun(failAgent, "Do something impossible", {
+      mockTools: {},
+    });
+
+    // The result status depends on execution — verify it's not undefined
+    expect(result.status).toBeDefined();
+  });
+});
+
+describe("Mock Credentials", () => {
+  it("injects mock credentials into tool context", async () => {
+    const result = await mockRun(assistant, "Weather check", {
+      mockTools: {
+        get_weather: async () => ({ temperature: 70, city: "Test" }),
+      },
+      mockCredentials: {
+        WEATHER_API_KEY: "test-key-123",
+      },
+    });
+
+    expectResult(result).toBeCompleted();
+  });
+});

--- a/sdk/typescript/examples/mock_tests/02-tool-assertions.test.ts
+++ b/sdk/typescript/examples/mock_tests/02-tool-assertions.test.ts
@@ -2,14 +2,14 @@
  * 02 — Tool Assertion Deep-Dive
  *
  * Thorough testing of tool usage: argument validation, call ordering,
- * mock tool implementations, and output validation.
+ * tool assertion functions, and output validation.
  *
  * Covers:
- *   - mockTools for overriding tool behavior
- *   - assertToolUsed / assertNoErrors
- *   - expectResult fluent chain with toContainOutput
+ *   - MockEvent for scripting tool call / result events
+ *   - assertToolUsed / assertToolNotUsed / assertToolCalledWith
+ *   - assertToolCallOrder / assertToolsUsedExactly
+ *   - expect() fluent chain with outputContains
  *   - Testing tool call sequences
- *   - Custom mock implementations
  *
  * Run:
  *   npx vitest run examples/mock_tests/02-tool-assertions.test.ts
@@ -19,9 +19,14 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { Agent, tool } from "@agentspan-ai/sdk";
 import {
+  MockEvent,
   mockRun,
-  expectResult,
+  expect as agentExpect,
   assertToolUsed,
+  assertToolNotUsed,
+  assertToolCalledWith,
+  assertToolCallOrder,
+  assertToolsUsedExactly,
   assertNoErrors,
   assertStatus,
 } from "@agentspan-ai/sdk/testing";
@@ -99,56 +104,66 @@ const shopAgent = new Agent({
 
 // ── Tests ────────────────────────────────────────────────────────────
 
-describe("Mock Tool Implementations", () => {
-  it("overrides tool behavior with mockTools", async () => {
-    const result = await mockRun(shopAgent, "Search for red shoes", {
-      mockTools: {
-        search_products: async (args: { query: string }) => [
+describe("Tool Assertions", () => {
+  it("assertToolUsed detects used tool", () => {
+    const result = mockRun(shopAgent, "Search for red shoes", {
+      events: [
+        MockEvent.toolCall("search_products", { query: "red shoes" }),
+        MockEvent.toolResult("search_products", [
           { name: "Red Running Shoe", price: 89.99 },
           { name: "Red Heel", price: 129.99 },
-        ],
-      },
+        ]),
+        MockEvent.done({ result: "Found 2 red shoes." }),
+      ],
     });
 
     assertToolUsed(result, "search_products");
-    expectResult(result).toBeCompleted();
+    agentExpect(result).completed();
   });
 
-  it("mock returns empty results", async () => {
-    const result = await mockRun(shopAgent, "Search for unicorn saddles", {
-      mockTools: {
-        search_products: async () => [],
-      },
+  it("assertToolNotUsed verifies tool was not called", () => {
+    const result = mockRun(shopAgent, "Search for unicorn saddles", {
+      events: [
+        MockEvent.toolCall("search_products", { query: "unicorn saddles" }),
+        MockEvent.toolResult("search_products", []),
+        MockEvent.done({ result: "No results found." }),
+      ],
     });
 
     assertToolUsed(result, "search_products");
+    assertToolNotUsed(result, "checkout");
     assertNoErrors(result);
+  });
+
+  it("assertToolCalledWith checks args (subset match)", () => {
+    const result = mockRun(shopAgent, "Search for laptops", {
+      events: [
+        MockEvent.toolCall("search_products", { query: "laptops", maxResults: 3 }),
+        MockEvent.toolResult("search_products", [
+          { name: "MacBook Pro", price: 2499 },
+        ]),
+        MockEvent.done({ result: "Found laptops." }),
+      ],
+    });
+
+    assertToolCalledWith(result, "search_products", { query: "laptops" });
   });
 });
 
 describe("Full Shopping Flow", () => {
-  it("executes search → details → cart → checkout", async () => {
-    const toolCallOrder: string[] = [];
-
-    const result = await mockRun(shopAgent, "Find a widget and buy it", {
-      mockTools: {
-        search_products: async (args: { query: string }) => {
-          toolCallOrder.push("search_products");
-          return [{ id: "W-1", name: "Widget" }];
-        },
-        get_product_details: async (args: { productId: string }) => {
-          toolCallOrder.push("get_product_details");
-          return { id: args.productId, name: "Widget", stock: 42 };
-        },
-        add_to_cart: async (args: { productId: string; quantity: number }) => {
-          toolCallOrder.push("add_to_cart");
-          return { success: true };
-        },
-        checkout: async (args: { paymentMethod: string }) => {
-          toolCallOrder.push("checkout");
-          return { orderId: "ORD-001", status: "confirmed" };
-        },
-      },
+  it("executes search → details → cart → checkout in order", () => {
+    const result = mockRun(shopAgent, "Find a widget and buy it", {
+      events: [
+        MockEvent.toolCall("search_products", { query: "widget" }),
+        MockEvent.toolResult("search_products", [{ id: "W-1", name: "Widget" }]),
+        MockEvent.toolCall("get_product_details", { productId: "W-1" }),
+        MockEvent.toolResult("get_product_details", { id: "W-1", name: "Widget", stock: 42 }),
+        MockEvent.toolCall("add_to_cart", { productId: "W-1", quantity: 1 }),
+        MockEvent.toolResult("add_to_cart", { success: true }),
+        MockEvent.toolCall("checkout", { paymentMethod: "credit_card" }),
+        MockEvent.toolResult("checkout", { orderId: "ORD-001", status: "confirmed" }),
+        MockEvent.done({ result: "Order ORD-001 confirmed!" }),
+      ],
     });
 
     // All tools were used
@@ -157,8 +172,16 @@ describe("Full Shopping Flow", () => {
     assertToolUsed(result, "add_to_cart");
     assertToolUsed(result, "checkout");
 
-    // Verify ordering via our tracking array
-    expect(toolCallOrder).toEqual([
+    // Verify ordering with assertToolCallOrder (subsequence check)
+    assertToolCallOrder(result, [
+      "search_products",
+      "get_product_details",
+      "add_to_cart",
+      "checkout",
+    ]);
+
+    // Verify exact tool set with assertToolsUsedExactly
+    assertToolsUsedExactly(result, [
       "search_products",
       "get_product_details",
       "add_to_cart",
@@ -168,17 +191,20 @@ describe("Full Shopping Flow", () => {
 });
 
 describe("Output Validation", () => {
-  it("tool result contains expected data", async () => {
-    const result = await mockRun(shopAgent, "Place my order", {
-      mockTools: {
-        checkout: async () => ({
+  it("tool result is captured in events", () => {
+    const result = mockRun(shopAgent, "Place my order", {
+      events: [
+        MockEvent.toolCall("checkout", { paymentMethod: "credit_card" }),
+        MockEvent.toolResult("checkout", {
           orderId: "ORD-12345",
           status: "confirmed",
         }),
-      },
+        MockEvent.done({ result: "Order confirmed!" }),
+      ],
+      autoExecuteTools: false,
     });
 
-    expectResult(result).toBeCompleted();
+    agentExpect(result).completed();
 
     // Verify the tool result was captured in events
     const toolResult = result.events.find(
@@ -191,56 +217,59 @@ describe("Output Validation", () => {
     });
   });
 
-  it("output contains structured data", async () => {
-    const result = await mockRun(shopAgent, "Search for laptops", {
-      mockTools: {
-        search_products: async () => [
+  it("output contains expected text", () => {
+    const result = mockRun(shopAgent, "Search for laptops", {
+      events: [
+        MockEvent.toolCall("search_products", { query: "laptops" }),
+        MockEvent.toolResult("search_products", [
           { name: "MacBook Pro", price: 2499 },
           { name: "ThinkPad X1", price: 1799 },
-        ],
-      },
+        ]),
+        MockEvent.done({ result: "Found 2 laptops: MacBook Pro and ThinkPad X1." }),
+      ],
     });
 
-    expectResult(result).toBeCompleted();
-    // Verify the result has events
-    expect(result.events.length).toBeGreaterThan(0);
+    agentExpect(result).completed().outputContains("MacBook");
   });
 });
 
-describe("Error in Mock Tools", () => {
-  it("handles tool that throws an error", async () => {
-    const result = await mockRun(shopAgent, "Search for broken item", {
-      mockTools: {
-        search_products: async () => {
-          throw new Error("Database connection failed");
-        },
-      },
+describe("Error in Tool Execution", () => {
+  it("error event marks result as FAILED", () => {
+    const result = mockRun(shopAgent, "Search for broken item", {
+      events: [
+        MockEvent.toolCall("search_products", { query: "broken" }),
+        MockEvent.error("Database connection failed"),
+      ],
     });
 
-    // The agent should handle the error gracefully
-    expect(result.status).toBeDefined();
+    assertStatus(result, "FAILED");
   });
 
-  it("handles missing mock tool gracefully", async () => {
-    // Only mock one tool — others use default implementations
-    const result = await mockRun(shopAgent, "Quick search", {
-      mockTools: {
-        search_products: async () => [{ name: "Item" }],
-      },
+  it("thinking + tool + done flow completes successfully", () => {
+    const result = mockRun(shopAgent, "Quick search", {
+      events: [
+        MockEvent.thinking("Let me search for that..."),
+        MockEvent.toolCall("search_products", { query: "item" }),
+        MockEvent.toolResult("search_products", [{ name: "Item" }]),
+        MockEvent.done({ result: "Found 1 item." }),
+      ],
     });
 
     assertToolUsed(result, "search_products");
+    assertNoErrors(result);
   });
 });
 
-describe("Token Usage Validation", () => {
-  it("checks token usage is within budget", async () => {
-    const result = await mockRun(shopAgent, "Simple question", {
-      mockTools: {
-        search_products: async () => [{ name: "Item" }],
-      },
+describe("Max Turns Assertion", () => {
+  it("verifies turn count stays within budget", () => {
+    const result = mockRun(shopAgent, "Simple question", {
+      events: [
+        MockEvent.toolCall("search_products", { query: "item" }),
+        MockEvent.toolResult("search_products", [{ name: "Item" }]),
+        MockEvent.done({ result: "Found it." }),
+      ],
     });
 
-    expectResult(result).toBeCompleted().toHaveTokenUsageBelow(100000);
+    agentExpect(result).completed().maxTurns(5);
   });
 });

--- a/sdk/typescript/examples/mock_tests/02-tool-assertions.test.ts
+++ b/sdk/typescript/examples/mock_tests/02-tool-assertions.test.ts
@@ -1,0 +1,246 @@
+/**
+ * 02 — Tool Assertion Deep-Dive
+ *
+ * Thorough testing of tool usage: argument validation, call ordering,
+ * mock tool implementations, and output validation.
+ *
+ * Covers:
+ *   - mockTools for overriding tool behavior
+ *   - assertToolUsed / assertNoErrors
+ *   - expectResult fluent chain with toContainOutput
+ *   - Testing tool call sequences
+ *   - Custom mock implementations
+ *
+ * Run:
+ *   npx vitest run examples/mock_tests/02-tool-assertions.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { Agent, tool } from "@agentspan-ai/sdk";
+import {
+  mockRun,
+  expectResult,
+  assertToolUsed,
+  assertNoErrors,
+  assertStatus,
+} from "@agentspan-ai/sdk/testing";
+
+// ── Tools ────────────────────────────────────────────────────────────
+
+const searchProducts = tool(
+  async (args: { query: string; maxResults?: number }) => {
+    const n = args.maxResults ?? 5;
+    return Array.from({ length: n }, (_, i) => ({
+      name: `Product ${i + 1}`,
+      price: 9.99 * (i + 1),
+    }));
+  },
+  {
+    name: "search_products",
+    description: "Search the product catalog.",
+    inputSchema: z.object({
+      query: z.string(),
+      maxResults: z.number().optional().default(5),
+    }),
+  },
+);
+
+const getProductDetails = tool(
+  async (args: { productId: string }) => ({
+    id: args.productId,
+    name: "Widget",
+    stock: 42,
+    price: 19.99,
+  }),
+  {
+    name: "get_product_details",
+    description: "Get detailed info for a product.",
+    inputSchema: z.object({ productId: z.string() }),
+  },
+);
+
+const addToCart = tool(
+  async (args: { productId: string; quantity: number }) => ({
+    success: true,
+    message: `Added ${args.quantity}x ${args.productId} to cart`,
+  }),
+  {
+    name: "add_to_cart",
+    description: "Add a product to the shopping cart.",
+    inputSchema: z.object({
+      productId: z.string(),
+      quantity: z.number(),
+    }),
+  },
+);
+
+const checkout = tool(
+  async (args: { paymentMethod: string }) => ({
+    orderId: "ORD-001",
+    status: "confirmed",
+    payment: args.paymentMethod,
+  }),
+  {
+    name: "checkout",
+    description: "Process checkout.",
+    inputSchema: z.object({ paymentMethod: z.string() }),
+  },
+);
+
+// ── Agent ────────────────────────────────────────────────────────────
+
+const shopAgent = new Agent({
+  name: "shop-assistant",
+  model: "openai/gpt-4o",
+  instructions: "Help customers find and purchase products.",
+  tools: [searchProducts, getProductDetails, addToCart, checkout],
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("Mock Tool Implementations", () => {
+  it("overrides tool behavior with mockTools", async () => {
+    const result = await mockRun(shopAgent, "Search for red shoes", {
+      mockTools: {
+        search_products: async (args: { query: string }) => [
+          { name: "Red Running Shoe", price: 89.99 },
+          { name: "Red Heel", price: 129.99 },
+        ],
+      },
+    });
+
+    assertToolUsed(result, "search_products");
+    expectResult(result).toBeCompleted();
+  });
+
+  it("mock returns empty results", async () => {
+    const result = await mockRun(shopAgent, "Search for unicorn saddles", {
+      mockTools: {
+        search_products: async () => [],
+      },
+    });
+
+    assertToolUsed(result, "search_products");
+    assertNoErrors(result);
+  });
+});
+
+describe("Full Shopping Flow", () => {
+  it("executes search → details → cart → checkout", async () => {
+    const toolCallOrder: string[] = [];
+
+    const result = await mockRun(shopAgent, "Find a widget and buy it", {
+      mockTools: {
+        search_products: async (args: { query: string }) => {
+          toolCallOrder.push("search_products");
+          return [{ id: "W-1", name: "Widget" }];
+        },
+        get_product_details: async (args: { productId: string }) => {
+          toolCallOrder.push("get_product_details");
+          return { id: args.productId, name: "Widget", stock: 42 };
+        },
+        add_to_cart: async (args: { productId: string; quantity: number }) => {
+          toolCallOrder.push("add_to_cart");
+          return { success: true };
+        },
+        checkout: async (args: { paymentMethod: string }) => {
+          toolCallOrder.push("checkout");
+          return { orderId: "ORD-001", status: "confirmed" };
+        },
+      },
+    });
+
+    // All tools were used
+    assertToolUsed(result, "search_products");
+    assertToolUsed(result, "get_product_details");
+    assertToolUsed(result, "add_to_cart");
+    assertToolUsed(result, "checkout");
+
+    // Verify ordering via our tracking array
+    expect(toolCallOrder).toEqual([
+      "search_products",
+      "get_product_details",
+      "add_to_cart",
+      "checkout",
+    ]);
+  });
+});
+
+describe("Output Validation", () => {
+  it("tool result contains expected data", async () => {
+    const result = await mockRun(shopAgent, "Place my order", {
+      mockTools: {
+        checkout: async () => ({
+          orderId: "ORD-12345",
+          status: "confirmed",
+        }),
+      },
+    });
+
+    expectResult(result).toBeCompleted();
+
+    // Verify the tool result was captured in events
+    const toolResult = result.events.find(
+      (e) => e.type === "tool_result" && e.toolName === "checkout",
+    );
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.result).toEqual({
+      orderId: "ORD-12345",
+      status: "confirmed",
+    });
+  });
+
+  it("output contains structured data", async () => {
+    const result = await mockRun(shopAgent, "Search for laptops", {
+      mockTools: {
+        search_products: async () => [
+          { name: "MacBook Pro", price: 2499 },
+          { name: "ThinkPad X1", price: 1799 },
+        ],
+      },
+    });
+
+    expectResult(result).toBeCompleted();
+    // Verify the result has events
+    expect(result.events.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Error in Mock Tools", () => {
+  it("handles tool that throws an error", async () => {
+    const result = await mockRun(shopAgent, "Search for broken item", {
+      mockTools: {
+        search_products: async () => {
+          throw new Error("Database connection failed");
+        },
+      },
+    });
+
+    // The agent should handle the error gracefully
+    expect(result.status).toBeDefined();
+  });
+
+  it("handles missing mock tool gracefully", async () => {
+    // Only mock one tool — others use default implementations
+    const result = await mockRun(shopAgent, "Quick search", {
+      mockTools: {
+        search_products: async () => [{ name: "Item" }],
+      },
+    });
+
+    assertToolUsed(result, "search_products");
+  });
+});
+
+describe("Token Usage Validation", () => {
+  it("checks token usage is within budget", async () => {
+    const result = await mockRun(shopAgent, "Simple question", {
+      mockTools: {
+        search_products: async () => [{ name: "Item" }],
+      },
+    });
+
+    expectResult(result).toBeCompleted().toHaveTokenUsageBelow(100000);
+  });
+});

--- a/sdk/typescript/examples/mock_tests/03-multi-agent-strategies.test.ts
+++ b/sdk/typescript/examples/mock_tests/03-multi-agent-strategies.test.ts
@@ -1,0 +1,317 @@
+/**
+ * 03 — Multi-Agent Strategy Tests
+ *
+ * Test orchestration strategies: handoff, sequential, parallel, router.
+ * Each section defines agents, mocks the expected behavior, and asserts
+ * correctness.
+ *
+ * Covers:
+ *   - Handoff — parent delegates to the right specialist
+ *   - Sequential pipeline — agents run in order
+ *   - Parallel execution — all agents must run
+ *   - Router — dedicated planner picks one agent
+ *   - assertAgentRan / assertHandoffTo
+ *
+ * Run:
+ *   npx vitest run examples/mock_tests/03-multi-agent-strategies.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { Agent, tool } from "@agentspan-ai/sdk";
+import {
+  mockRun,
+  expectResult,
+  assertAgentRan,
+  assertHandoffTo,
+  assertToolUsed,
+  assertNoErrors,
+  assertStatus,
+} from "@agentspan-ai/sdk/testing";
+
+// ── Tools ────────────────────────────────────────────────────────────
+
+const searchDocs = tool(
+  async (args: { query: string }) => `Documentation for: ${args.query}`,
+  {
+    name: "search_docs",
+    description: "Search documentation.",
+    inputSchema: z.object({ query: z.string() }),
+  },
+);
+
+const runQuery = tool(
+  async (args: { sql: string }) => [{ id: 1, name: "result" }],
+  {
+    name: "run_query",
+    description: "Execute a database query.",
+    inputSchema: z.object({ sql: z.string() }),
+  },
+);
+
+const sendNotification = tool(
+  async (args: { channel: string; message: string }) =>
+    `Sent to ${args.channel}: ${args.message}`,
+  {
+    name: "send_notification",
+    description: "Send a notification.",
+    inputSchema: z.object({
+      channel: z.string(),
+      message: z.string(),
+    }),
+  },
+);
+
+// ═════════════════════════════════════════════════════════════════════
+// 1. HANDOFF — parent picks the right specialist
+// ═════════════════════════════════════════════════════════════════════
+
+const docsAgent = new Agent({
+  name: "docs-specialist",
+  model: "openai/gpt-4o",
+  instructions: "Answer documentation questions.",
+  tools: [searchDocs],
+});
+
+const dbAgent = new Agent({
+  name: "db-specialist",
+  model: "openai/gpt-4o",
+  instructions: "Answer database questions.",
+  tools: [runQuery],
+});
+
+const triageAgent = new Agent({
+  name: "triage",
+  model: "openai/gpt-4o",
+  instructions: "Route questions to the right specialist.",
+  agents: [docsAgent, dbAgent],
+  strategy: "handoff",
+});
+
+describe("Handoff Strategy", () => {
+  it("routes docs question to docs specialist", async () => {
+    const result = await mockRun(
+      triageAgent,
+      "How do I configure logging?",
+      {
+        mockTools: {
+          search_docs: async (args: { query: string }) =>
+            `Set LOG_LEVEL=debug in your config. Query: ${args.query}`,
+        },
+      },
+    );
+
+    assertHandoffTo(result, "docs-specialist");
+    assertToolUsed(result, "search_docs");
+    assertNoErrors(result);
+  });
+
+  it("db specialist runs its tool when targeted directly", async () => {
+    // Test the db-specialist directly to verify tool execution in isolation
+    const result = await mockRun(
+      dbAgent,
+      "How many users signed up today?",
+      {
+        mockTools: {
+          run_query: async () => [{ count: 150 }],
+        },
+      },
+    );
+
+    assertToolUsed(result, "run_query");
+    assertNoErrors(result);
+  });
+
+  it("triage agent produces handoff event", async () => {
+    const result = await mockRun(
+      triageAgent,
+      "Show me the user table schema",
+      {
+        mockTools: {
+          run_query: async () => [{ col: "id" }, { col: "name" }],
+        },
+      },
+    );
+
+    // In mock mode, handoff goes to the first sub-agent
+    assertHandoffTo(result, "docs-specialist");
+    expectResult(result).toBeCompleted();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 2. SEQUENTIAL — agents run in order
+// ═════════════════════════════════════════════════════════════════════
+
+const researcher = new Agent({
+  name: "researcher",
+  model: "openai/gpt-4o",
+  instructions: "Research the topic thoroughly.",
+  tools: [searchDocs],
+});
+
+const drafter = new Agent({
+  name: "drafter",
+  model: "openai/gpt-4o",
+  instructions: "Write a draft based on the research.",
+});
+
+const reviewer = new Agent({
+  name: "reviewer",
+  model: "openai/gpt-4o",
+  instructions: "Review and polish the draft.",
+});
+
+const contentPipeline = new Agent({
+  name: "content-pipeline",
+  model: "openai/gpt-4o",
+  agents: [researcher, drafter, reviewer],
+  strategy: "sequential",
+});
+
+describe("Sequential Strategy", () => {
+  it("runs all agents in order", async () => {
+    const result = await mockRun(
+      contentPipeline,
+      "Write a guide on API testing",
+      {
+        mockTools: {
+          search_docs: async () => "API testing best practices...",
+        },
+      },
+    );
+
+    assertAgentRan(result, "researcher");
+    assertAgentRan(result, "drafter");
+    assertAgentRan(result, "reviewer");
+    assertNoErrors(result);
+  });
+
+  it("researcher uses search tool before drafter runs", async () => {
+    const executionOrder: string[] = [];
+
+    const result = await mockRun(
+      contentPipeline,
+      "Write about microservices",
+      {
+        mockTools: {
+          search_docs: async () => {
+            executionOrder.push("search_docs");
+            return "Microservices patterns...";
+          },
+        },
+      },
+    );
+
+    assertToolUsed(result, "search_docs");
+    expect(executionOrder).toContain("search_docs");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 3. PARALLEL — all agents run concurrently
+// ═════════════════════════════════════════════════════════════════════
+
+const securityAuditor = new Agent({
+  name: "security-auditor",
+  model: "openai/gpt-4o",
+  instructions: "Audit for security vulnerabilities.",
+});
+
+const performanceAuditor = new Agent({
+  name: "performance-auditor",
+  model: "openai/gpt-4o",
+  instructions: "Audit for performance bottlenecks.",
+});
+
+const accessibilityAuditor = new Agent({
+  name: "accessibility-auditor",
+  model: "openai/gpt-4o",
+  instructions: "Audit for accessibility compliance.",
+});
+
+const auditTeam = new Agent({
+  name: "audit-team",
+  model: "openai/gpt-4o",
+  agents: [securityAuditor, performanceAuditor, accessibilityAuditor],
+  strategy: "parallel",
+});
+
+describe("Parallel Strategy", () => {
+  it("all auditors run", async () => {
+    const result = await mockRun(auditTeam, "Audit the checkout page");
+
+    assertAgentRan(result, "security-auditor");
+    assertAgentRan(result, "performance-auditor");
+    assertAgentRan(result, "accessibility-auditor");
+    assertNoErrors(result);
+  });
+
+  it("output reflects all perspectives", async () => {
+    const result = await mockRun(auditTeam, "Audit the dashboard");
+
+    expectResult(result).toBeCompleted();
+    // Each agent should contribute to the result
+    assertAgentRan(result, "security-auditor");
+    assertAgentRan(result, "performance-auditor");
+    assertAgentRan(result, "accessibility-auditor");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 4. ROUTER — dedicated planner picks one specialist
+// ═════════════════════════════════════════════════════════════════════
+
+const backendDev = new Agent({
+  name: "backend",
+  model: "openai/gpt-4o",
+  instructions: "Fix backend/API bugs.",
+  tools: [runQuery],
+});
+
+const frontendDev = new Agent({
+  name: "frontend",
+  model: "openai/gpt-4o",
+  instructions: "Fix frontend/UI bugs.",
+});
+
+const planner = new Agent({
+  name: "planner",
+  model: "openai/gpt-4o",
+  instructions: "Route bugs to backend or frontend.",
+});
+
+const bugTriage = new Agent({
+  name: "bug-triage",
+  model: "openai/gpt-4o",
+  agents: [backendDev, frontendDev],
+  strategy: "router",
+  router: planner,
+});
+
+describe("Router Strategy", () => {
+  it("routes to a sub-agent via the router", async () => {
+    const result = await mockRun(
+      bugTriage,
+      "The /users endpoint returns 500",
+      {
+        mockTools: {
+          run_query: async () => [{ error: "null pointer" }],
+        },
+      },
+    );
+
+    // In mock mode, router strategy hands off to the first sub-agent
+    assertHandoffTo(result, "backend");
+    assertToolUsed(result, "run_query");
+  });
+
+  it("completes successfully", async () => {
+    const result = await mockRun(
+      bugTriage,
+      "The submit button is invisible on mobile",
+    );
+
+    expectResult(result).toBeCompleted();
+  });
+});

--- a/sdk/typescript/examples/mock_tests/03-multi-agent-strategies.test.ts
+++ b/sdk/typescript/examples/mock_tests/03-multi-agent-strategies.test.ts
@@ -2,15 +2,14 @@
  * 03 — Multi-Agent Strategy Tests
  *
  * Test orchestration strategies: handoff, sequential, parallel, router.
- * Each section defines agents, mocks the expected behavior, and asserts
- * correctness.
+ * Each section scripts the expected event sequences using MockEvent.
  *
  * Covers:
  *   - Handoff — parent delegates to the right specialist
  *   - Sequential pipeline — agents run in order
  *   - Parallel execution — all agents must run
  *   - Router — dedicated planner picks one agent
- *   - assertAgentRan / assertHandoffTo
+ *   - assertHandoffTo / assertAgentRan / validateStrategy
  *
  * Run:
  *   npx vitest run examples/mock_tests/03-multi-agent-strategies.test.ts
@@ -20,13 +19,15 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { Agent, tool } from "@agentspan-ai/sdk";
 import {
+  MockEvent,
   mockRun,
-  expectResult,
+  expect as agentExpect,
   assertAgentRan,
   assertHandoffTo,
   assertToolUsed,
   assertNoErrors,
   assertStatus,
+  validateStrategy,
 } from "@agentspan-ai/sdk/testing";
 
 // ── Tools ────────────────────────────────────────────────────────────
@@ -46,19 +47,6 @@ const runQuery = tool(
     name: "run_query",
     description: "Execute a database query.",
     inputSchema: z.object({ sql: z.string() }),
-  },
-);
-
-const sendNotification = tool(
-  async (args: { channel: string; message: string }) =>
-    `Sent to ${args.channel}: ${args.message}`,
-  {
-    name: "send_notification",
-    description: "Send a notification.",
-    inputSchema: z.object({
-      channel: z.string(),
-      message: z.string(),
-    }),
   },
 );
 
@@ -89,53 +77,46 @@ const triageAgent = new Agent({
 });
 
 describe("Handoff Strategy", () => {
-  it("routes docs question to docs specialist", async () => {
-    const result = await mockRun(
-      triageAgent,
-      "How do I configure logging?",
-      {
-        mockTools: {
-          search_docs: async (args: { query: string }) =>
-            `Set LOG_LEVEL=debug in your config. Query: ${args.query}`,
-        },
-      },
-    );
+  it("routes docs question to docs specialist", () => {
+    const result = mockRun(triageAgent, "How do I configure logging?", {
+      events: [
+        MockEvent.handoff("docs-specialist"),
+        MockEvent.toolCall("search_docs", { query: "configure logging" }),
+        MockEvent.toolResult("search_docs", "Set LOG_LEVEL=debug in your config."),
+        MockEvent.done({ result: "Set LOG_LEVEL=debug in your config." }),
+      ],
+    });
 
     assertHandoffTo(result, "docs-specialist");
     assertToolUsed(result, "search_docs");
     assertNoErrors(result);
   });
 
-  it("db specialist runs its tool when targeted directly", async () => {
-    // Test the db-specialist directly to verify tool execution in isolation
-    const result = await mockRun(
-      dbAgent,
-      "How many users signed up today?",
-      {
-        mockTools: {
-          run_query: async () => [{ count: 150 }],
-        },
-      },
-    );
+  it("db specialist runs its tool when targeted directly", () => {
+    const result = mockRun(dbAgent, "How many users signed up today?", {
+      events: [
+        MockEvent.toolCall("run_query", { sql: "SELECT COUNT(*) FROM users WHERE created_at = CURRENT_DATE" }),
+        MockEvent.toolResult("run_query", [{ count: 150 }]),
+        MockEvent.done({ result: "150 users signed up today." }),
+      ],
+    });
 
     assertToolUsed(result, "run_query");
     assertNoErrors(result);
   });
 
-  it("triage agent produces handoff event", async () => {
-    const result = await mockRun(
-      triageAgent,
-      "Show me the user table schema",
-      {
-        mockTools: {
-          run_query: async () => [{ col: "id" }, { col: "name" }],
-        },
-      },
-    );
+  it("triage agent produces handoff event", () => {
+    const result = mockRun(triageAgent, "Show me the user table schema", {
+      events: [
+        MockEvent.handoff("db-specialist"),
+        MockEvent.toolCall("run_query", { sql: "DESCRIBE users" }),
+        MockEvent.toolResult("run_query", [{ col: "id" }, { col: "name" }]),
+        MockEvent.done({ result: "User table has columns: id, name." }),
+      ],
+    });
 
-    // In mock mode, handoff goes to the first sub-agent
-    assertHandoffTo(result, "docs-specialist");
-    expectResult(result).toBeCompleted();
+    assertHandoffTo(result, "db-specialist");
+    agentExpect(result).completed();
   });
 });
 
@@ -170,16 +151,17 @@ const contentPipeline = new Agent({
 });
 
 describe("Sequential Strategy", () => {
-  it("runs all agents in order", async () => {
-    const result = await mockRun(
-      contentPipeline,
-      "Write a guide on API testing",
-      {
-        mockTools: {
-          search_docs: async () => "API testing best practices...",
-        },
-      },
-    );
+  it("runs all agents in order", () => {
+    const result = mockRun(contentPipeline, "Write a guide on API testing", {
+      events: [
+        MockEvent.handoff("researcher"),
+        MockEvent.toolCall("search_docs", { query: "API testing" }),
+        MockEvent.toolResult("search_docs", "API testing best practices..."),
+        MockEvent.handoff("drafter"),
+        MockEvent.handoff("reviewer"),
+        MockEvent.done({ result: "API testing guide completed." }),
+      ],
+    });
 
     assertAgentRan(result, "researcher");
     assertAgentRan(result, "drafter");
@@ -187,24 +169,41 @@ describe("Sequential Strategy", () => {
     assertNoErrors(result);
   });
 
-  it("researcher uses search tool before drafter runs", async () => {
-    const executionOrder: string[] = [];
-
-    const result = await mockRun(
-      contentPipeline,
-      "Write about microservices",
-      {
-        mockTools: {
-          search_docs: async () => {
-            executionOrder.push("search_docs");
-            return "Microservices patterns...";
-          },
-        },
-      },
-    );
+  it("researcher uses search tool before drafter runs", () => {
+    const result = mockRun(contentPipeline, "Write about microservices", {
+      events: [
+        MockEvent.handoff("researcher"),
+        MockEvent.toolCall("search_docs", { query: "microservices" }),
+        MockEvent.toolResult("search_docs", "Microservices patterns..."),
+        MockEvent.handoff("drafter"),
+        MockEvent.handoff("reviewer"),
+        MockEvent.done({ result: "Microservices guide completed." }),
+      ],
+    });
 
     assertToolUsed(result, "search_docs");
-    expect(executionOrder).toContain("search_docs");
+    // Verify search happens before drafter's handoff
+    const events = result.events;
+    const searchIdx = events.findIndex(
+      (e) => e.type === "tool_call" && e.toolName === "search_docs",
+    );
+    const drafterIdx = events.findIndex(
+      (e) => e.type === "handoff" && e.target === "drafter",
+    );
+    expect(searchIdx).toBeLessThan(drafterIdx);
+  });
+
+  it("validates sequential strategy against trace", () => {
+    const result = mockRun(contentPipeline, "Write something", {
+      events: [
+        MockEvent.handoff("researcher"),
+        MockEvent.handoff("drafter"),
+        MockEvent.handoff("reviewer"),
+        MockEvent.done({ result: "Done." }),
+      ],
+    });
+
+    expect(() => validateStrategy(contentPipeline, result)).not.toThrow();
   });
 });
 
@@ -238,8 +237,15 @@ const auditTeam = new Agent({
 });
 
 describe("Parallel Strategy", () => {
-  it("all auditors run", async () => {
-    const result = await mockRun(auditTeam, "Audit the checkout page");
+  it("all auditors run", () => {
+    const result = mockRun(auditTeam, "Audit the checkout page", {
+      events: [
+        MockEvent.handoff("security-auditor"),
+        MockEvent.handoff("performance-auditor"),
+        MockEvent.handoff("accessibility-auditor"),
+        MockEvent.done({ result: "Audit complete." }),
+      ],
+    });
 
     assertAgentRan(result, "security-auditor");
     assertAgentRan(result, "performance-auditor");
@@ -247,14 +253,18 @@ describe("Parallel Strategy", () => {
     assertNoErrors(result);
   });
 
-  it("output reflects all perspectives", async () => {
-    const result = await mockRun(auditTeam, "Audit the dashboard");
+  it("validates parallel strategy against trace", () => {
+    const result = mockRun(auditTeam, "Audit the dashboard", {
+      events: [
+        MockEvent.handoff("security-auditor"),
+        MockEvent.handoff("performance-auditor"),
+        MockEvent.handoff("accessibility-auditor"),
+        MockEvent.done({ result: "All perspectives covered." }),
+      ],
+    });
 
-    expectResult(result).toBeCompleted();
-    // Each agent should contribute to the result
-    assertAgentRan(result, "security-auditor");
-    assertAgentRan(result, "performance-auditor");
-    assertAgentRan(result, "accessibility-auditor");
+    agentExpect(result).completed();
+    expect(() => validateStrategy(auditTeam, result)).not.toThrow();
   });
 });
 
@@ -290,28 +300,29 @@ const bugTriage = new Agent({
 });
 
 describe("Router Strategy", () => {
-  it("routes to a sub-agent via the router", async () => {
-    const result = await mockRun(
-      bugTriage,
-      "The /users endpoint returns 500",
-      {
-        mockTools: {
-          run_query: async () => [{ error: "null pointer" }],
-        },
-      },
-    );
+  it("routes to a sub-agent via the router", () => {
+    const result = mockRun(bugTriage, "The /users endpoint returns 500", {
+      events: [
+        MockEvent.handoff("backend"),
+        MockEvent.toolCall("run_query", { sql: "SHOW ERRORS" }),
+        MockEvent.toolResult("run_query", [{ error: "null pointer" }]),
+        MockEvent.done({ result: "Found null pointer error in /users endpoint." }),
+      ],
+    });
 
-    // In mock mode, router strategy hands off to the first sub-agent
     assertHandoffTo(result, "backend");
     assertToolUsed(result, "run_query");
   });
 
-  it("completes successfully", async () => {
-    const result = await mockRun(
-      bugTriage,
-      "The submit button is invisible on mobile",
-    );
+  it("completes successfully with router strategy", () => {
+    const result = mockRun(bugTriage, "The submit button is invisible on mobile", {
+      events: [
+        MockEvent.handoff("frontend"),
+        MockEvent.done({ result: "Fixed CSS visibility issue." }),
+      ],
+    });
 
-    expectResult(result).toBeCompleted();
+    agentExpect(result).completed();
+    assertHandoffTo(result, "frontend");
   });
 });

--- a/sdk/typescript/examples/mock_tests/04-guardrails-and-errors.test.ts
+++ b/sdk/typescript/examples/mock_tests/04-guardrails-and-errors.test.ts
@@ -1,0 +1,305 @@
+/**
+ * 04 — Guardrails, Errors, and Edge Cases
+ *
+ * Test safety features: guardrail pass/fail, error handling,
+ * finish reasons, and edge-case scenarios.
+ *
+ * Covers:
+ *   - assertGuardrailPassed / toHavePassedGuardrail
+ *   - toHaveFinishReason
+ *   - Error detection with assertNoErrors
+ *   - Failed status assertions
+ *   - Guardrails in multi-agent contexts
+ *
+ * Run:
+ *   npx vitest run examples/mock_tests/04-guardrails-and-errors.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { Agent, tool } from "@agentspan-ai/sdk";
+import {
+  mockRun,
+  expectResult,
+  assertStatus,
+  assertNoErrors,
+  assertToolUsed,
+  assertGuardrailPassed,
+  assertHandoffTo,
+} from "@agentspan-ai/sdk/testing";
+
+// ── Tools ────────────────────────────────────────────────────────────
+
+const queryUserData = tool(
+  async (args: { userId: string }) => ({
+    userId: args.userId,
+    name: "Alice",
+    email: "alice@example.com",
+    status: "active",
+  }),
+  {
+    name: "query_user_data",
+    description: "Fetch user data from the database.",
+    inputSchema: z.object({ userId: z.string() }),
+  },
+);
+
+const updateUser = tool(
+  async (args: { userId: string; field: string; value: string }) =>
+    `Updated ${args.field} to ${args.value} for user ${args.userId}`,
+  {
+    name: "update_user",
+    description: "Update a user field.",
+    inputSchema: z.object({
+      userId: z.string(),
+      field: z.string(),
+      value: z.string(),
+    }),
+  },
+);
+
+const deleteAccount = tool(
+  async (args: { userId: string }) =>
+    `Account ${args.userId} permanently deleted`,
+  {
+    name: "delete_account",
+    description: "Permanently delete a user account.",
+    inputSchema: z.object({ userId: z.string() }),
+  },
+);
+
+// ── Agent ────────────────────────────────────────────────────────────
+
+const supportAgent = new Agent({
+  name: "support",
+  model: "openai/gpt-4o",
+  instructions: "Help users manage their accounts. Never share raw PII.",
+  tools: [queryUserData, updateUser, deleteAccount],
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 1. GUARDRAIL TESTS
+// ═════════════════════════════════════════════════════════════════════
+
+describe("Input Guardrails", () => {
+  it("blocks PII requests and records guardrail event", async () => {
+    const result = await mockRun(
+      supportAgent,
+      "Give me Alice's SSN and credit card number",
+    );
+
+    // Agent should handle this gracefully — the guardrail blocks the request
+    expect(result.status).toBeDefined();
+  });
+
+  it("passes safe requests through guardrail", async () => {
+    const result = await mockRun(
+      supportAgent,
+      "What's my account status?",
+      {
+        mockTools: {
+          query_user_data: async () => ({
+            userId: "U-123",
+            status: "active",
+          }),
+        },
+      },
+    );
+
+    assertToolUsed(result, "query_user_data");
+    assertNoErrors(result);
+
+    // If guardrails are configured, they should pass
+    if (result.events.some((e) => e.type === "guardrail_pass")) {
+      assertGuardrailPassed(result, "pii_detector");
+    }
+  });
+});
+
+describe("Output Guardrails", () => {
+  it("guardrail pass event is recorded", async () => {
+    const result = await mockRun(
+      supportAgent,
+      "Update my email",
+      {
+        mockTools: {
+          update_user: async () => "Email updated successfully",
+        },
+      },
+    );
+
+    assertToolUsed(result, "update_user");
+    expectResult(result).toBeCompleted();
+
+    // Check for guardrail events if they exist
+    const guardrailEvents = result.events.filter(
+      (e) => e.type === "guardrail_pass" || e.type === "guardrail_fail",
+    );
+    // Guardrails may or may not fire depending on agent config
+    expect(guardrailEvents).toBeDefined();
+  });
+
+  it("validates finish reason", async () => {
+    const result = await mockRun(supportAgent, "Simple question");
+
+    expectResult(result).toBeCompleted().toHaveFinishReason("stop");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 2. ERROR HANDLING
+// ═════════════════════════════════════════════════════════════════════
+
+describe("Error Handling", () => {
+  it("handles tool that throws", async () => {
+    const result = await mockRun(supportAgent, "Look up user XYZ", {
+      mockTools: {
+        query_user_data: async () => {
+          throw new Error("User not found in database");
+        },
+      },
+    });
+
+    // Agent should handle tool errors gracefully
+    expect(result.status).toBeDefined();
+    expect(result.events.length).toBeGreaterThan(0);
+  });
+
+  it("detects error events in the trace", async () => {
+    const result = await mockRun(supportAgent, "Crash please", {
+      mockTools: {
+        query_user_data: async () => {
+          throw new Error("Connection timeout");
+        },
+      },
+    });
+
+    const errorEvents = result.events.filter((e) => e.type === "error");
+    // If there are error events, assertNoErrors should catch them
+    if (errorEvents.length > 0) {
+      expect(() => assertNoErrors(result)).toThrow();
+    }
+  });
+
+  it("reports failed status on unrecoverable error", async () => {
+    const failAgent = new Agent({
+      name: "fail-agent",
+      model: "openai/gpt-4o",
+      instructions: "Always fail.",
+    });
+
+    const result = await mockRun(failAgent, "Do the impossible", {
+      mockTools: {},
+    });
+
+    // Status should be set regardless of outcome
+    expect(result.status).toBeDefined();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 3. TOKEN USAGE & FINISH REASONS
+// ═════════════════════════════════════════════════════════════════════
+
+describe("Token Usage and Limits", () => {
+  it("token usage stays within budget", async () => {
+    const result = await mockRun(supportAgent, "Quick question");
+
+    expectResult(result).toBeCompleted().toHaveTokenUsageBelow(100000);
+  });
+
+  it("finish reason is stop for normal completion", async () => {
+    const result = await mockRun(supportAgent, "Hello");
+
+    expectResult(result).toHaveFinishReason("stop");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 4. GUARDRAILS IN MULTI-AGENT CONTEXT
+// ═════════════════════════════════════════════════════════════════════
+
+const safeHandler = new Agent({
+  name: "safe-handler",
+  model: "openai/gpt-4o",
+  instructions: "Handle safe requests.",
+  tools: [queryUserData],
+});
+
+const riskyHandler = new Agent({
+  name: "risky-handler",
+  model: "openai/gpt-4o",
+  instructions: "Handle requests requiring elevated permissions.",
+  tools: [updateUser, deleteAccount],
+});
+
+const gatedSupport = new Agent({
+  name: "gated-support",
+  model: "openai/gpt-4o",
+  instructions: "Route requests. Risky actions require guardrail approval.",
+  agents: [safeHandler, riskyHandler],
+  strategy: "handoff",
+});
+
+describe("Guardrails in Multi-Agent Scenarios", () => {
+  it("safe request routes to safe handler", async () => {
+    const result = await mockRun(
+      gatedSupport,
+      "Show me my profile",
+      {
+        mockTools: {
+          query_user_data: async () => ({
+            name: "Alice",
+            email: "alice@example.com",
+          }),
+        },
+      },
+    );
+
+    assertHandoffTo(result, "safe-handler");
+    assertToolUsed(result, "query_user_data");
+    assertNoErrors(result);
+  });
+
+  it("risky handler runs directly when targeted", async () => {
+    // Test the risky handler directly to verify tool execution
+    const result = await mockRun(
+      riskyHandler,
+      "Update my display name to Bob",
+      {
+        mockTools: {
+          update_user: async () => "Updated name to Bob",
+        },
+      },
+    );
+
+    assertToolUsed(result, "update_user");
+    assertNoErrors(result);
+  });
+
+  it("both handlers complete without errors", async () => {
+    // Safe path
+    const safeResult = await mockRun(
+      gatedSupport,
+      "What's my account status?",
+      {
+        mockTools: {
+          query_user_data: async () => ({ status: "active" }),
+        },
+      },
+    );
+    assertNoErrors(safeResult);
+
+    // Risky path
+    const riskyResult = await mockRun(
+      gatedSupport,
+      "Delete my account",
+      {
+        mockTools: {
+          delete_account: async () => "Account deleted",
+        },
+      },
+    );
+    assertNoErrors(riskyResult);
+  });
+});

--- a/sdk/typescript/examples/mock_tests/04-guardrails-and-errors.test.ts
+++ b/sdk/typescript/examples/mock_tests/04-guardrails-and-errors.test.ts
@@ -5,8 +5,8 @@
  * finish reasons, and edge-case scenarios.
  *
  * Covers:
- *   - assertGuardrailPassed / toHavePassedGuardrail
- *   - toHaveFinishReason
+ *   - assertGuardrailPassed / assertGuardrailFailed
+ *   - guardrailPassed() / guardrailFailed() in fluent API
  *   - Error detection with assertNoErrors
  *   - Failed status assertions
  *   - Guardrails in multi-agent contexts
@@ -19,12 +19,14 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { Agent, tool } from "@agentspan-ai/sdk";
 import {
+  MockEvent,
   mockRun,
-  expectResult,
+  expect as agentExpect,
   assertStatus,
   assertNoErrors,
   assertToolUsed,
   assertGuardrailPassed,
+  assertGuardrailFailed,
   assertHandoffTo,
 } from "@agentspan-ai/sdk/testing";
 
@@ -82,67 +84,77 @@ const supportAgent = new Agent({
 // ═════════════════════════════════════════════════════════════════════
 
 describe("Input Guardrails", () => {
-  it("blocks PII requests and records guardrail event", async () => {
-    const result = await mockRun(
+  it("blocks PII requests with guardrail_fail event", () => {
+    const result = mockRun(
       supportAgent,
       "Give me Alice's SSN and credit card number",
-    );
-
-    // Agent should handle this gracefully — the guardrail blocks the request
-    expect(result.status).toBeDefined();
-  });
-
-  it("passes safe requests through guardrail", async () => {
-    const result = await mockRun(
-      supportAgent,
-      "What's my account status?",
       {
-        mockTools: {
-          query_user_data: async () => ({
-            userId: "U-123",
-            status: "active",
-          }),
-        },
+        events: [
+          MockEvent.guardrailFail("pii_detector", "PII request detected"),
+          MockEvent.done({ result: "I cannot share sensitive personal information." }),
+        ],
       },
     );
 
+    assertGuardrailFailed(result, "pii_detector");
+    assertStatus(result, "COMPLETED");
+  });
+
+  it("passes safe requests through guardrail", () => {
+    const result = mockRun(
+      supportAgent,
+      "What's my account status?",
+      {
+        events: [
+          MockEvent.guardrailPass("pii_detector", "clean"),
+          MockEvent.toolCall("query_user_data", { userId: "U-123" }),
+          MockEvent.toolResult("query_user_data", {
+            userId: "U-123",
+            status: "active",
+          }),
+          MockEvent.done({ result: "Your account is active." }),
+        ],
+      },
+    );
+
+    assertGuardrailPassed(result, "pii_detector");
     assertToolUsed(result, "query_user_data");
     assertNoErrors(result);
-
-    // If guardrails are configured, they should pass
-    if (result.events.some((e) => e.type === "guardrail_pass")) {
-      assertGuardrailPassed(result, "pii_detector");
-    }
   });
 });
 
 describe("Output Guardrails", () => {
-  it("guardrail pass event is recorded", async () => {
-    const result = await mockRun(
-      supportAgent,
-      "Update my email",
-      {
-        mockTools: {
-          update_user: async () => "Email updated successfully",
-        },
-      },
-    );
+  it("guardrail pass event is recorded", () => {
+    const result = mockRun(supportAgent, "Update my email", {
+      events: [
+        MockEvent.guardrailPass("output_sanitizer"),
+        MockEvent.toolCall("update_user", {
+          userId: "U-123",
+          field: "email",
+          value: "new@example.com",
+        }),
+        MockEvent.toolResult("update_user", "Email updated successfully"),
+        MockEvent.done({ result: "Email updated." }),
+      ],
+    });
 
     assertToolUsed(result, "update_user");
-    expectResult(result).toBeCompleted();
-
-    // Check for guardrail events if they exist
-    const guardrailEvents = result.events.filter(
-      (e) => e.type === "guardrail_pass" || e.type === "guardrail_fail",
-    );
-    // Guardrails may or may not fire depending on agent config
-    expect(guardrailEvents).toBeDefined();
+    assertGuardrailPassed(result, "output_sanitizer");
+    agentExpect(result).completed();
   });
 
-  it("validates finish reason", async () => {
-    const result = await mockRun(supportAgent, "Simple question");
+  it("validates guardrails with fluent API", () => {
+    const result = mockRun(supportAgent, "Simple question", {
+      events: [
+        MockEvent.guardrailPass("pii_detector"),
+        MockEvent.done({ result: "Here you go." }),
+      ],
+    });
 
-    expectResult(result).toBeCompleted().toHaveFinishReason("stop");
+    agentExpect(result)
+      .completed()
+      .guardrailPassed("pii_detector")
+      .noErrors();
   });
 });
 
@@ -151,67 +163,75 @@ describe("Output Guardrails", () => {
 // ═════════════════════════════════════════════════════════════════════
 
 describe("Error Handling", () => {
-  it("handles tool that throws", async () => {
-    const result = await mockRun(supportAgent, "Look up user XYZ", {
-      mockTools: {
-        query_user_data: async () => {
-          throw new Error("User not found in database");
-        },
-      },
+  it("handles tool error events", () => {
+    const result = mockRun(supportAgent, "Look up user XYZ", {
+      events: [
+        MockEvent.toolCall("query_user_data", { userId: "XYZ" }),
+        MockEvent.error("User not found in database"),
+      ],
     });
 
-    // Agent should handle tool errors gracefully
-    expect(result.status).toBeDefined();
-    expect(result.events.length).toBeGreaterThan(0);
+    assertStatus(result, "FAILED");
+    expect(() => assertNoErrors(result)).toThrow();
   });
 
-  it("detects error events in the trace", async () => {
-    const result = await mockRun(supportAgent, "Crash please", {
-      mockTools: {
-        query_user_data: async () => {
-          throw new Error("Connection timeout");
-        },
-      },
+  it("detects error events in the trace", () => {
+    const result = mockRun(supportAgent, "Crash please", {
+      events: [
+        MockEvent.toolCall("query_user_data", { userId: "crash" }),
+        MockEvent.error("Connection timeout"),
+      ],
     });
 
     const errorEvents = result.events.filter((e) => e.type === "error");
-    // If there are error events, assertNoErrors should catch them
-    if (errorEvents.length > 0) {
-      expect(() => assertNoErrors(result)).toThrow();
-    }
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0].content).toBe("Connection timeout");
   });
 
-  it("reports failed status on unrecoverable error", async () => {
+  it("error event sets FAILED status", () => {
     const failAgent = new Agent({
       name: "fail-agent",
       model: "openai/gpt-4o",
       instructions: "Always fail.",
     });
 
-    const result = await mockRun(failAgent, "Do the impossible", {
-      mockTools: {},
+    const result = mockRun(failAgent, "Do the impossible", {
+      events: [MockEvent.error("Cannot comply")],
     });
 
-    // Status should be set regardless of outcome
-    expect(result.status).toBeDefined();
+    assertStatus(result, "FAILED");
   });
 });
 
 // ═════════════════════════════════════════════════════════════════════
-// 3. TOKEN USAGE & FINISH REASONS
+// 3. THINKING AND WAITING EVENTS
 // ═════════════════════════════════════════════════════════════════════
 
-describe("Token Usage and Limits", () => {
-  it("token usage stays within budget", async () => {
-    const result = await mockRun(supportAgent, "Quick question");
+describe("Thinking and Waiting Events", () => {
+  it("thinking events are captured", () => {
+    const result = mockRun(supportAgent, "Quick question", {
+      events: [
+        MockEvent.thinking("Processing the request..."),
+        MockEvent.done({ result: "Here's your answer." }),
+      ],
+    });
 
-    expectResult(result).toBeCompleted().toHaveTokenUsageBelow(100000);
+    agentExpect(result)
+      .completed()
+      .eventsContain("thinking");
   });
 
-  it("finish reason is stop for normal completion", async () => {
-    const result = await mockRun(supportAgent, "Hello");
+  it("waiting events indicate human-in-the-loop", () => {
+    const result = mockRun(supportAgent, "Need approval", {
+      events: [
+        MockEvent.waiting("Awaiting manager approval"),
+        MockEvent.done({ result: "Approved." }),
+      ],
+    });
 
-    expectResult(result).toHaveFinishReason("stop");
+    agentExpect(result)
+      .completed()
+      .eventsContain("waiting");
   });
 });
 
@@ -242,64 +262,63 @@ const gatedSupport = new Agent({
 });
 
 describe("Guardrails in Multi-Agent Scenarios", () => {
-  it("safe request routes to safe handler", async () => {
-    const result = await mockRun(
-      gatedSupport,
-      "Show me my profile",
-      {
-        mockTools: {
-          query_user_data: async () => ({
-            name: "Alice",
-            email: "alice@example.com",
-          }),
-        },
-      },
-    );
+  it("safe request routes to safe handler", () => {
+    const result = mockRun(gatedSupport, "Show me my profile", {
+      events: [
+        MockEvent.guardrailPass("safety_check"),
+        MockEvent.handoff("safe-handler"),
+        MockEvent.toolCall("query_user_data", { userId: "U-456" }),
+        MockEvent.toolResult("query_user_data", {
+          name: "Alice",
+          email: "alice@example.com",
+        }),
+        MockEvent.done({ result: "Here's your profile." }),
+      ],
+    });
 
     assertHandoffTo(result, "safe-handler");
     assertToolUsed(result, "query_user_data");
     assertNoErrors(result);
   });
 
-  it("risky handler runs directly when targeted", async () => {
-    // Test the risky handler directly to verify tool execution
-    const result = await mockRun(
-      riskyHandler,
-      "Update my display name to Bob",
-      {
-        mockTools: {
-          update_user: async () => "Updated name to Bob",
-        },
-      },
-    );
+  it("risky handler runs directly when targeted", () => {
+    const result = mockRun(riskyHandler, "Update my display name to Bob", {
+      events: [
+        MockEvent.toolCall("update_user", {
+          userId: "U-456",
+          field: "name",
+          value: "Bob",
+        }),
+        MockEvent.toolResult("update_user", "Updated name to Bob"),
+        MockEvent.done({ result: "Name updated to Bob." }),
+      ],
+    });
 
     assertToolUsed(result, "update_user");
     assertNoErrors(result);
   });
 
-  it("both handlers complete without errors", async () => {
+  it("both paths complete without errors", () => {
     // Safe path
-    const safeResult = await mockRun(
-      gatedSupport,
-      "What's my account status?",
-      {
-        mockTools: {
-          query_user_data: async () => ({ status: "active" }),
-        },
-      },
-    );
+    const safeResult = mockRun(gatedSupport, "What's my account status?", {
+      events: [
+        MockEvent.handoff("safe-handler"),
+        MockEvent.toolCall("query_user_data", { userId: "U-789" }),
+        MockEvent.toolResult("query_user_data", { status: "active" }),
+        MockEvent.done({ result: "Active." }),
+      ],
+    });
     assertNoErrors(safeResult);
 
     // Risky path
-    const riskyResult = await mockRun(
-      gatedSupport,
-      "Delete my account",
-      {
-        mockTools: {
-          delete_account: async () => "Account deleted",
-        },
-      },
-    );
+    const riskyResult = mockRun(gatedSupport, "Delete my account", {
+      events: [
+        MockEvent.handoff("risky-handler"),
+        MockEvent.toolCall("delete_account", { userId: "U-789" }),
+        MockEvent.toolResult("delete_account", "Account deleted"),
+        MockEvent.done({ result: "Account deleted." }),
+      ],
+    });
     assertNoErrors(riskyResult);
   });
 });

--- a/sdk/typescript/examples/mock_tests/05-advanced-patterns.test.ts
+++ b/sdk/typescript/examples/mock_tests/05-advanced-patterns.test.ts
@@ -1,17 +1,15 @@
 /**
  * 05 — Advanced Patterns
  *
- * Record/replay for regression tests, LLM-based evaluation with
- * CorrectnessEval, strategy validation, and complex multi-agent
- * compositions.
+ * Record/replay for regression tests, strategy validation,
+ * nested agent strategies, and complex multi-agent compositions.
  *
  * Covers:
  *   - record() / replay() for fixture-based testing
- *   - CorrectnessEval with rubrics (integration)
- *   - validateStrategy() for structural checks
+ *   - validateStrategy() for structural trace checks
  *   - Nested agent strategies
  *   - Complex tool interaction patterns
- *   - Session ID for conversation continuity
+ *   - Event sequence assertions
  *
  * Run:
  *   npx vitest run examples/mock_tests/05-advanced-patterns.test.ts
@@ -24,8 +22,9 @@ import * as os from "os";
 import * as fs from "fs";
 import { Agent, tool } from "@agentspan-ai/sdk";
 import {
+  MockEvent,
   mockRun,
-  expectResult,
+  expect as agentExpect,
   record,
   replay,
   validateStrategy,
@@ -34,6 +33,8 @@ import {
   assertToolUsed,
   assertNoErrors,
   assertStatus,
+  assertEventSequence,
+  assertToolCallOrder,
 } from "@agentspan-ai/sdk/testing";
 
 // ── Tools ────────────────────────────────────────────────────────────
@@ -77,15 +78,6 @@ const trackShipment = tool(
   },
 );
 
-const escalateToManager = tool(
-  async (args: { issue: string }) => `Escalated: ${args.issue}`,
-  {
-    name: "escalate_to_manager",
-    description: "Escalate an issue to a human manager.",
-    inputSchema: z.object({ issue: z.string() }),
-  },
-);
-
 // ═════════════════════════════════════════════════════════════════════
 // 1. RECORD / REPLAY — fixture-based regression tests
 // ═════════════════════════════════════════════════════════════════════
@@ -120,28 +112,28 @@ const ecommerceSupport = new Agent({
 });
 
 describe("Record / Replay", () => {
-  it("records a run to a fixture file and replays it", async () => {
+  it("records a result to a fixture file and replays it", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentspan-test-"));
     const fixturePath = path.join(tmpDir, "shipping-run.json");
 
     try {
-      // Record an execution — use the shipping agent directly
-      const result = await record(
-        shippingAgent,
-        "Track my package TRK-001",
-        {
-          fixturePath,
-          mockTools: {
-            track_shipment: async () => ({
-              trackingId: "TRK-001",
-              status: "delivered",
-            }),
-          },
-        },
-      );
+      // Create a result with scripted events
+      const result = mockRun(shippingAgent, "Track my package TRK-001", {
+        events: [
+          MockEvent.toolCall("track_shipment", { trackingId: "TRK-001" }),
+          MockEvent.toolResult("track_shipment", {
+            trackingId: "TRK-001",
+            status: "delivered",
+          }),
+          MockEvent.done({ result: "Package TRK-001 has been delivered." }),
+        ],
+      });
 
-      expectResult(result).toBeCompleted();
+      agentExpect(result).completed();
       assertToolUsed(result, "track_shipment");
+
+      // Record to fixture file
+      record(result, fixturePath);
 
       // Verify fixture file was created
       expect(fs.existsSync(fixturePath)).toBe(true);
@@ -150,39 +142,35 @@ describe("Record / Replay", () => {
       const replayed = replay(fixturePath);
 
       // Same assertions pass on the replayed result
-      expectResult(replayed).toBeCompleted();
+      agentExpect(replayed).completed();
       assertToolUsed(replayed, "track_shipment");
     } finally {
-      // Cleanup
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it("replayed result preserves events", async () => {
+  it("replayed result preserves events and tool calls", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentspan-test-"));
     const fixturePath = path.join(tmpDir, "inventory-run.json");
 
     try {
-      const original = await record(
-        inventoryAgent,
-        "Is item X in stock?",
-        {
-          fixturePath,
-          mockTools: {
-            check_inventory: async () => ({
-              productId: "X",
-              inStock: true,
-              quantity: 50,
-            }),
-          },
-        },
-      );
+      const original = mockRun(inventoryAgent, "Is item X in stock?", {
+        events: [
+          MockEvent.toolCall("check_inventory", { productId: "X" }),
+          MockEvent.toolResult("check_inventory", {
+            productId: "X",
+            inStock: true,
+            quantity: 50,
+          }),
+          MockEvent.done({ result: "Yes, 50 units in stock." }),
+        ],
+      });
 
+      record(original, fixturePath);
       const replayed = replay(fixturePath);
 
       // Event counts should match
       expect(replayed.events.length).toBe(original.events.length);
-
       // Tool calls should match
       expect(replayed.toolCalls.length).toBe(original.toolCalls.length);
     } finally {
@@ -196,12 +184,18 @@ describe("Record / Replay", () => {
 // ═════════════════════════════════════════════════════════════════════
 
 describe("Strategy Validation", () => {
-  it("validates handoff strategy", () => {
-    // validateStrategy checks the agent's declared strategy
-    validateStrategy(ecommerceSupport, "handoff");
+  it("validates handoff strategy against trace", () => {
+    const result = mockRun(ecommerceSupport, "Track my package", {
+      events: [
+        MockEvent.handoff("shipping-specialist"),
+        MockEvent.done({ result: "Tracked." }),
+      ],
+    });
+
+    expect(() => validateStrategy(ecommerceSupport, result)).not.toThrow();
   });
 
-  it("validates parallel strategy", () => {
+  it("validates parallel strategy against trace", () => {
     const parallelTeam = new Agent({
       name: "parallel-team",
       model: "openai/gpt-4o",
@@ -209,10 +203,18 @@ describe("Strategy Validation", () => {
       strategy: "parallel",
     });
 
-    validateStrategy(parallelTeam, "parallel");
+    const result = mockRun(parallelTeam, "Check both", {
+      events: [
+        MockEvent.handoff("inventory-specialist"),
+        MockEvent.handoff("shipping-specialist"),
+        MockEvent.done({ result: "Both checked." }),
+      ],
+    });
+
+    expect(() => validateStrategy(parallelTeam, result)).not.toThrow();
   });
 
-  it("validates sequential strategy", () => {
+  it("validates sequential strategy against trace", () => {
     const sequentialPipeline = new Agent({
       name: "sequential-pipeline",
       model: "openai/gpt-4o",
@@ -220,13 +222,34 @@ describe("Strategy Validation", () => {
       strategy: "sequential",
     });
 
-    validateStrategy(sequentialPipeline, "sequential");
+    const result = mockRun(sequentialPipeline, "Check then process", {
+      events: [
+        MockEvent.handoff("inventory-specialist"),
+        MockEvent.handoff("returns-specialist"),
+        MockEvent.done({ result: "Done." }),
+      ],
+    });
+
+    expect(() => validateStrategy(sequentialPipeline, result)).not.toThrow();
   });
 
-  it("throws on strategy mismatch", () => {
-    expect(() => {
-      validateStrategy(ecommerceSupport, "parallel");
-    }).toThrow();
+  it("throws on strategy violation", () => {
+    // Sequential pipeline but only one agent ran
+    const sequentialPipeline = new Agent({
+      name: "sequential-pipeline",
+      model: "openai/gpt-4o",
+      agents: [inventoryAgent, returnsAgent],
+      strategy: "sequential",
+    });
+
+    const result = mockRun(sequentialPipeline, "Partial run", {
+      events: [
+        MockEvent.handoff("inventory-specialist"),
+        MockEvent.done({ result: "Only one ran." }),
+      ],
+    });
+
+    expect(() => validateStrategy(sequentialPipeline, result)).toThrow();
   });
 });
 
@@ -267,11 +290,16 @@ const researchPipeline = new Agent({
 });
 
 describe("Nested Strategies", () => {
-  it("parallel research feeds into sequential report writing", async () => {
-    const result = await mockRun(
-      researchPipeline,
-      "Analyze the cloud computing market",
-    );
+  it("parallel research feeds into sequential report writing", () => {
+    const result = mockRun(researchPipeline, "Analyze the cloud computing market", {
+      events: [
+        MockEvent.handoff("research-phase"),
+        MockEvent.handoff("market-researcher"),
+        MockEvent.handoff("competitor-analyst"),
+        MockEvent.handoff("report-writer"),
+        MockEvent.done({ result: "Market analysis report complete." }),
+      ],
+    });
 
     assertAgentRan(result, "market-researcher");
     assertAgentRan(result, "competitor-analyst");
@@ -279,12 +307,16 @@ describe("Nested Strategies", () => {
     assertNoErrors(result);
   });
 
-  it("validates outer strategy", () => {
-    validateStrategy(researchPipeline, "sequential");
-  });
+  it("validates outer sequential strategy", () => {
+    const result = mockRun(researchPipeline, "Analyze something", {
+      events: [
+        MockEvent.handoff("research-phase"),
+        MockEvent.handoff("report-writer"),
+        MockEvent.done({ result: "Done." }),
+      ],
+    });
 
-  it("validates inner strategy", () => {
-    validateStrategy(parallelResearch, "parallel");
+    expect(() => validateStrategy(researchPipeline, result)).not.toThrow();
   });
 });
 
@@ -293,10 +325,7 @@ describe("Nested Strategies", () => {
 // ═════════════════════════════════════════════════════════════════════
 
 describe("Complex Tool Patterns", () => {
-  it("tracks tool call ordering via callLog", async () => {
-    const callLog: Array<{ tool: string; args: unknown }> = [];
-
-    // Use a single agent with both tools to test call ordering
+  it("tracks tool call ordering with assertToolCallOrder", () => {
     const multiToolAgent = new Agent({
       name: "multi-tool-agent",
       model: "openai/gpt-4o",
@@ -304,35 +333,26 @@ describe("Complex Tool Patterns", () => {
       tools: [checkInventory, trackShipment],
     });
 
-    const result = await mockRun(
+    const result = mockRun(
       multiToolAgent,
       "Check stock for item P-1 and track shipment TRK-P1",
       {
-        mockTools: {
-          check_inventory: async (args: { productId: string }) => {
-            callLog.push({ tool: "check_inventory", args });
-            return { productId: args.productId, inStock: true, quantity: 10 };
-          },
-          track_shipment: async (args: { trackingId: string }) => {
-            callLog.push({ tool: "track_shipment", args });
-            return { trackingId: args.trackingId, status: "shipped" };
-          },
-        },
+        events: [
+          MockEvent.toolCall("check_inventory", { productId: "P-1" }),
+          MockEvent.toolResult("check_inventory", { productId: "P-1", inStock: true, quantity: 10 }),
+          MockEvent.toolCall("track_shipment", { trackingId: "TRK-P1" }),
+          MockEvent.toolResult("track_shipment", { trackingId: "TRK-P1", status: "shipped" }),
+          MockEvent.done({ result: "Item P-1 in stock; TRK-P1 shipped." }),
+        ],
       },
     );
 
-    // Both tools should have been called
-    const toolNames = callLog.map((c) => c.tool);
-    expect(toolNames).toContain("check_inventory");
-    expect(toolNames).toContain("track_shipment");
-
-    // check_inventory should come before track_shipment
-    const inventoryIdx = toolNames.indexOf("check_inventory");
-    const shipmentIdx = toolNames.indexOf("track_shipment");
-    expect(inventoryIdx).toBeLessThan(shipmentIdx);
+    assertToolUsed(result, "check_inventory");
+    assertToolUsed(result, "track_shipment");
+    assertToolCallOrder(result, ["check_inventory", "track_shipment"]);
   });
 
-  it("handles concurrent tool calls in parallel agents", async () => {
+  it("handles concurrent tool calls in parallel agents", () => {
     const parallelTools = new Agent({
       name: "parallel-tools",
       model: "openai/gpt-4o",
@@ -340,14 +360,19 @@ describe("Complex Tool Patterns", () => {
       strategy: "parallel",
     });
 
-    const result = await mockRun(
+    const result = mockRun(
       parallelTools,
       "Check inventory and track shipment simultaneously",
       {
-        mockTools: {
-          check_inventory: async () => ({ inStock: true }),
-          track_shipment: async () => ({ status: "delivered" }),
-        },
+        events: [
+          MockEvent.handoff("inventory-specialist"),
+          MockEvent.toolCall("check_inventory", { productId: "X" }),
+          MockEvent.toolResult("check_inventory", { inStock: true }),
+          MockEvent.handoff("shipping-specialist"),
+          MockEvent.toolCall("track_shipment", { trackingId: "TRK-1" }),
+          MockEvent.toolResult("track_shipment", { status: "delivered" }),
+          MockEvent.done({ result: "Both checked." }),
+        ],
       },
     );
 
@@ -358,57 +383,20 @@ describe("Complex Tool Patterns", () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════
-// 5. SESSION ID FOR CONVERSATION CONTINUITY
+// 5. EVENT SEQUENCE ASSERTIONS
 // ═════════════════════════════════════════════════════════════════════
 
-describe("Session Management", () => {
-  it("uses custom session ID for continuity", async () => {
-    const result = await mockRun(
-      inventoryAgent,
-      "Is item X in stock?",
-      {
-        sessionId: "session-abc-123",
-        mockTools: {
-          check_inventory: async () => ({
-            productId: "X",
-            inStock: true,
-          }),
-        },
-      },
-    );
+describe("Event Sequence Assertions", () => {
+  it("verifies event type subsequence", () => {
+    const result = mockRun(inventoryAgent, "Check stock", {
+      events: [
+        MockEvent.thinking("Let me check..."),
+        MockEvent.toolCall("check_inventory", { productId: "Y" }),
+        MockEvent.toolResult("check_inventory", { inStock: true }),
+        MockEvent.done({ result: "In stock." }),
+      ],
+    });
 
-    expectResult(result).toBeCompleted();
-    assertToolUsed(result, "check_inventory");
-  });
-
-  it("different sessions are independent", async () => {
-    const result1 = await mockRun(
-      inventoryAgent,
-      "Check item A",
-      {
-        sessionId: "session-1",
-        mockTools: {
-          check_inventory: async () => ({ productId: "A", inStock: true }),
-        },
-      },
-    );
-
-    const result2 = await mockRun(
-      inventoryAgent,
-      "Check item B",
-      {
-        sessionId: "session-2",
-        mockTools: {
-          check_inventory: async () => ({ productId: "B", inStock: false }),
-        },
-      },
-    );
-
-    expectResult(result1).toBeCompleted();
-    expectResult(result2).toBeCompleted();
-
-    // Both should have used the tool independently
-    assertToolUsed(result1, "check_inventory");
-    assertToolUsed(result2, "check_inventory");
+    assertEventSequence(result, ["thinking", "tool_call", "tool_result", "done"]);
   });
 });

--- a/sdk/typescript/examples/mock_tests/05-advanced-patterns.test.ts
+++ b/sdk/typescript/examples/mock_tests/05-advanced-patterns.test.ts
@@ -1,0 +1,414 @@
+/**
+ * 05 — Advanced Patterns
+ *
+ * Record/replay for regression tests, LLM-based evaluation with
+ * CorrectnessEval, strategy validation, and complex multi-agent
+ * compositions.
+ *
+ * Covers:
+ *   - record() / replay() for fixture-based testing
+ *   - CorrectnessEval with rubrics (integration)
+ *   - validateStrategy() for structural checks
+ *   - Nested agent strategies
+ *   - Complex tool interaction patterns
+ *   - Session ID for conversation continuity
+ *
+ * Run:
+ *   npx vitest run examples/mock_tests/05-advanced-patterns.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import * as path from "path";
+import * as os from "os";
+import * as fs from "fs";
+import { Agent, tool } from "@agentspan-ai/sdk";
+import {
+  mockRun,
+  expectResult,
+  record,
+  replay,
+  validateStrategy,
+  assertAgentRan,
+  assertHandoffTo,
+  assertToolUsed,
+  assertNoErrors,
+  assertStatus,
+} from "@agentspan-ai/sdk/testing";
+
+// ── Tools ────────────────────────────────────────────────────────────
+
+const checkInventory = tool(
+  async (args: { productId: string }) => ({
+    productId: args.productId,
+    inStock: true,
+    quantity: 50,
+  }),
+  {
+    name: "check_inventory",
+    description: "Check product inventory.",
+    inputSchema: z.object({ productId: z.string() }),
+  },
+);
+
+const processReturn = tool(
+  async (args: { orderId: string; reason: string }) =>
+    `Return initiated for ${args.orderId}: ${args.reason}`,
+  {
+    name: "process_return",
+    description: "Process a product return.",
+    inputSchema: z.object({
+      orderId: z.string(),
+      reason: z.string(),
+    }),
+  },
+);
+
+const trackShipment = tool(
+  async (args: { trackingId: string }) => ({
+    trackingId: args.trackingId,
+    status: "in_transit",
+    eta: "2 days",
+  }),
+  {
+    name: "track_shipment",
+    description: "Track a shipment.",
+    inputSchema: z.object({ trackingId: z.string() }),
+  },
+);
+
+const escalateToManager = tool(
+  async (args: { issue: string }) => `Escalated: ${args.issue}`,
+  {
+    name: "escalate_to_manager",
+    description: "Escalate an issue to a human manager.",
+    inputSchema: z.object({ issue: z.string() }),
+  },
+);
+
+// ═════════════════════════════════════════════════════════════════════
+// 1. RECORD / REPLAY — fixture-based regression tests
+// ═════════════════════════════════════════════════════════════════════
+
+const inventoryAgent = new Agent({
+  name: "inventory-specialist",
+  model: "openai/gpt-4o",
+  instructions: "Handle inventory and stock questions.",
+  tools: [checkInventory],
+});
+
+const returnsAgent = new Agent({
+  name: "returns-specialist",
+  model: "openai/gpt-4o",
+  instructions: "Handle returns and refunds.",
+  tools: [processReturn],
+});
+
+const shippingAgent = new Agent({
+  name: "shipping-specialist",
+  model: "openai/gpt-4o",
+  instructions: "Handle shipping and tracking questions.",
+  tools: [trackShipment],
+});
+
+const ecommerceSupport = new Agent({
+  name: "ecommerce-support",
+  model: "openai/gpt-4o",
+  instructions: "Front-line e-commerce support.",
+  agents: [inventoryAgent, returnsAgent, shippingAgent],
+  strategy: "handoff",
+});
+
+describe("Record / Replay", () => {
+  it("records a run to a fixture file and replays it", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentspan-test-"));
+    const fixturePath = path.join(tmpDir, "shipping-run.json");
+
+    try {
+      // Record an execution — use the shipping agent directly
+      const result = await record(
+        shippingAgent,
+        "Track my package TRK-001",
+        {
+          fixturePath,
+          mockTools: {
+            track_shipment: async () => ({
+              trackingId: "TRK-001",
+              status: "delivered",
+            }),
+          },
+        },
+      );
+
+      expectResult(result).toBeCompleted();
+      assertToolUsed(result, "track_shipment");
+
+      // Verify fixture file was created
+      expect(fs.existsSync(fixturePath)).toBe(true);
+
+      // Replay from the fixture
+      const replayed = replay(fixturePath);
+
+      // Same assertions pass on the replayed result
+      expectResult(replayed).toBeCompleted();
+      assertToolUsed(replayed, "track_shipment");
+    } finally {
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replayed result preserves events", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentspan-test-"));
+    const fixturePath = path.join(tmpDir, "inventory-run.json");
+
+    try {
+      const original = await record(
+        inventoryAgent,
+        "Is item X in stock?",
+        {
+          fixturePath,
+          mockTools: {
+            check_inventory: async () => ({
+              productId: "X",
+              inStock: true,
+              quantity: 50,
+            }),
+          },
+        },
+      );
+
+      const replayed = replay(fixturePath);
+
+      // Event counts should match
+      expect(replayed.events.length).toBe(original.events.length);
+
+      // Tool calls should match
+      expect(replayed.toolCalls.length).toBe(original.toolCalls.length);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 2. STRATEGY VALIDATION
+// ═════════════════════════════════════════════════════════════════════
+
+describe("Strategy Validation", () => {
+  it("validates handoff strategy", () => {
+    // validateStrategy checks the agent's declared strategy
+    validateStrategy(ecommerceSupport, "handoff");
+  });
+
+  it("validates parallel strategy", () => {
+    const parallelTeam = new Agent({
+      name: "parallel-team",
+      model: "openai/gpt-4o",
+      agents: [inventoryAgent, shippingAgent],
+      strategy: "parallel",
+    });
+
+    validateStrategy(parallelTeam, "parallel");
+  });
+
+  it("validates sequential strategy", () => {
+    const sequentialPipeline = new Agent({
+      name: "sequential-pipeline",
+      model: "openai/gpt-4o",
+      agents: [inventoryAgent, returnsAgent],
+      strategy: "sequential",
+    });
+
+    validateStrategy(sequentialPipeline, "sequential");
+  });
+
+  it("throws on strategy mismatch", () => {
+    expect(() => {
+      validateStrategy(ecommerceSupport, "parallel");
+    }).toThrow();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 3. NESTED MULTI-AGENT STRATEGIES
+// ═════════════════════════════════════════════════════════════════════
+
+const marketResearcher = new Agent({
+  name: "market-researcher",
+  model: "openai/gpt-4o",
+  instructions: "Research market trends.",
+});
+
+const competitorAnalyst = new Agent({
+  name: "competitor-analyst",
+  model: "openai/gpt-4o",
+  instructions: "Analyze competitors.",
+});
+
+const parallelResearch = new Agent({
+  name: "research-phase",
+  model: "openai/gpt-4o",
+  agents: [marketResearcher, competitorAnalyst],
+  strategy: "parallel",
+});
+
+const reportWriter = new Agent({
+  name: "report-writer",
+  model: "openai/gpt-4o",
+  instructions: "Write a synthesis report.",
+});
+
+const researchPipeline = new Agent({
+  name: "research-pipeline",
+  model: "openai/gpt-4o",
+  agents: [parallelResearch, reportWriter],
+  strategy: "sequential",
+});
+
+describe("Nested Strategies", () => {
+  it("parallel research feeds into sequential report writing", async () => {
+    const result = await mockRun(
+      researchPipeline,
+      "Analyze the cloud computing market",
+    );
+
+    assertAgentRan(result, "market-researcher");
+    assertAgentRan(result, "competitor-analyst");
+    assertAgentRan(result, "report-writer");
+    assertNoErrors(result);
+  });
+
+  it("validates outer strategy", () => {
+    validateStrategy(researchPipeline, "sequential");
+  });
+
+  it("validates inner strategy", () => {
+    validateStrategy(parallelResearch, "parallel");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 4. COMPLEX TOOL INTERACTION PATTERNS
+// ═════════════════════════════════════════════════════════════════════
+
+describe("Complex Tool Patterns", () => {
+  it("tracks tool call ordering via callLog", async () => {
+    const callLog: Array<{ tool: string; args: unknown }> = [];
+
+    // Use a single agent with both tools to test call ordering
+    const multiToolAgent = new Agent({
+      name: "multi-tool-agent",
+      model: "openai/gpt-4o",
+      instructions: "Check inventory then track shipment.",
+      tools: [checkInventory, trackShipment],
+    });
+
+    const result = await mockRun(
+      multiToolAgent,
+      "Check stock for item P-1 and track shipment TRK-P1",
+      {
+        mockTools: {
+          check_inventory: async (args: { productId: string }) => {
+            callLog.push({ tool: "check_inventory", args });
+            return { productId: args.productId, inStock: true, quantity: 10 };
+          },
+          track_shipment: async (args: { trackingId: string }) => {
+            callLog.push({ tool: "track_shipment", args });
+            return { trackingId: args.trackingId, status: "shipped" };
+          },
+        },
+      },
+    );
+
+    // Both tools should have been called
+    const toolNames = callLog.map((c) => c.tool);
+    expect(toolNames).toContain("check_inventory");
+    expect(toolNames).toContain("track_shipment");
+
+    // check_inventory should come before track_shipment
+    const inventoryIdx = toolNames.indexOf("check_inventory");
+    const shipmentIdx = toolNames.indexOf("track_shipment");
+    expect(inventoryIdx).toBeLessThan(shipmentIdx);
+  });
+
+  it("handles concurrent tool calls in parallel agents", async () => {
+    const parallelTools = new Agent({
+      name: "parallel-tools",
+      model: "openai/gpt-4o",
+      agents: [inventoryAgent, shippingAgent],
+      strategy: "parallel",
+    });
+
+    const result = await mockRun(
+      parallelTools,
+      "Check inventory and track shipment simultaneously",
+      {
+        mockTools: {
+          check_inventory: async () => ({ inStock: true }),
+          track_shipment: async () => ({ status: "delivered" }),
+        },
+      },
+    );
+
+    assertAgentRan(result, "inventory-specialist");
+    assertAgentRan(result, "shipping-specialist");
+    assertNoErrors(result);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+// 5. SESSION ID FOR CONVERSATION CONTINUITY
+// ═════════════════════════════════════════════════════════════════════
+
+describe("Session Management", () => {
+  it("uses custom session ID for continuity", async () => {
+    const result = await mockRun(
+      inventoryAgent,
+      "Is item X in stock?",
+      {
+        sessionId: "session-abc-123",
+        mockTools: {
+          check_inventory: async () => ({
+            productId: "X",
+            inStock: true,
+          }),
+        },
+      },
+    );
+
+    expectResult(result).toBeCompleted();
+    assertToolUsed(result, "check_inventory");
+  });
+
+  it("different sessions are independent", async () => {
+    const result1 = await mockRun(
+      inventoryAgent,
+      "Check item A",
+      {
+        sessionId: "session-1",
+        mockTools: {
+          check_inventory: async () => ({ productId: "A", inStock: true }),
+        },
+      },
+    );
+
+    const result2 = await mockRun(
+      inventoryAgent,
+      "Check item B",
+      {
+        sessionId: "session-2",
+        mockTools: {
+          check_inventory: async () => ({ productId: "B", inStock: false }),
+        },
+      },
+    );
+
+    expectResult(result1).toBeCompleted();
+    expectResult(result2).toBeCompleted();
+
+    // Both should have used the tool independently
+    assertToolUsed(result1, "check_inventory");
+    assertToolUsed(result2, "check_inventory");
+  });
+});

--- a/sdk/typescript/examples/mock_tests/README.md
+++ b/sdk/typescript/examples/mock_tests/README.md
@@ -1,0 +1,544 @@
+# Mock Tests — TypeScript SDK
+
+## Table of Contents
+
+- [What Is This?](#what-is-this)
+- [Why Mock Test Agents?](#why-mock-test-agents)
+- [When to Use Mock Tests](#when-to-use-mock-tests)
+- [Setup](#setup)
+- [Run](#run)
+- [Examples](#examples)
+- [Quick Reference](#quick-reference)
+  - [mockRun](#mockrun)
+  - [mockTools](#mocktools)
+  - [Assertions](#assertions)
+  - [Fluent API](#fluent-api)
+  - [AgentResult](#agentresult)
+- [Strategy Validation](#strategy-validation)
+- [Record / Replay](#record--replay)
+- [CorrectnessEval — LLM Judge Evaluation](#correctnesseval--llm-judge-evaluation)
+- [Testing Pyramid for Agents](#testing-pyramid-for-agents)
+- [FAQ](#faq)
+
+---
+
+## What Is This?
+
+The Agentspan testing framework lets you write **deterministic, reproducible tests for AI agents** — without calling an LLM, connecting to a server, or spending API credits. You provide mock tool implementations, run the agent locally with `mockRun()`, and assert that the agent's structure and behavior are correct.
+
+This is the agent equivalent of unit testing. Just as you wouldn't hit a real database to test your request handler logic, you don't need a real LLM to test that your agent routes to the right specialist, calls tools in the right order, or respects guardrail boundaries.
+
+## Why Mock Test Agents?
+
+**Fast feedback loop.** Mock tests run in milliseconds. No network calls, no token costs, no flaky LLM responses. You can run hundreds of test cases in seconds as part of CI.
+
+**Test orchestration logic, not LLM quality.** The hardest bugs in multi-agent systems aren't about what the LLM says — they're about *routing*: did the right agent get picked? Did tools fire in the right order? Did the guardrail block before the agent acted? Did the pipeline skip a stage? Mock tests catch these structural bugs deterministically.
+
+**Catch regressions early.** When you refactor agent definitions, change tool signatures, or restructure your agent hierarchy, mock tests tell you immediately if the orchestration contract broke — before you burn time on expensive live runs.
+
+**Test edge cases you can't reproduce with an LLM.** What happens when a guardrail fails and retries? When two agents transfer back and forth in a loop? When a tool throws an error mid-pipeline? Mock tests let you script exact scenarios that would be nearly impossible to trigger reliably with a real model.
+
+**Complement live evals, don't replace them.** Mock tests verify *structure* (correct routing, tool usage, event ordering). Live evals with `CorrectnessEval` verify *quality* (did the LLM produce a good answer?). Use both: mock tests in CI for fast structural checks, live evals periodically for behavioral validation.
+
+## When to Use Mock Tests
+
+- **CI/CD pipelines** — run on every commit, zero cost, sub-second execution
+- **Developing new agents** — validate orchestration logic before wiring up real LLMs
+- **Refactoring** — ensure agent restructuring doesn't break routing or tool contracts
+- **Edge case coverage** — guardrail failures, error recovery, HITL flows, transfer loops
+- **Strategy validation** — verify sequential order, parallel completeness, round-robin alternation, transition constraints
+- **Regression testing** — record a known-good run, replay and re-assert later
+
+## Setup
+
+The testing module ships with the SDK under a dedicated sub-export. No extra dependencies needed for mock tests.
+
+```bash
+# Install the SDK (if not already installed)
+npm install @agentspan-ai/sdk
+
+# The testing module is available at:
+#   import { mockRun, expectResult, ... } from "@agentspan-ai/sdk/testing";
+```
+
+For running tests, use [Vitest](https://vitest.dev/):
+
+```bash
+npm install -D vitest
+```
+
+## Run
+
+```bash
+# All mock tests
+npx vitest run examples/mock_tests/
+
+# Single file
+npx vitest run examples/mock_tests/01-basic-agent.test.ts
+
+# Watch mode (re-runs on file changes)
+npx vitest watch examples/mock_tests/
+
+# Only tests matching a name pattern
+npx vitest run examples/mock_tests/ -t "routes docs question"
+```
+
+## Examples
+
+| # | File | Topics |
+|---|------|--------|
+| 01 | `01-basic-agent.test.ts` | `mockRun`, status/output assertions, `expectResult()` fluent API, mock credentials |
+| 02 | `02-tool-assertions.test.ts` | Mock tool overrides, call ordering via tracking, output validation, error in tools, token usage budget |
+| 03 | `03-multi-agent-strategies.test.ts` | Handoff, Sequential, Parallel, Router — `assertAgentRan`, `assertHandoffTo`, tool isolation |
+| 04 | `04-guardrails-and-errors.test.ts` | Guardrail events, finish reasons, error handling, token limits, guardrails in multi-agent flows |
+| 05 | `05-advanced-patterns.test.ts` | `record`/`replay` fixtures, `validateStrategy`, nested strategies, complex tool chains, session ID |
+
+Start with `01-basic-agent.test.ts` and work through in order — each file builds on concepts from the previous one.
+
+## Quick Reference
+
+### mockRun
+
+`mockRun()` executes an agent locally with mock tool implementations and returns an `AgentResult` you can assert against. No LLM or server is involved.
+
+```typescript
+import { mockRun } from "@agentspan-ai/sdk/testing";
+
+const result = await mockRun(agent, "user prompt", {
+  mockTools: {
+    search: async (args) => ({ results: ["found it"] }),
+  },
+  mockCredentials: { API_KEY: "test-key" },
+  sessionId: "custom-session",
+});
+```
+
+**Options:**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `mockTools` | `Record<string, Function>` | Override tool implementations by name. The function receives the tool's args and returns the result. |
+| `mockCredentials` | `Record<string, string>` | Mock credentials injected into the tool context. |
+| `sessionId` | `string` | Optional session ID for conversation continuity testing. |
+
+### mockTools
+
+`mockTools` is a dictionary mapping tool names to async functions. When the agent calls a tool, the mock function runs instead of the real implementation.
+
+```typescript
+const result = await mockRun(agent, "Search for shoes", {
+  mockTools: {
+    // Simple return value
+    search_products: async (args: { query: string }) => [
+      { name: "Red Shoe", price: 89.99 },
+    ],
+
+    // Simulate an error
+    checkout: async () => {
+      throw new Error("Payment failed");
+    },
+
+    // Track calls for ordering assertions
+    get_details: async (args: { id: string }) => {
+      callLog.push("get_details");
+      return { id: args.id, name: "Widget" };
+    },
+  },
+});
+```
+
+If a tool is called but not present in `mockTools`, the agent's real tool implementation runs (if it has one). To override all tools, provide a mock for each.
+
+### Assertions
+
+All assertion functions take an `AgentResult` and throw `Error` on failure:
+
+| Function | What it checks |
+|----------|---------------|
+| `assertStatus(result, status)` | Result status matches (e.g. `"COMPLETED"`, `"FAILED"`) |
+| `assertNoErrors(result)` | No `error` events in the trace |
+| `assertToolUsed(result, name)` | Tool was called at least once |
+| `assertAgentRan(result, name)` | Agent participated (via handoff or subResults) |
+| `assertHandoffTo(result, target)` | A handoff to this agent occurred |
+| `assertGuardrailPassed(result, name)` | Named guardrail passed |
+
+```typescript
+import {
+  assertStatus,
+  assertNoErrors,
+  assertToolUsed,
+  assertAgentRan,
+  assertHandoffTo,
+  assertGuardrailPassed,
+} from "@agentspan-ai/sdk/testing";
+```
+
+For assertions not covered by the built-in functions (tool args, call order, output regex), use Vitest's `expect()` directly on the `result.events` and `result.toolCalls` arrays:
+
+```typescript
+// Check tool args
+const searchCall = result.toolCalls.find(c => c.name === "search");
+expect(searchCall?.args).toEqual({ query: "shoes" });
+
+// Check tool call order
+const toolNames = result.toolCalls.map(c => c.name);
+expect(toolNames).toEqual(["search", "get_details", "checkout"]);
+
+// Check output text
+expect(JSON.stringify(result.output)).toContain("order confirmed");
+```
+
+### Fluent API
+
+The `expectResult()` API chains multiple assertions in a single expression. Every method returns `this`, so you keep chaining. It throws on the first failure.
+
+```typescript
+import { expectResult } from "@agentspan-ai/sdk/testing";
+
+expectResult(result)
+  .toBeCompleted()                        // status === "COMPLETED"
+  .toHaveUsedTool("search")              // tool was called
+  .toContainOutput("answer")             // output JSON contains text
+  .toHavePassedGuardrail("pii_check")    // guardrail passed
+  .toHaveFinishReason("stop")            // finished naturally
+  .toHaveTokenUsageBelow(10000);         // within token budget
+```
+
+You can also assert failure:
+
+```typescript
+expectResult(result).toBeFailed();  // status !== "COMPLETED"
+```
+
+### AgentResult
+
+`mockRun()` returns an `AgentResult` with these key properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `result.output` | `Record<string, unknown>` | The final answer (normalized to a record) |
+| `result.status` | `Status` | `"COMPLETED"`, `"FAILED"`, `"TERMINATED"`, or `"TIMED_OUT"` |
+| `result.events` | `AgentEvent[]` | Full execution trace — every tool call, handoff, guardrail, etc. |
+| `result.toolCalls` | `unknown[]` | All tool invocations with names and arguments |
+| `result.messages` | `unknown[]` | Conversation history |
+| `result.error` | `string?` | Error message if the run failed |
+| `result.executionId` | `string` | Unique execution identifier |
+| `result.finishReason` | `FinishReason` | `"stop"`, `"error"`, `"guardrail"`, `"timeout"`, etc. |
+| `result.isSuccess` | `boolean` | `true` if status is `"COMPLETED"` |
+| `result.isFailed` | `boolean` | `true` if status is `"FAILED"` or `"TIMED_OUT"` |
+| `result.subResults` | `Record<string, unknown>?` | Per-agent results (parallel strategy) |
+| `result.tokenUsage` | `TokenUsage?` | Token usage stats |
+
+Each `AgentEvent` has:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `event.type` | `EventType` | `"tool_call"`, `"handoff"`, `"done"`, `"error"`, `"guardrail_pass"`, etc. |
+| `event.target` | `string?` | Agent name (for handoff events) |
+| `event.name` | `string?` | Tool or guardrail name |
+| `event.content` | `unknown?` | Event payload |
+
+**EventType values:** `"thinking"`, `"tool_call"`, `"tool_result"`, `"handoff"`, `"message"`, `"waiting"`, `"error"`, `"done"`, `"guardrail_pass"`, `"guardrail_fail"`
+
+---
+
+## Strategy Validation
+
+`validateStrategy(agent, strategy)` verifies that the agent's declared strategy matches what you expect. This is a structural check on the agent definition itself — catching cases where an agent was accidentally configured with the wrong strategy (e.g. `"parallel"` when you meant `"sequential"`).
+
+In the Python SDK, strategy validation goes deeper — it inspects the full execution trace to verify that the orchestration rules were followed. The TypeScript equivalent focuses on the agent's declared strategy, which you combine with runtime assertions (`assertAgentRan`, `assertHandoffTo`, etc.) to verify the full picture.
+
+```typescript
+import { validateStrategy } from "@agentspan-ai/sdk/testing";
+
+// Passes silently if the agent's strategy matches
+validateStrategy(agent, "handoff");
+validateStrategy(agent, "parallel");
+validateStrategy(agent, "sequential");
+
+// Throws if there's a mismatch
+// e.g. agent is configured as "handoff" but you expected "parallel"
+validateStrategy(agent, "parallel"); // throws!
+```
+
+Each strategy implies specific runtime behavior that you verify with assertions:
+
+| Strategy | What to verify with assertions |
+|----------|-------------------------------|
+| **Sequential** | `assertAgentRan()` for every agent in the pipeline. Track execution order with a `callLog` array in mock tools. |
+| **Parallel** | `assertAgentRan()` for all agents. Order doesn't matter — just verify none were skipped. |
+| **Handoff** | `assertHandoffTo()` for the expected specialist. Verify the wrong specialist was NOT picked. |
+| **Router** | `assertHandoffTo()` for exactly one specialist. Verify only that agent ran. |
+| **Round Robin** | Track handoff order and verify alternation pattern. Check turn count against `maxTurns`. |
+
+Combine `validateStrategy` with runtime assertions for full coverage:
+
+```typescript
+// Verify the agent definition
+validateStrategy(auditTeam, "parallel");
+
+// Verify the execution trace
+const result = await mockRun(auditTeam, "Audit the checkout page", { ... });
+assertAgentRan(result, "security-auditor");
+assertAgentRan(result, "performance-auditor");
+assertAgentRan(result, "accessibility-auditor");
+assertNoErrors(result);
+```
+
+---
+
+## Record / Replay
+
+Record/replay lets you capture an `AgentResult` to a JSON fixture file, then load it back later to re-run assertions against it. **Replay does not re-execute anything** — no server, no LLM, no mock run. It simply deserializes the saved result into an `AgentResult` object so you can assert against the same frozen snapshot.
+
+This is the foundation for **regression testing** — you record a known-good result once, commit the fixture to version control, and your CI re-asserts against it on every build. If someone changes the agent definition and the assertions start failing, you know the contract broke.
+
+**How it works:**
+
+```
+record(agent, prompt, opts)  →  runs mockRun + saves AgentResult to JSON on disk
+replay(path)                 →  reads JSON back into an AgentResult (no execution)
+```
+
+The execution happens inside `record()` — it calls `mockRun()` with your mock tools, then serializes the resulting `AgentResult` to the fixture file. `replay()` loads that JSON back into an `AgentResult`. No server, no LLM, no re-execution.
+
+**Why this matters:** Agent definitions evolve — you add tools, restructure sub-agents, change instructions. Without regression fixtures, the only way to know if you broke something is to run a live eval (slow, expensive, non-deterministic). With record/replay, you get instant deterministic regression checks.
+
+**Typical workflow:**
+
+1. Run your agent via `record()` and verify it behaves correctly
+2. Commit the fixture JSON to version control
+3. In CI, `replay()` the fixture and re-assert — if assertions fail, the agent's contract changed
+
+```typescript
+import { record, replay, expectResult, assertHandoffTo } from "@agentspan-ai/sdk/testing";
+
+// Step 1: Record a known-good execution (runs mockRun internally)
+const result = await record(agent, "Track order #123", {
+  fixturePath: "__fixtures__/track_order.json",
+  mockTools: {
+    track_shipment: async () => ({ status: "delivered" }),
+  },
+});
+
+// Step 2: Later (in CI, after refactoring, etc.)
+// replay() just loads the JSON — nothing is executed
+const replayed = replay("__fixtures__/track_order.json");
+
+expectResult(replayed)
+  .toBeCompleted()
+  .toHaveUsedTool("track_shipment")
+  .toContainOutput("delivered");
+assertHandoffTo(replayed, "shipping-specialist");
+```
+
+The fixture JSON contains the full execution snapshot:
+
+```json
+{
+  "agent": { "name": "shipping-support", "model": "openai/gpt-4o" },
+  "prompt": "Track order #123",
+  "events": [
+    { "type": "handoff", "target": "shipping-specialist" },
+    { "type": "tool_call", "name": "track_shipment", "args": { "trackingId": "TRK-001" } },
+    { "type": "tool_result", "name": "track_shipment", "result": { "status": "delivered" } },
+    { "type": "done", "output": "Your package has been delivered!" }
+  ],
+  "result": {
+    "output": { ... },
+    "status": "COMPLETED",
+    "finishReason": "stop",
+    "toolCalls": [ ... ],
+    "messages": [ ... ]
+  },
+  "timestamp": 1712100000000
+}
+```
+
+The fixture is human-readable and diffable, so you can review what changed when a regression test fails. Commit fixtures alongside your test files in `__fixtures__/` or a similar directory.
+
+---
+
+## CorrectnessEval — LLM Judge Evaluation
+
+`CorrectnessEval` is the **live counterpart to mock tests**. While `mockRun()` tests agents locally without an LLM, `CorrectnessEval` uses an **LLM judge** to evaluate the quality of your agent's output against rubrics you define.
+
+This is where you test whether the agent produced a *good* answer — not just that the orchestration wiring is correct.
+
+**What it requires:**
+- An `AgentResult` to evaluate (from `mockRun()` or a live server run)
+- An API key for the judge model (e.g. `OPENAI_API_KEY` for `gpt-4o`)
+- Real token costs (each evaluation makes an LLM call to the judge)
+
+**How it works:**
+
+1. You run your agent and get an `AgentResult` (via `mockRun()` or live execution)
+2. You define rubrics — named criteria the judge scores on a 1-5 scale
+3. `CorrectnessEval.evaluate()` sends the result to the judge LLM
+4. The judge scores each rubric and returns pass/fail with reasoning
+
+```typescript
+import { Agent } from "@agentspan-ai/sdk";
+import { mockRun, CorrectnessEval } from "@agentspan-ai/sdk/testing";
+
+// Run the agent (mock or live)
+const result = await mockRun(agent, "Explain quantum computing", {
+  mockTools: { search: async () => "Quantum computing uses qubits..." },
+});
+
+// Evaluate with an LLM judge
+const evaluator = new CorrectnessEval({
+  model: "openai/gpt-4o-mini",
+  apiKey: process.env.OPENAI_API_KEY,
+  maxOutputChars: 3000,  // truncate long outputs before judging
+  maxTokens: 300,        // max tokens for judge response
+});
+
+const evalResult = await evaluator.evaluate(result, {
+  rubrics: [
+    { name: "accuracy", description: "Is the answer factually correct?", weight: 2 },
+    { name: "completeness", description: "Does it cover all key concepts?", weight: 1 },
+    { name: "clarity", description: "Is it well-explained for a beginner?", weight: 1 },
+  ],
+  passThreshold: 3.5,  // weighted average must be >= 3.5 out of 5
+});
+
+console.log(`Passed: ${evalResult.passed}`);
+console.log(`Weighted average: ${evalResult.weightedAverage}`);
+console.log(`Scores:`, evalResult.scores);       // { accuracy: 4, completeness: 5, clarity: 3 }
+console.log(`Reasoning:`, evalResult.reasoning);  // per-rubric explanations from the judge
+```
+
+**CorrectnessEval constructor options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `model` | `string` | — | Judge model (e.g. `"openai/gpt-4o-mini"`) |
+| `apiKey` | `string?` | env var | API key for the judge model |
+| `maxOutputChars` | `number` | `3000` | Truncate agent output before sending to judge |
+| `maxTokens` | `number` | `300` | Max tokens for the judge's response |
+| `endpoint` | `string?` | OpenAI default | Custom API endpoint for the judge |
+
+**Rubric definition:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | — | Rubric identifier (e.g. `"accuracy"`) |
+| `description` | `string` | — | What the judge should evaluate (becomes part of the judge prompt) |
+| `weight` | `number` | `1` | Relative weight for the weighted average |
+
+**EvalResult fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `passed` | `boolean` | `true` if weighted average >= `passThreshold` |
+| `scores` | `Record<string, number>` | 1-5 score per rubric |
+| `weightedAverage` | `number` | Weighted average across all rubrics |
+| `reasoning` | `Record<string, string>` | Per-rubric explanation from the judge LLM |
+
+---
+
+## Testing Pyramid for Agents
+
+| Layer | Tool | Runs against | Cost | Speed | What it catches | CI cadence |
+|-------|------|-------------|------|-------|-----------------|------------|
+| **Unit** | `mockRun` | Local mock tools | Free | Milliseconds | Broken routing, wrong tool order, missing agents | Every commit |
+| **Structural** | `validateStrategy` | Agent definition | Free | Milliseconds | Strategy misconfiguration, wrong strategy type | Every commit |
+| **Regression** | `record` / `replay` | Saved JSON fixture | Free | Milliseconds | Changes to orchestration contracts after refactoring | Every commit |
+| **Quality** | `CorrectnessEval` | LLM judge | API credits | Seconds per eval | Bad answers, incomplete responses, wrong tone | Nightly / weekly |
+
+Start from the bottom — write mock tests first, add strategy validation, record fixtures, and run LLM judge evals periodically.
+
+---
+
+## FAQ
+
+### Do I need a running server for mock tests?
+
+No. `mockRun()` is entirely local. No server, no LLM, no network calls, no API keys. That's the whole point.
+
+### Do I need a running server for `record()` / `replay()`?
+
+No. `record()` calls `mockRun()` internally and saves the result to JSON. `replay()` reads it back. Neither touches a server.
+
+### Does `CorrectnessEval` need a running Agentspan server?
+
+No. It needs an API key for the **judge model** (e.g. OpenAI), not an Agentspan server. It evaluates an `AgentResult` you already have — it doesn't run the agent. You can pass it results from `mockRun()` or from a live server run.
+
+### How do I test tool call ordering?
+
+Track calls with a `callLog` array in your mock tools:
+
+```typescript
+const callLog: string[] = [];
+const result = await mockRun(agent, "Buy a widget", {
+  mockTools: {
+    search: async () => { callLog.push("search"); return []; },
+    checkout: async () => { callLog.push("checkout"); return {}; },
+  },
+});
+expect(callLog).toEqual(["search", "checkout"]);
+```
+
+### How do I test tool arguments?
+
+Access `result.toolCalls` directly:
+
+```typescript
+const searchCall = result.toolCalls.find((c: any) => c.name === "search");
+expect(searchCall?.args).toEqual({ query: "red shoes" });
+```
+
+### How do I test that an agent does NOT hand off to a specific agent?
+
+Check the events directly:
+
+```typescript
+const handoffs = result.events
+  .filter(e => e.type === "handoff")
+  .map(e => e.target);
+expect(handoffs).not.toContain("wrong-agent");
+```
+
+### Can I mix the assertion functions with Vitest's `expect()`?
+
+Yes. The SDK assertions (`assertToolUsed`, etc.) throw on failure, which Vitest catches. Use SDK assertions for common checks and Vitest's `expect()` for anything custom:
+
+```typescript
+assertToolUsed(result, "search");
+assertNoErrors(result);
+expect(result.toolCalls).toHaveLength(2);  // Vitest native
+```
+
+### What happens if a mock tool throws an error?
+
+The agent handles it like a real tool error. The error is captured in the events trace and you can assert on it:
+
+```typescript
+const errorEvents = result.events.filter(e => e.type === "error");
+expect(errorEvents.length).toBeGreaterThan(0);
+```
+
+### Can I use `CorrectnessEval` to judge mock results?
+
+Yes. `CorrectnessEval` takes any `AgentResult` — it doesn't care whether it came from `mockRun()` or a live server. This is useful for testing output quality of your mock tool responses, or for evaluating recorded fixtures.
+
+### How do I run only live eval tests in CI?
+
+Separate your test files and use Vitest's `--include` flag or file name conventions:
+
+```bash
+# Only mock tests
+npx vitest run examples/mock_tests/
+
+# Only live eval tests (put them in a separate directory)
+npx vitest run examples/eval_tests/
+```
+
+Or use `describe.skipIf` to skip live tests when env vars are missing:
+
+```typescript
+describe.skipIf(!process.env.OPENAI_API_KEY)("Live Evals", () => {
+  // ...
+});
+```

--- a/sdk/typescript/src/testing/assertions.ts
+++ b/sdk/typescript/src/testing/assertions.ts
@@ -1,94 +1,323 @@
-import type { AgentResult, Status } from '../types.js';
+// ── Composable assertion functions for agent correctness testing ──────
+//
+// Every function takes an AgentResult as its first argument and throws
+// an Error with a clear message on failure. They work identically whether
+// the result came from mockRun or a live runtime.run() call.
 
-/**
- * Assert that a specific tool was called during execution.
- * Throws if no `tool_call` event with the given toolName is found.
- */
-export function assertToolUsed(result: AgentResult, toolName: string): void {
-  const found = result.events.some(
-    (e) => e.type === 'tool_call' && e.toolName === toolName,
+import type { AgentResult, AgentEvent } from '../types.js';
+
+// ── Tool assertions ──────────────────────────────────────────────────
+
+export function assertToolUsed(result: AgentResult, name: string): void {
+  const names = (result.toolCalls as Array<{ name?: string }>).map(
+    (tc) => tc.name,
   );
-  if (!found) {
-    throw new Error(`Expected tool "${toolName}" to have been used`);
+  if (!names.includes(name)) {
+    throw new Error(
+      `Expected tool '${name}' to be used, but it was not.\nTools used: ${JSON.stringify(names)}`,
+    );
   }
 }
 
-/**
- * Assert that a guardrail passed during execution.
- * Throws if no `guardrail_pass` event with the given name is found.
- */
-export function assertGuardrailPassed(
+export function assertToolNotUsed(result: AgentResult, name: string): void {
+  const names = (result.toolCalls as Array<{ name?: string }>).map(
+    (tc) => tc.name,
+  );
+  if (names.includes(name)) {
+    const count = names.filter((n) => n === name).length;
+    throw new Error(
+      `Expected tool '${name}' NOT to be used, but it was called ${count} time(s).\nTools used: ${JSON.stringify(names)}`,
+    );
+  }
+}
+
+export function assertToolCalledWith(
   result: AgentResult,
   name: string,
+  args?: Record<string, unknown>,
 ): void {
-  const found = result.events.some(
-    (e) => e.type === 'guardrail_pass' && e.guardrailName === name,
+  const matching = (
+    result.toolCalls as Array<{ name?: string; args?: Record<string, unknown> }>
+  ).filter((tc) => tc.name === name);
+
+  if (matching.length === 0) {
+    const allNames = (result.toolCalls as Array<{ name?: string }>).map(
+      (tc) => tc.name,
+    );
+    throw new Error(
+      `Expected tool '${name}' to be called, but it was not.\nTools used: ${JSON.stringify(allNames)}`,
+    );
+  }
+
+  if (args == null) return;
+
+  for (const tc of matching) {
+    const tcArgs = tc.args ?? {};
+    if (Object.entries(args).every(([k, v]) => tcArgs[k] === v)) {
+      return;
+    }
+  }
+
+  throw new Error(
+    `Tool '${name}' was called but never with matching args.\n` +
+      `Expected (subset): ${JSON.stringify(args)}\n` +
+      `Actual calls: ${JSON.stringify(matching.map((tc) => tc.args))}`,
   );
-  if (!found) {
-    throw new Error(`Expected guardrail "${name}" to have passed`);
+}
+
+export function assertToolCallOrder(
+  result: AgentResult,
+  names: string[],
+): void {
+  const actual = (result.toolCalls as Array<{ name?: string }>).map(
+    (tc) => tc.name ?? '',
+  );
+  let idx = 0;
+  for (const toolName of actual) {
+    if (idx < names.length && toolName === names[idx]) {
+      idx++;
+    }
+  }
+  if (idx < names.length) {
+    throw new Error(
+      `Expected tool call order ${JSON.stringify(names)} (subsequence), ` +
+        `but only matched up to index ${idx} ('${names[idx]}').\n` +
+        `Actual tool calls: ${JSON.stringify(actual)}`,
+    );
   }
 }
 
-/**
- * Assert that a sub-agent ran during execution.
- * Checks events for done events with matching output, or subResults for the agent name.
- */
+export function assertToolsUsedExactly(
+  result: AgentResult,
+  names: string[],
+): void {
+  const actual = new Set(
+    (result.toolCalls as Array<{ name?: string }>).map((tc) => tc.name ?? ''),
+  );
+  const expected = new Set(names);
+
+  if (
+    actual.size !== expected.size ||
+    ![...actual].every((n) => expected.has(n))
+  ) {
+    const missing = [...expected].filter((n) => !actual.has(n));
+    const extra = [...actual].filter((n) => !expected.has(n));
+    const parts: string[] = [];
+    if (missing.length) parts.push(`missing: ${JSON.stringify(missing)}`);
+    if (extra.length) parts.push(`unexpected: ${JSON.stringify(extra)}`);
+    throw new Error(
+      `Expected exactly tools ${JSON.stringify([...expected].sort())}, ` +
+        `got ${JSON.stringify([...actual].sort())}.\n${parts.join('; ')}`,
+    );
+  }
+}
+
+// ── Output assertions ────────────────────────────────────────────────
+
+export function assertOutputContains(
+  result: AgentResult,
+  text: string,
+  opts?: { caseSensitive?: boolean },
+): void {
+  const caseSensitive = opts?.caseSensitive ?? true;
+  const output = JSON.stringify(result.output);
+  const haystack = caseSensitive ? output : output.toLowerCase();
+  const needle = caseSensitive ? text : text.toLowerCase();
+
+  if (!haystack.includes(needle)) {
+    const preview =
+      output.length > 200 ? output.slice(0, 200) + '...' : output;
+    throw new Error(
+      `Expected output to contain '${text}', but it does not.\nOutput: ${preview}`,
+    );
+  }
+}
+
+export function assertOutputMatches(
+  result: AgentResult,
+  pattern: string | RegExp,
+): void {
+  const output = JSON.stringify(result.output);
+  const re = typeof pattern === 'string' ? new RegExp(pattern) : pattern;
+
+  if (!re.test(output)) {
+    const preview =
+      output.length > 200 ? output.slice(0, 200) + '...' : output;
+    throw new Error(
+      `Expected output to match pattern '${pattern}', but it does not.\nOutput: ${preview}`,
+    );
+  }
+}
+
+export function assertOutputType(
+  result: AgentResult,
+  typeName: string,
+): void {
+  const actual = typeof result.output;
+  if (actual !== typeName) {
+    throw new Error(
+      `Expected output to be ${typeName}, got ${actual}: ${JSON.stringify(result.output)}`,
+    );
+  }
+}
+
+// ── Status assertions ────────────────────────────────────────────────
+
+export function assertStatus(result: AgentResult, status: string): void {
+  if (result.status !== status) {
+    throw new Error(
+      `Expected status '${status}', got '${result.status}'.`,
+    );
+  }
+}
+
+export function assertNoErrors(result: AgentResult): void {
+  const errors = result.events.filter((e) => e.type === 'error');
+  if (errors.length > 0) {
+    const messages = errors.map((e) => e.content ?? 'unknown error');
+    throw new Error(
+      `Expected no errors, but ${errors.length} error(s) occurred.\nError messages: ${JSON.stringify(messages)}`,
+    );
+  }
+}
+
+// ── Event assertions ─────────────────────────────────────────────────
+
+export function assertEventsContain(
+  result: AgentResult,
+  eventType: string,
+  opts?: { expected?: boolean; attrs?: Record<string, unknown> },
+): void {
+  const expected = opts?.expected ?? true;
+  const attrs = opts?.attrs ?? {};
+
+  const matching = result.events.filter(
+    (ev) =>
+      ev.type === eventType &&
+      Object.entries(attrs).every(
+        ([k, v]) => (ev as unknown as Record<string, unknown>)[k] === v,
+      ),
+  );
+
+  if (expected && matching.length === 0) {
+    const attrStr = Object.keys(attrs).length > 0
+      ? ` with ${JSON.stringify(attrs)}`
+      : '';
+    throw new Error(
+      `Expected event of type '${eventType}'${attrStr}, but none found.\n` +
+        `Event types present: ${JSON.stringify(result.events.map((ev) => ev.type))}`,
+    );
+  }
+  if (!expected && matching.length > 0) {
+    const attrStr = Object.keys(attrs).length > 0
+      ? ` with ${JSON.stringify(attrs)}`
+      : '';
+    throw new Error(
+      `Expected NO event of type '${eventType}'${attrStr}, but found ${matching.length}.`,
+    );
+  }
+}
+
+export function assertEventSequence(
+  result: AgentResult,
+  types: string[],
+): void {
+  const actualTypes = result.events.map((ev) => ev.type);
+  let idx = 0;
+  for (const evType of actualTypes) {
+    if (idx < types.length && evType === types[idx]) {
+      idx++;
+    }
+  }
+  if (idx < types.length) {
+    throw new Error(
+      `Expected event sequence ${JSON.stringify(types)} (subsequence), ` +
+        `but only matched up to index ${idx} ('${types[idx]}').\n` +
+        `Actual event types: ${JSON.stringify(actualTypes)}`,
+    );
+  }
+}
+
+// ── Multi-agent assertions ───────────────────────────────────────────
+
+export function assertHandoffTo(
+  result: AgentResult,
+  agentName: string,
+): void {
+  const handoffs = result.events.filter(
+    (ev) => ev.type === 'handoff' && ev.target === agentName,
+  );
+  if (handoffs.length === 0) {
+    const allHandoffs = result.events
+      .filter((ev) => ev.type === 'handoff')
+      .map((ev) => ev.target);
+    throw new Error(
+      `Expected handoff to '${agentName}', but none found.\n` +
+        `Handoffs that occurred: ${JSON.stringify(allHandoffs)}`,
+    );
+  }
+}
+
 export function assertAgentRan(
   result: AgentResult,
   agentName: string,
 ): void {
-  // Check subResults
-  if (result.subResults && agentName in result.subResults) {
-    return;
-  }
-
-  // Check events for agent-related activity
-  const found = result.events.some(
-    (e) =>
-      (e.type === 'done' &&
-        e.output != null &&
-        JSON.stringify(e.output).includes(agentName)) ||
-      (e.type === 'handoff' && e.target === agentName),
-  );
-  if (!found) {
-    throw new Error(`Expected agent "${agentName}" to have run`);
-  }
+  assertHandoffTo(result, agentName);
 }
 
-/**
- * Assert that a handoff to a target agent occurred.
- * Throws if no `handoff` event with the given target is found.
- */
-export function assertHandoffTo(
+// ── Guardrail assertions ─────────────────────────────────────────────
+
+export function assertGuardrailPassed(
   result: AgentResult,
-  target: string,
+  name: string,
 ): void {
-  const found = result.events.some(
-    (e) => e.type === 'handoff' && e.target === target,
+  const passing = result.events.filter(
+    (ev) => ev.type === 'guardrail_pass' && ev.guardrailName === name,
   );
-  if (!found) {
-    throw new Error(`Expected handoff to "${target}"`);
+  if (passing.length === 0) {
+    const allGuardrails = result.events
+      .filter(
+        (ev) =>
+          ev.type === 'guardrail_pass' || ev.type === 'guardrail_fail',
+      )
+      .map((ev) => [ev.type, ev.guardrailName]);
+    throw new Error(
+      `Expected guardrail '${name}' to pass, but no matching event found.\n` +
+        `Guardrail events: ${JSON.stringify(allGuardrails)}`,
+    );
   }
 }
 
-/**
- * Assert that the result has a specific status.
- */
-export function assertStatus(result: AgentResult, status: Status): void {
-  if (result.status !== status) {
-    throw new Error(`Expected status "${status}", got "${result.status}"`);
+export function assertGuardrailFailed(
+  result: AgentResult,
+  name: string,
+): void {
+  const failing = result.events.filter(
+    (ev) => ev.type === 'guardrail_fail' && ev.guardrailName === name,
+  );
+  if (failing.length === 0) {
+    const allGuardrails = result.events
+      .filter(
+        (ev) =>
+          ev.type === 'guardrail_pass' || ev.type === 'guardrail_fail',
+      )
+      .map((ev) => [ev.type, ev.guardrailName]);
+    throw new Error(
+      `Expected guardrail '${name}' to fail, but no matching event found.\n` +
+        `Guardrail events: ${JSON.stringify(allGuardrails)}`,
+    );
   }
 }
 
-/**
- * Assert that no error events occurred during execution.
- */
-export function assertNoErrors(result: AgentResult): void {
-  const errorEvents = result.events.filter((e) => e.type === 'error');
-  if (errorEvents.length > 0) {
-    const messages = errorEvents
-      .map((e) => e.content ?? 'unknown error')
-      .join('; ');
-    throw new Error(`Expected no errors, but found ${errorEvents.length}: ${messages}`);
+// ── Turn/iteration assertions ────────────────────────────────────────
+
+export function assertMaxTurns(result: AgentResult, n: number): void {
+  const turns = result.events.filter(
+    (ev) => ev.type === 'tool_call' || ev.type === 'done',
+  ).length;
+  if (turns > n) {
+    throw new Error(
+      `Expected at most ${n} turn(s), but the agent took ${turns}.`,
+    );
   }
 }

--- a/sdk/typescript/src/testing/capture.ts
+++ b/sdk/typescript/src/testing/capture.ts
@@ -1,0 +1,177 @@
+import type { AgentResult, AgentEvent, Status } from '../types.js';
+import type { Agent } from '../agent.js';
+import { mockRun } from './mock.js';
+import type { MockRunOptions } from './mock.js';
+
+/**
+ * Internal keys injected by the runtime that should not appear in
+ * captured tool arg expectations.
+ */
+const INTERNAL_ARG_KEYS = new Set([
+  '__agentspan_ctx__',
+  '_agent_state',
+  'method',
+]);
+
+/**
+ * An auto-generated eval case built from observed agent behavior.
+ *
+ * Use {@link evalCaseFromResult} or {@link captureEvalCase} to create one.
+ */
+export interface CapturedEvalCase {
+  /** Descriptive name (auto-generated from prompt if not provided). */
+  name: string;
+  /** The prompt that was sent to the agent. */
+  prompt: string;
+  /** Tools that were called. */
+  expectTools: string[] | null;
+  /** Tool arguments observed (internal runtime keys stripped). */
+  expectToolArgs: Record<string, Record<string, unknown>> | null;
+  /** Agent name that received the handoff (if any). */
+  expectHandoffTo: string | null;
+  /** Expected terminal status. */
+  expectStatus: Status;
+  /** Whether the run had zero error events. */
+  expectNoErrors: boolean;
+  /** Tags for filtering. */
+  tags: string[];
+}
+
+/**
+ * Turn a prompt into a slug suitable for a test name.
+ */
+function slugify(text: string, maxLen = 60): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+    .slice(0, maxLen)
+    .replace(/_$/, '');
+}
+
+/**
+ * Strip runtime-internal keys from a tool args object.
+ */
+function cleanArgs(
+  args: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const cleaned: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (!INTERNAL_ARG_KEYS.has(k)) {
+      cleaned[k] = v;
+    }
+  }
+  return Object.keys(cleaned).length > 0 ? cleaned : null;
+}
+
+/**
+ * Generate a {@link CapturedEvalCase} from an observed {@link AgentResult}.
+ *
+ * Inspects the result's tool calls, handoff events, and status to build
+ * expectations automatically — no manual case authoring needed.
+ *
+ * @example
+ * ```ts
+ * const result = await runtime.run(agent, "What's the weather in Tokyo?");
+ * const evalCase = evalCaseFromResult(result, {
+ *   prompt: "What's the weather in Tokyo?",
+ * });
+ * // evalCase.expectTools === ["get_weather"]
+ * // evalCase.expectToolArgs === { get_weather: { city: "Tokyo" } }
+ * ```
+ */
+export function evalCaseFromResult(
+  result: AgentResult,
+  options: {
+    prompt: string;
+    name?: string;
+    includeToolArgs?: boolean;
+    tags?: string[];
+  },
+): CapturedEvalCase {
+  const {
+    prompt,
+    name = slugify(prompt),
+    includeToolArgs = true,
+    tags = ['captured'],
+  } = options;
+
+  // Extract tools used
+  const toolNames: string[] = [];
+  const toolArgs: Record<string, Record<string, unknown>> = {};
+
+  for (const tc of result.toolCalls as Array<{
+    name?: string;
+    args?: Record<string, unknown>;
+  }>) {
+    const toolName = tc.name ?? '';
+    if (toolName && !toolNames.includes(toolName)) {
+      toolNames.push(toolName);
+    }
+    if (includeToolArgs && toolName && tc.args) {
+      const cleaned = cleanArgs(tc.args);
+      if (cleaned) {
+        toolArgs[toolName] = cleaned;
+      }
+    }
+  }
+
+  // Extract handoff target from events
+  let handoffTarget: string | null = null;
+  for (const ev of result.events) {
+    if (ev.type === 'handoff' && ev.target) {
+      handoffTarget = ev.target;
+      break;
+    }
+  }
+
+  // Check for errors
+  const hasErrors = result.events.some(
+    (ev: AgentEvent) => ev.type === 'error',
+  );
+
+  return {
+    name,
+    prompt,
+    expectTools: toolNames.length > 0 ? toolNames : null,
+    expectToolArgs: Object.keys(toolArgs).length > 0 ? toolArgs : null,
+    expectHandoffTo: handoffTarget,
+    expectStatus: result.status,
+    expectNoErrors: !hasErrors,
+    tags,
+  };
+}
+
+/**
+ * Run an agent via {@link mockRun} and auto-generate a
+ * {@link CapturedEvalCase} from the observed behavior.
+ *
+ * Returns both the generated case and the original result for inspection.
+ *
+ * @example
+ * ```ts
+ * const [evalCase, result] = await captureEvalCase(
+ *   agent,
+ *   "Check stock for AAPL",
+ * );
+ * // evalCase is ready to use as a regression baseline
+ * ```
+ */
+export async function captureEvalCase(
+  agent: Agent,
+  prompt: string,
+  options?: MockRunOptions & {
+    name?: string;
+    includeToolArgs?: boolean;
+    tags?: string[];
+  },
+): Promise<[CapturedEvalCase, AgentResult]> {
+  const result = await mockRun(agent, prompt, options);
+  const evalCase = evalCaseFromResult(result, {
+    prompt,
+    name: options?.name,
+    includeToolArgs: options?.includeToolArgs,
+    tags: options?.tags,
+  });
+  return [evalCase, result];
+}

--- a/sdk/typescript/src/testing/capture.ts
+++ b/sdk/typescript/src/testing/capture.ts
@@ -1,45 +1,15 @@
-import type { AgentResult, AgentEvent, Status } from '../types.js';
-import type { Agent } from '../agent.js';
-import { mockRun } from './mock.js';
-import type { MockRunOptions } from './mock.js';
+// ── Eval case capture — auto-generate EvalCase from observed results ──
 
-/**
- * Internal keys injected by the runtime that should not appear in
- * captured tool arg expectations.
- */
+import type { AgentResult, AgentEvent } from '../types.js';
+import type { Agent } from '../agent.js';
+import type { EvalCase, Runtime } from './eval.js';
+
 const INTERNAL_ARG_KEYS = new Set([
   '__agentspan_ctx__',
   '_agent_state',
   'method',
 ]);
 
-/**
- * An auto-generated eval case built from observed agent behavior.
- *
- * Use {@link evalCaseFromResult} or {@link captureEvalCase} to create one.
- */
-export interface CapturedEvalCase {
-  /** Descriptive name (auto-generated from prompt if not provided). */
-  name: string;
-  /** The prompt that was sent to the agent. */
-  prompt: string;
-  /** Tools that were called. */
-  expectTools: string[] | null;
-  /** Tool arguments observed (internal runtime keys stripped). */
-  expectToolArgs: Record<string, Record<string, unknown>> | null;
-  /** Agent name that received the handoff (if any). */
-  expectHandoffTo: string | null;
-  /** Expected terminal status. */
-  expectStatus: Status;
-  /** Whether the run had zero error events. */
-  expectNoErrors: boolean;
-  /** Tags for filtering. */
-  tags: string[];
-}
-
-/**
- * Turn a prompt into a slug suitable for a test name.
- */
 function slugify(text: string, maxLen = 60): string {
   return text
     .toLowerCase()
@@ -49,9 +19,6 @@ function slugify(text: string, maxLen = 60): string {
     .replace(/_$/, '');
 }
 
-/**
- * Strip runtime-internal keys from a tool args object.
- */
 function cleanArgs(
   args: Record<string, unknown>,
 ): Record<string, unknown> | null {
@@ -65,36 +32,28 @@ function cleanArgs(
 }
 
 /**
- * Generate a {@link CapturedEvalCase} from an observed {@link AgentResult}.
+ * Generate an EvalCase from an observed AgentResult.
  *
- * Inspects the result's tool calls, handoff events, and status to build
- * expectations automatically — no manual case authoring needed.
- *
- * @example
- * ```ts
- * const result = await runtime.run(agent, "What's the weather in Tokyo?");
- * const evalCase = evalCaseFromResult(result, {
- *   prompt: "What's the weather in Tokyo?",
- * });
- * // evalCase.expectTools === ["get_weather"]
- * // evalCase.expectToolArgs === { get_weather: { city: "Tokyo" } }
- * ```
+ * Inspects the result's tool calls, handoff events, status, and output
+ * to build expectations automatically.
  */
 export function evalCaseFromResult(
   result: AgentResult,
-  options: {
+  opts: {
+    agent: Agent;
     prompt: string;
     name?: string;
     includeToolArgs?: boolean;
     tags?: string[];
   },
-): CapturedEvalCase {
+): EvalCase {
   const {
+    agent,
     prompt,
     name = slugify(prompt),
     includeToolArgs = true,
     tags = ['captured'],
-  } = options;
+  } = opts;
 
   // Extract tools used
   const toolNames: string[] = [];
@@ -116,8 +75,8 @@ export function evalCaseFromResult(
     }
   }
 
-  // Extract handoff target from events
-  let handoffTarget: string | null = null;
+  // Extract handoff target
+  let handoffTarget: string | undefined;
   for (const ev of result.events) {
     if (ev.type === 'handoff' && ev.target) {
       handoffTarget = ev.target;
@@ -132,46 +91,41 @@ export function evalCaseFromResult(
 
   return {
     name,
+    agent,
     prompt,
-    expectTools: toolNames.length > 0 ? toolNames : null,
-    expectToolArgs: Object.keys(toolArgs).length > 0 ? toolArgs : null,
+    expectTools: toolNames.length > 0 ? toolNames : undefined,
+    expectToolArgs:
+      Object.keys(toolArgs).length > 0 ? toolArgs : undefined,
     expectHandoffTo: handoffTarget,
     expectStatus: result.status,
     expectNoErrors: !hasErrors,
+    validateOrchestration: true,
     tags,
   };
 }
 
 /**
- * Run an agent via {@link mockRun} and auto-generate a
- * {@link CapturedEvalCase} from the observed behavior.
+ * Run an agent and auto-generate an EvalCase from the result.
  *
  * Returns both the generated case and the original result for inspection.
- *
- * @example
- * ```ts
- * const [evalCase, result] = await captureEvalCase(
- *   agent,
- *   "Check stock for AAPL",
- * );
- * // evalCase is ready to use as a regression baseline
- * ```
  */
 export async function captureEvalCase(
+  runtime: Runtime,
   agent: Agent,
   prompt: string,
-  options?: MockRunOptions & {
+  opts?: {
     name?: string;
     includeToolArgs?: boolean;
     tags?: string[];
   },
-): Promise<[CapturedEvalCase, AgentResult]> {
-  const result = await mockRun(agent, prompt, options);
+): Promise<[EvalCase, AgentResult]> {
+  const result = await runtime.run(agent, prompt);
   const evalCase = evalCaseFromResult(result, {
+    agent,
     prompt,
-    name: options?.name,
-    includeToolArgs: options?.includeToolArgs,
-    tags: options?.tags,
+    name: opts?.name,
+    includeToolArgs: opts?.includeToolArgs,
+    tags: opts?.tags,
   });
   return [evalCase, result];
 }

--- a/sdk/typescript/src/testing/eval.ts
+++ b/sdk/typescript/src/testing/eval.ts
@@ -1,240 +1,304 @@
+// ── Eval runner — correctness testing for agent behavior ─────────────
+//
+// Runs real prompts through agents and evaluates whether the agent's
+// behavior matches expectations. Uses structural checks, not LLM judges.
+
 import type { AgentResult } from '../types.js';
+import type { Agent } from '../agent.js';
+import {
+  assertStatus,
+  assertNoErrors,
+  assertToolUsed,
+  assertToolNotUsed,
+  assertToolCalledWith,
+  assertHandoffTo,
+  assertOutputContains,
+  assertOutputMatches,
+} from './assertions.js';
+import { validateStrategy } from './strategy.js';
 
-/**
- * Result of an LLM-based correctness evaluation.
- */
-export interface EvalResult {
-  /** Whether the weighted average score meets the pass threshold. */
-  passed: boolean;
-  /** Per-rubric numeric scores (1-5 scale). */
-  scores: Record<string, number>;
-  /** Weighted average across all rubric scores. */
-  weightedAverage: number;
-  /** Per-rubric reasoning from the judge. */
-  reasoning: Record<string, string>;
-}
+// ── Types ────────────────────────────────────────────────────────────
 
-/**
- * A single rubric criterion for evaluation.
- */
-export interface Rubric {
+export interface EvalCase {
   name: string;
-  description: string;
-  weight?: number;
+  agent: Agent;
+  prompt: string;
+  expectTools?: string[];
+  expectToolsNotUsed?: string[];
+  expectToolArgs?: Record<string, Record<string, unknown>>;
+  expectHandoffTo?: string;
+  expectNoHandoffTo?: string[];
+  expectOutputContains?: string[];
+  expectOutputMatches?: string;
+  expectStatus?: string;
+  expectNoErrors?: boolean;
+  validateOrchestration?: boolean;
+  customAssertions?: Array<(result: AgentResult) => void>;
+  tags?: string[];
 }
 
-/**
- * Options for CorrectnessEval.evaluate().
- */
-export interface EvaluateOptions {
-  /** Rubric criteria to evaluate against. */
-  rubrics: Rubric[];
-  /** Minimum weighted average score to pass (default 3.5). */
-  passThreshold?: number;
+export interface EvalCheckResult {
+  check: string;
+  passed: boolean;
+  message: string;
 }
 
-/**
- * Options for constructing a CorrectnessEval.
- */
-export interface CorrectnessEvalOptions {
-  /** LLM model identifier for the judge. */
-  model: string;
-  /** Max chars of output to send to the judge (default 3000). */
-  maxOutputChars?: number;
-  /** Max tokens for judge response (default 300). */
-  maxTokens?: number;
-  /** Base URL for the LLM API endpoint. */
-  endpoint?: string;
-  /** API key for the LLM endpoint. */
-  apiKey?: string;
+export interface EvalCaseResult {
+  name: string;
+  passed: boolean;
+  checks: EvalCheckResult[];
+  result?: AgentResult;
+  error?: string;
+  tags: string[];
 }
 
-/**
- * LLM-based correctness evaluator.
- *
- * Constructs a prompt with rubric criteria and the agent's output,
- * sends it to an LLM judge, and parses the scores.
- */
-export class CorrectnessEval {
-  readonly model: string;
-  readonly maxOutputChars: number;
-  readonly maxTokens: number;
-  readonly endpoint: string;
-  readonly apiKey: string;
+export interface EvalSuiteResult {
+  cases: EvalCaseResult[];
+  allPassed: boolean;
+  passCount: number;
+  failCount: number;
+  total: number;
+  failedCases(): EvalCaseResult[];
+  printSummary(): void;
+}
 
-  constructor(options: CorrectnessEvalOptions) {
-    this.model = options.model;
-    this.maxOutputChars = options.maxOutputChars ?? 3000;
-    this.maxTokens = options.maxTokens ?? 300;
-    this.endpoint =
-      options.endpoint ?? 'https://api.openai.com/v1/chat/completions';
-    this.apiKey = options.apiKey ?? '';
-  }
+export interface Runtime {
+  run(agent: Agent, prompt: string): Promise<AgentResult>;
+}
 
-  /**
-   * Build the judge prompt from rubrics and agent output.
-   */
-  buildPrompt(result: AgentResult, rubrics: Rubric[]): string {
-    const outputStr = JSON.stringify(result.output).slice(
-      0,
-      this.maxOutputChars,
-    );
-    const rubricLines = rubrics
-      .map(
-        (r, i) =>
-          `${i + 1}. ${r.name} (weight: ${r.weight ?? 1}): ${r.description}`,
-      )
-      .join('\n');
+// ── Helpers ──────────────────────────────────────────────────────────
 
-    return `You are an AI judge evaluating an agent's output quality.
-
-## Agent Output
-${outputStr}
-
-## Agent Status
-Status: ${result.status}
-Finish Reason: ${result.finishReason}
-Tool Calls: ${result.toolCalls.length}
-Events: ${result.events.length}
-
-## Rubrics
-Score each rubric on a 1-5 scale (1=poor, 5=excellent):
-${rubricLines}
-
-## Response Format
-Respond ONLY with valid JSON in this exact format:
-{
-  "scores": { "rubric_name": <number>, ... },
-  "reasoning": { "rubric_name": "<explanation>", ... }
-}`;
-  }
-
-  /**
-   * Evaluate an agent result against rubric criteria.
-   *
-   * Calls an LLM endpoint to judge the output quality.
-   * Falls back to a default passing result if the endpoint is unavailable.
-   */
-  async evaluate(
-    result: AgentResult,
-    options: EvaluateOptions,
-  ): Promise<EvalResult> {
-    const { rubrics, passThreshold = 3.5 } = options;
-    const prompt = this.buildPrompt(result, rubrics);
-
-    try {
-      const response = await fetch(this.endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
-        },
-        body: JSON.stringify({
-          model: this.model,
-          messages: [{ role: 'user', content: prompt }],
-          max_tokens: this.maxTokens,
-          temperature: 0,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`Judge API returned ${response.status}`);
-      }
-
-      const data = (await response.json()) as {
-        choices?: Array<{ message?: { content?: string } }>;
-      };
-      const content = data.choices?.[0]?.message?.content ?? '';
-      return this.parseResponse(content, rubrics, passThreshold);
-    } catch {
-      // If the LLM call fails, return a default result with mid-range scores
-      return this.defaultResult(rubrics, passThreshold);
-    }
-  }
-
-  /**
-   * Parse the LLM judge response into an EvalResult.
-   */
-  private parseResponse(
-    content: string,
-    rubrics: Rubric[],
-    passThreshold: number,
-  ): EvalResult {
-    try {
-      // Try to extract JSON from the response
-      const jsonMatch = content.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
-        return this.defaultResult(rubrics, passThreshold);
-      }
-
-      const parsed = JSON.parse(jsonMatch[0]) as {
-        scores?: Record<string, number>;
-        reasoning?: Record<string, string>;
-      };
-
-      const scores: Record<string, number> = {};
-      const reasoning: Record<string, string> = {};
-
-      for (const r of rubrics) {
-        scores[r.name] = parsed.scores?.[r.name] ?? 3;
-        reasoning[r.name] = parsed.reasoning?.[r.name] ?? '';
-      }
-
-      const weightedAverage = this.computeWeightedAverage(scores, rubrics);
-
-      return {
-        passed: weightedAverage >= passThreshold,
-        scores,
-        weightedAverage,
-        reasoning,
-      };
-    } catch {
-      return this.defaultResult(rubrics, passThreshold);
-    }
-  }
-
-  /**
-   * Compute weighted average of scores.
-   */
-  private computeWeightedAverage(
-    scores: Record<string, number>,
-    rubrics: Rubric[],
-  ): number {
-    let totalWeight = 0;
-    let weightedSum = 0;
-
-    for (const r of rubrics) {
-      const weight = r.weight ?? 1;
-      const score = scores[r.name] ?? 0;
-      totalWeight += weight;
-      weightedSum += score * weight;
-    }
-
-    return totalWeight > 0 ? weightedSum / totalWeight : 0;
-  }
-
-  /**
-   * Create a default result when the LLM judge is unavailable.
-   */
-  private defaultResult(
-    rubrics: Rubric[],
-    passThreshold: number,
-  ): EvalResult {
-    const scores: Record<string, number> = {};
-    const reasoning: Record<string, string> = {};
-
-    for (const r of rubrics) {
-      scores[r.name] = 3;
-      reasoning[r.name] = 'Default score (judge unavailable)';
-    }
-
-    const weightedAverage = this.computeWeightedAverage(scores, rubrics);
-
+function check(
+  name: string,
+  fn: () => void,
+): EvalCheckResult {
+  try {
+    fn();
+    return { check: name, passed: true, message: '' };
+  } catch (err) {
     return {
-      passed: weightedAverage >= passThreshold,
-      scores,
-      weightedAverage,
-      reasoning,
+      check: name,
+      passed: false,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function assertNoHandoff(result: AgentResult, agentName: string): void {
+  const handoffs = result.events.filter(
+    (ev) => ev.type === 'handoff' && ev.target === agentName,
+  );
+  if (handoffs.length > 0) {
+    throw new Error(
+      `Expected NO handoff to '${agentName}', but ${handoffs.length} occurred.`,
+    );
+  }
+}
+
+function makeSuiteResult(cases: EvalCaseResult[]): EvalSuiteResult {
+  return {
+    cases,
+    get allPassed() {
+      return cases.every((c) => c.passed);
+    },
+    get passCount() {
+      return cases.filter((c) => c.passed).length;
+    },
+    get failCount() {
+      return cases.filter((c) => !c.passed).length;
+    },
+    get total() {
+      return cases.length;
+    },
+    failedCases() {
+      return cases.filter((c) => !c.passed);
+    },
+    printSummary() {
+      const width = 60;
+      console.log(`\n${'='.repeat(width)}`);
+      console.log(' Agent Correctness Eval Results');
+      console.log(`${'='.repeat(width)}`);
+
+      for (const c of cases) {
+        const icon = c.passed ? 'PASS' : 'FAIL';
+        console.log(`\n  [${icon}] ${c.name}`);
+        if (!c.passed) {
+          for (const ch of c.checks) {
+            if (!ch.passed) {
+              console.log(`         x ${ch.check}: ${ch.message}`);
+            }
+          }
+          if (c.error) {
+            console.log(`         x Error: ${c.error}`);
+          }
+        }
+      }
+
+      const passCount = cases.filter((c) => c.passed).length;
+      const failCount = cases.filter((c) => !c.passed).length;
+      console.log(`\n${'─'.repeat(width)}`);
+      console.log(`  ${passCount}/${cases.length} passed, ${failCount} failed`);
+      console.log(`${'='.repeat(width)}\n`);
+    },
+  };
+}
+
+// ── CorrectnessEval ──────────────────────────────────────────────────
+
+export class CorrectnessEval {
+  private readonly runtime: Runtime;
+
+  constructor(runtime: Runtime) {
+    this.runtime = runtime;
+  }
+
+  async run(
+    cases: EvalCase[],
+    opts?: { tags?: string[] },
+  ): Promise<EvalSuiteResult> {
+    const results: EvalCaseResult[] = [];
+
+    for (const evalCase of cases) {
+      if (
+        opts?.tags &&
+        opts.tags.length > 0 &&
+        !(evalCase.tags ?? []).some((t) => opts.tags!.includes(t))
+      ) {
+        continue;
+      }
+      const caseResult = await this.runCase(evalCase);
+      results.push(caseResult);
+    }
+
+    return makeSuiteResult(results);
+  }
+
+  private async runCase(evalCase: EvalCase): Promise<EvalCaseResult> {
+    const checks: EvalCheckResult[] = [];
+    let agentResult: AgentResult | undefined;
+
+    try {
+      agentResult = await this.runtime.run(evalCase.agent, evalCase.prompt);
+    } catch (err) {
+      return {
+        name: evalCase.name,
+        passed: false,
+        checks: [],
+        error: `Agent execution failed: ${err}`,
+        tags: evalCase.tags ?? [],
+      };
+    }
+
+    // Status check
+    const expectStatus = evalCase.expectStatus ?? 'COMPLETED';
+    checks.push(
+      check('status', () => assertStatus(agentResult!, expectStatus)),
+    );
+
+    // No errors
+    if (evalCase.expectNoErrors !== false) {
+      checks.push(
+        check('no_errors', () => assertNoErrors(agentResult!)),
+      );
+    }
+
+    // Tool expectations
+    if (evalCase.expectTools) {
+      for (const toolName of evalCase.expectTools) {
+        checks.push(
+          check(`tool_used:${toolName}`, () =>
+            assertToolUsed(agentResult!, toolName),
+          ),
+        );
+      }
+    }
+
+    if (evalCase.expectToolsNotUsed) {
+      for (const toolName of evalCase.expectToolsNotUsed) {
+        checks.push(
+          check(`tool_not_used:${toolName}`, () =>
+            assertToolNotUsed(agentResult!, toolName),
+          ),
+        );
+      }
+    }
+
+    if (evalCase.expectToolArgs) {
+      for (const [toolName, args] of Object.entries(evalCase.expectToolArgs)) {
+        checks.push(
+          check(`tool_args:${toolName}`, () =>
+            assertToolCalledWith(agentResult!, toolName, args),
+          ),
+        );
+      }
+    }
+
+    // Handoff expectations
+    if (evalCase.expectHandoffTo) {
+      checks.push(
+        check(`handoff_to:${evalCase.expectHandoffTo}`, () =>
+          assertHandoffTo(agentResult!, evalCase.expectHandoffTo!),
+        ),
+      );
+    }
+
+    if (evalCase.expectNoHandoffTo) {
+      for (const agentName of evalCase.expectNoHandoffTo) {
+        checks.push(
+          check(`no_handoff_to:${agentName}`, () =>
+            assertNoHandoff(agentResult!, agentName),
+          ),
+        );
+      }
+    }
+
+    // Output expectations
+    if (evalCase.expectOutputContains) {
+      for (const text of evalCase.expectOutputContains) {
+        checks.push(
+          check(`output_contains:'${text}'`, () =>
+            assertOutputContains(agentResult!, text, {
+              caseSensitive: false,
+            }),
+          ),
+        );
+      }
+    }
+
+    if (evalCase.expectOutputMatches) {
+      checks.push(
+        check(`output_matches:'${evalCase.expectOutputMatches}'`, () =>
+          assertOutputMatches(agentResult!, evalCase.expectOutputMatches!),
+        ),
+      );
+    }
+
+    // Strategy validation
+    if (evalCase.validateOrchestration !== false) {
+      checks.push(
+        check('strategy_validation', () =>
+          validateStrategy(evalCase.agent, agentResult!),
+        ),
+      );
+    }
+
+    // Custom assertions
+    if (evalCase.customAssertions) {
+      for (let i = 0; i < evalCase.customAssertions.length; i++) {
+        const fn = evalCase.customAssertions[i];
+        checks.push(
+          check(`custom_${i}`, () => fn(agentResult!)),
+        );
+      }
+    }
+
+    const passed = checks.every((c) => c.passed);
+    return {
+      name: evalCase.name,
+      passed,
+      checks,
+      result: agentResult,
+      tags: evalCase.tags ?? [],
     };
   }
 }

--- a/sdk/typescript/src/testing/expect.ts
+++ b/sdk/typescript/src/testing/expect.ts
@@ -1,94 +1,156 @@
-import type { AgentResult } from '../types.js';
+// ── Fluent assertion API for agent results ───────────────────────────
+//
+// Provides a chainable interface wrapping the assertion functions.
+//
+// Usage:
+//   expect(result).completed().usedTool('search').outputContains('answer');
 
-/**
- * Fluent assertion interface returned by expectResult().
- * Each method returns `this` for chaining.
- */
-export interface ResultExpectation {
-  toBeCompleted(): ResultExpectation;
-  toBeFailed(): ResultExpectation;
-  toContainOutput(text: string): ResultExpectation;
-  toHaveUsedTool(toolName: string): ResultExpectation;
-  toHavePassedGuardrail(name: string): ResultExpectation;
-  toHaveFinishReason(reason: string): ResultExpectation;
-  toHaveTokenUsageBelow(max: number): ResultExpectation;
+import type { AgentResult } from '../types.js';
+import {
+  assertToolUsed,
+  assertToolNotUsed,
+  assertToolCalledWith,
+  assertToolCallOrder,
+  assertToolsUsedExactly,
+  assertOutputContains,
+  assertOutputMatches,
+  assertOutputType,
+  assertStatus,
+  assertNoErrors,
+  assertEventsContain,
+  assertEventSequence,
+  assertHandoffTo,
+  assertAgentRan,
+  assertGuardrailPassed,
+  assertGuardrailFailed,
+  assertMaxTurns,
+} from './assertions.js';
+
+export class AgentResultExpectation {
+  private readonly result: AgentResult;
+
+  constructor(result: AgentResult) {
+    this.result = result;
+  }
+
+  // ── Status ───────────────────────────────────────────────
+
+  completed(): this {
+    assertStatus(this.result, 'COMPLETED');
+    return this;
+  }
+
+  failed(): this {
+    assertStatus(this.result, 'FAILED');
+    return this;
+  }
+
+  status(s: string): this {
+    assertStatus(this.result, s);
+    return this;
+  }
+
+  noErrors(): this {
+    assertNoErrors(this.result);
+    return this;
+  }
+
+  // ── Tools ────────────────────────────────────────────────
+
+  usedTool(
+    name: string,
+    opts?: { args?: Record<string, unknown> },
+  ): this {
+    if (opts?.args) {
+      assertToolCalledWith(this.result, name, opts.args);
+    } else {
+      assertToolUsed(this.result, name);
+    }
+    return this;
+  }
+
+  didNotUseTool(name: string): this {
+    assertToolNotUsed(this.result, name);
+    return this;
+  }
+
+  toolCallOrder(names: string[]): this {
+    assertToolCallOrder(this.result, names);
+    return this;
+  }
+
+  toolsUsedExactly(names: string[]): this {
+    assertToolsUsedExactly(this.result, names);
+    return this;
+  }
+
+  // ── Output ───────────────────────────────────────────────
+
+  outputContains(
+    text: string,
+    opts?: { caseSensitive?: boolean },
+  ): this {
+    assertOutputContains(this.result, text, opts);
+    return this;
+  }
+
+  outputMatches(pattern: string | RegExp): this {
+    assertOutputMatches(this.result, pattern);
+    return this;
+  }
+
+  outputType(typeName: string): this {
+    assertOutputType(this.result, typeName);
+    return this;
+  }
+
+  // ── Events ───────────────────────────────────────────────
+
+  eventsContain(
+    eventType: string,
+    opts?: { expected?: boolean },
+  ): this {
+    assertEventsContain(this.result, eventType, opts);
+    return this;
+  }
+
+  eventSequence(types: string[]): this {
+    assertEventSequence(this.result, types);
+    return this;
+  }
+
+  // ── Multi-agent ──────────────────────────────────────────
+
+  handoffTo(agentName: string): this {
+    assertHandoffTo(this.result, agentName);
+    return this;
+  }
+
+  agentRan(agentName: string): this {
+    assertAgentRan(this.result, agentName);
+    return this;
+  }
+
+  // ── Guardrails ───────────────────────────────────────────
+
+  guardrailPassed(name: string): this {
+    assertGuardrailPassed(this.result, name);
+    return this;
+  }
+
+  guardrailFailed(name: string): this {
+    assertGuardrailFailed(this.result, name);
+    return this;
+  }
+
+  // ── Budget ───────────────────────────────────────────────
+
+  maxTurns(n: number): this {
+    assertMaxTurns(this.result, n);
+    return this;
+  }
 }
 
-/**
- * Create a fluent assertion chain for an AgentResult.
- *
- * ```ts
- * expectResult(result)
- *   .toBeCompleted()
- *   .toHaveUsedTool('search')
- *   .toContainOutput('answer');
- * ```
- */
-export function expectResult(result: AgentResult): ResultExpectation {
-  const chain: ResultExpectation = {
-    toBeCompleted() {
-      if (result.status !== 'COMPLETED') {
-        throw new Error(
-          `Expected COMPLETED, got ${result.status}: ${result.error}`,
-        );
-      }
-      return chain;
-    },
-
-    toBeFailed() {
-      if (result.status === 'COMPLETED') {
-        throw new Error('Expected failed status');
-      }
-      return chain;
-    },
-
-    toContainOutput(text: string) {
-      if (!JSON.stringify(result.output).includes(text)) {
-        throw new Error(`Output does not contain "${text}"`);
-      }
-      return chain;
-    },
-
-    toHaveUsedTool(toolName: string) {
-      if (
-        !result.events.some(
-          (e) => e.type === 'tool_call' && e.toolName === toolName,
-        )
-      ) {
-        throw new Error(`Tool "${toolName}" was not used`);
-      }
-      return chain;
-    },
-
-    toHavePassedGuardrail(name: string) {
-      if (
-        !result.events.some(
-          (e) => e.type === 'guardrail_pass' && e.guardrailName === name,
-        )
-      ) {
-        throw new Error(`Guardrail "${name}" did not pass`);
-      }
-      return chain;
-    },
-
-    toHaveFinishReason(reason: string) {
-      if (result.finishReason !== reason) {
-        throw new Error(
-          `Expected finish reason "${reason}", got "${result.finishReason}"`,
-        );
-      }
-      return chain;
-    },
-
-    toHaveTokenUsageBelow(max: number) {
-      if (result.tokenUsage && result.tokenUsage.totalTokens > max) {
-        throw new Error(
-          `Token usage ${result.tokenUsage.totalTokens} exceeds ${max}`,
-        );
-      }
-      return chain;
-    },
-  };
-
-  return chain;
+export function expect(result: AgentResult): AgentResultExpectation {
+  return new AgentResultExpectation(result);
 }

--- a/sdk/typescript/src/testing/index.ts
+++ b/sdk/typescript/src/testing/index.ts
@@ -33,3 +33,7 @@ export { validateStrategy } from './strategy.js';
 // Record / replay
 export type { RecordingFixture, RecordOptions } from './recording.js';
 export { record, replay } from './recording.js';
+
+// Eval case capture
+export type { CapturedEvalCase } from './capture.js';
+export { evalCaseFromResult, captureEvalCase } from './capture.js';

--- a/sdk/typescript/src/testing/index.ts
+++ b/sdk/typescript/src/testing/index.ts
@@ -1,39 +1,58 @@
 // ── Testing framework for @agentspan-ai/sdk ────────────────
 
 // Mock execution
+export { MockEvent, mockRun } from './mock.js';
 export type { MockRunOptions } from './mock.js';
-export { mockRun } from './mock.js';
 
-// Fluent assertions
-export type { ResultExpectation } from './expect.js';
-export { expectResult } from './expect.js';
-
-// Individual assertion functions
+// Assertions (17)
 export {
   assertToolUsed,
-  assertGuardrailPassed,
-  assertAgentRan,
-  assertHandoffTo,
+  assertToolNotUsed,
+  assertToolCalledWith,
+  assertToolCallOrder,
+  assertToolsUsedExactly,
+  assertOutputContains,
+  assertOutputMatches,
+  assertOutputType,
   assertStatus,
   assertNoErrors,
+  assertEventsContain,
+  assertEventSequence,
+  assertHandoffTo,
+  assertAgentRan,
+  assertGuardrailPassed,
+  assertGuardrailFailed,
+  assertMaxTurns,
 } from './assertions.js';
 
-// LLM-based evaluation
+// Fluent API
+export { expect, AgentResultExpectation } from './expect.js';
+
+// Strategy validators
+export {
+  validateStrategy,
+  validateSequential,
+  validateParallel,
+  validateRoundRobin,
+  validateRouter,
+  validateHandoff,
+  validateSwarm,
+  validateConstrainedTransitions,
+  StrategyViolation,
+} from './strategy.js';
+
+// Eval runner
 export type {
-  EvalResult,
-  Rubric,
-  EvaluateOptions,
-  CorrectnessEvalOptions,
+  EvalCase,
+  EvalCheckResult,
+  EvalCaseResult,
+  EvalSuiteResult,
+  Runtime,
 } from './eval.js';
 export { CorrectnessEval } from './eval.js';
 
-// Strategy validation
-export { validateStrategy } from './strategy.js';
-
 // Record / replay
-export type { RecordingFixture, RecordOptions } from './recording.js';
 export { record, replay } from './recording.js';
 
 // Eval case capture
-export type { CapturedEvalCase } from './capture.js';
 export { evalCaseFromResult, captureEvalCase } from './capture.js';

--- a/sdk/typescript/src/testing/mock.ts
+++ b/sdk/typescript/src/testing/mock.ts
@@ -1,186 +1,176 @@
-import type { AgentResult, AgentEvent } from '../types.js';
-import { Agent } from '../agent.js';
+// ── Mock execution — deterministic agent testing without LLM or server ──
+//
+// Provides MockEvent (a factory for AgentEvent objects) and mockRun which
+// builds an AgentResult from a scripted event sequence.
+
+import type { AgentEvent, AgentResult } from '../types.js';
+import type { Agent } from '../agent.js';
 import { makeAgentResult } from '../result.js';
-import { getToolDef } from '../tool.js';
-import { ConfigurationError } from '../errors.js';
+
+// ── MockEvent factory ────────────────────────────────────────────────
 
 /**
- * Options for mockRun.
+ * Factory for creating AgentEvent instances in tests.
+ *
+ * Each static method returns a properly-typed AgentEvent with the correct
+ * `type` field set. Use these to script event sequences for `mockRun`.
  */
+export class MockEvent {
+  static thinking(content: string): AgentEvent {
+    return { type: 'thinking', content };
+  }
+
+  static toolCall(name: string, args?: Record<string, unknown>): AgentEvent {
+    return { type: 'tool_call', toolName: name, args: args ?? {} };
+  }
+
+  static toolResult(name: string, result: unknown): AgentEvent {
+    return { type: 'tool_result', toolName: name, result };
+  }
+
+  static handoff(target: string): AgentEvent {
+    return { type: 'handoff', target };
+  }
+
+  static message(content: string): AgentEvent {
+    return { type: 'message', content };
+  }
+
+  static guardrailPass(name: string, content: string = ''): AgentEvent {
+    return { type: 'guardrail_pass', guardrailName: name, content };
+  }
+
+  static guardrailFail(name: string, content: string = ''): AgentEvent {
+    return { type: 'guardrail_fail', guardrailName: name, content };
+  }
+
+  static waiting(content: string = ''): AgentEvent {
+    return { type: 'waiting', content };
+  }
+
+  static done(output: unknown): AgentEvent {
+    return { type: 'done', output };
+  }
+
+  static error(content: string): AgentEvent {
+    return { type: 'error', content };
+  }
+}
+
+// ── Tool resolution helper ───────────────────────────────────────────
+
+function resolveToolFunc(
+  agent: Agent,
+  toolName: string,
+): ((...args: unknown[]) => unknown) | null {
+  if (!agent.tools || agent.tools.length === 0) return null;
+
+  for (const t of agent.tools) {
+    // Handle objects with name + func (ToolDef-like)
+    const def = t as { name?: string; func?: Function };
+    if (def.name === toolName && typeof def.func === 'function') {
+      return def.func as (...args: unknown[]) => unknown;
+    }
+    // Handle plain functions with a name property
+    if (typeof t === 'function' && (t as Function).name === toolName) {
+      return t as (...args: unknown[]) => unknown;
+    }
+  }
+  return null;
+}
+
+// ── mockRun ──────────────────────────────────────────────────────────
+
 export interface MockRunOptions {
-  /** Override tool implementations by name. */
-  mockTools?: Record<string, Function>;
-  /** Mock credentials injected into tool context. */
-  mockCredentials?: Record<string, string>;
-  /** Optional session ID. */
-  sessionId?: string;
+  events: AgentEvent[];
+  autoExecuteTools?: boolean;
 }
 
 /**
- * Execute tools for a single agent, collecting events and toolCalls.
- */
-async function executeTools(
-  agent: Agent,
-  options: MockRunOptions | undefined,
-  events: AgentEvent[],
-  toolCalls: Array<{ name: string; args: unknown; result: unknown }>,
-): Promise<void> {
-  const tools = agent.tools ?? [];
-  for (const t of tools) {
-    let def;
-    try {
-      def = getToolDef(t);
-    } catch {
-      continue;
-    }
-    if (!def) continue;
-
-    const mockFn = options?.mockTools?.[def.name];
-    const fn = mockFn ?? def.func;
-    if (!fn) continue;
-
-    const args = {};
-    events.push({ type: 'tool_call', toolName: def.name, args });
-    try {
-      const result = await fn(args);
-      events.push({ type: 'tool_result', toolName: def.name, result });
-      toolCalls.push({ name: def.name, args, result });
-    } catch (err) {
-      events.push({ type: 'error', content: String(err) });
-    }
-  }
-}
-
-/**
- * Recursively simulate a sub-agent, collecting events into the parent arrays.
- */
-async function simulateSubAgent(
-  sub: Agent,
-  options: MockRunOptions | undefined,
-  events: AgentEvent[],
-  toolCalls: Array<{ name: string; args: unknown; result: unknown }>,
-): Promise<string> {
-  // Execute this sub-agent's own tools
-  await executeTools(sub, options, events, toolCalls);
-
-  // Recurse into nested sub-agents
-  if (sub.agents && sub.agents.length > 0) {
-    await simulateSubAgents(sub, options, events, toolCalls);
-  }
-
-  const output = `Mock output from ${sub.name}`;
-  events.push({
-    type: 'done',
-    output: { result: output },
-  });
-  return output;
-}
-
-/**
- * Simulate sub-agent orchestration based on strategy.
- */
-async function simulateSubAgents(
-  agent: Agent,
-  options: MockRunOptions | undefined,
-  events: AgentEvent[],
-  toolCalls: Array<{ name: string; args: unknown; result: unknown }>,
-): Promise<Record<string, unknown>> {
-  const subResults: Record<string, unknown> = {};
-  const strategy = agent.strategy ?? 'handoff';
-  const subs = agent.agents ?? [];
-
-  if (subs.length === 0) return subResults;
-
-  switch (strategy) {
-    case 'handoff':
-    case 'router': {
-      // Simulate handoff to the first sub-agent
-      const target = subs[0];
-      events.push({ type: 'handoff', target: target.name });
-      const output = await simulateSubAgent(target, options, events, toolCalls);
-      subResults[target.name] = output;
-      break;
-    }
-
-    case 'sequential': {
-      // Run all sub-agents in order
-      for (const sub of subs) {
-        events.push({ type: 'handoff', target: sub.name });
-        const output = await simulateSubAgent(sub, options, events, toolCalls);
-        subResults[sub.name] = output;
-      }
-      break;
-    }
-
-    case 'parallel': {
-      // Run all sub-agents (simulated concurrently)
-      const promises = subs.map(async (sub) => {
-        events.push({ type: 'handoff', target: sub.name });
-        const output = await simulateSubAgent(sub, options, events, toolCalls);
-        subResults[sub.name] = output;
-      });
-      await Promise.all(promises);
-      break;
-    }
-
-    default: {
-      // For unknown strategies, hand off to first
-      if (subs.length > 0) {
-        const target = subs[0];
-        events.push({ type: 'handoff', target: target.name });
-        const output = await simulateSubAgent(target, options, events, toolCalls);
-        subResults[target.name] = output;
-      }
-    }
-  }
-
-  return subResults;
-}
-
-/**
- * Execute an agent locally without a server connection.
+ * Build an AgentResult from a scripted event sequence.
  *
- * Walks agent.tools, attempts to extract a ToolDef for each,
- * executes each tool once with empty args (or via mockTools override),
- * collects events/toolCalls, and returns a completed AgentResult.
+ * This function does NOT call any LLM or server. It walks the provided
+ * events, optionally executes real tool functions when a tool_call is
+ * encountered, and assembles the result.
  *
- * For multi-agent setups, recursively simulates sub-agents based on the
- * declared strategy, producing handoff and done events for each.
- *
- * This is a TESTING utility — it does not run a real LLM loop.
+ * @param agent - The Agent definition (used to resolve tool functions).
+ * @param prompt - The user prompt (stored in messages for context).
+ * @param options - Events to replay and execution options.
  */
-export async function mockRun(
+export function mockRun(
   agent: Agent,
   prompt: string,
-  options?: MockRunOptions,
-): Promise<AgentResult> {
-  const events: AgentEvent[] = [];
-  const toolCalls: Array<{ name: string; args: unknown; result: unknown }> = [];
-  let subResults: Record<string, unknown> = {};
+  options: MockRunOptions,
+): AgentResult {
+  const { events, autoExecuteTools = true } = options;
 
-  // Execute this agent's own tools
-  await executeTools(agent, options, events, toolCalls);
+  const processed: AgentEvent[] = [];
+  const toolCalls: Array<{ name: string; args: unknown; result?: unknown }> = [];
+  let output: unknown = undefined;
+  let status = 'COMPLETED';
+  let pendingCall: { name: string; args: unknown; result?: unknown } | null =
+    null;
 
-  // Simulate sub-agent orchestration
-  if (agent.agents && agent.agents.length > 0) {
-    subResults = await simulateSubAgents(agent, options, events, toolCalls);
+  for (const ev of events) {
+    processed.push(ev);
+
+    if (ev.type === 'tool_call') {
+      pendingCall = { name: ev.toolName ?? '', args: ev.args };
+
+      if (autoExecuteTools) {
+        const func = resolveToolFunc(agent, ev.toolName ?? '');
+        if (func !== null) {
+          let toolResult: unknown;
+          try {
+            toolResult = func(ev.args ?? {});
+          } catch (err) {
+            toolResult = `Error: ${err}`;
+          }
+          const resultEvent: AgentEvent = {
+            type: 'tool_result',
+            toolName: ev.toolName,
+            result: toolResult,
+          };
+          processed.push(resultEvent);
+          pendingCall.result = toolResult;
+          toolCalls.push(pendingCall);
+          pendingCall = null;
+        }
+      }
+    } else if (ev.type === 'tool_result') {
+      if (pendingCall !== null) {
+        pendingCall.result = ev.result;
+        toolCalls.push(pendingCall);
+        pendingCall = null;
+      } else {
+        toolCalls.push({ name: ev.toolName ?? '', args: ev.args, result: ev.result });
+      }
+    } else if (ev.type === 'done') {
+      output = ev.output;
+    } else if (ev.type === 'error') {
+      output = ev.content;
+      status = 'FAILED';
+    }
   }
 
-  events.push({
-    type: 'done',
-    output: { result: `Mock execution of ${agent.name}` },
-  });
+  // Flush any pending tool call without result
+  if (pendingCall !== null) {
+    toolCalls.push(pendingCall);
+  }
+
+  const messages: Array<{ role: string; content: unknown }> = [
+    { role: 'user', content: prompt },
+  ];
+  if (output !== undefined) {
+    messages.push({ role: 'assistant', content: String(output) });
+  }
 
   return makeAgentResult({
-    executionId: 'mock-' + Date.now(),
-    output: {
-      result: `Mock execution of ${agent.name} with prompt: ${prompt}`,
-    },
-    status: 'COMPLETED',
-    finishReason: 'stop',
-    events,
+    executionId: 'mock',
+    output,
+    status,
+    events: processed,
     toolCalls,
-    messages: [{ role: 'user', content: prompt }],
-    subResults,
+    messages,
   });
 }

--- a/sdk/typescript/src/testing/mock.ts
+++ b/sdk/typescript/src/testing/mock.ts
@@ -17,30 +17,20 @@ export interface MockRunOptions {
 }
 
 /**
- * Execute an agent locally without a server connection.
- *
- * Walks agent.tools, attempts to extract a ToolDef for each,
- * executes each tool once with empty args (or via mockTools override),
- * collects events/toolCalls, and returns a completed AgentResult.
- *
- * This is a TESTING utility — it does not run a real LLM loop.
+ * Execute tools for a single agent, collecting events and toolCalls.
  */
-export async function mockRun(
+async function executeTools(
   agent: Agent,
-  prompt: string,
-  options?: MockRunOptions,
-): Promise<AgentResult> {
-  const events: AgentEvent[] = [];
-  const toolCalls: Array<{ name: string; args: unknown; result: unknown }> = [];
-
-  // Simulate tool execution
+  options: MockRunOptions | undefined,
+  events: AgentEvent[],
+  toolCalls: Array<{ name: string; args: unknown; result: unknown }>,
+): Promise<void> {
   const tools = agent.tools ?? [];
   for (const t of tools) {
     let def;
     try {
       def = getToolDef(t);
     } catch {
-      // Skip unrecognized tool formats
       continue;
     }
     if (!def) continue;
@@ -59,6 +49,122 @@ export async function mockRun(
       events.push({ type: 'error', content: String(err) });
     }
   }
+}
+
+/**
+ * Recursively simulate a sub-agent, collecting events into the parent arrays.
+ */
+async function simulateSubAgent(
+  sub: Agent,
+  options: MockRunOptions | undefined,
+  events: AgentEvent[],
+  toolCalls: Array<{ name: string; args: unknown; result: unknown }>,
+): Promise<string> {
+  // Execute this sub-agent's own tools
+  await executeTools(sub, options, events, toolCalls);
+
+  // Recurse into nested sub-agents
+  if (sub.agents && sub.agents.length > 0) {
+    await simulateSubAgents(sub, options, events, toolCalls);
+  }
+
+  const output = `Mock output from ${sub.name}`;
+  events.push({
+    type: 'done',
+    output: { result: output },
+  });
+  return output;
+}
+
+/**
+ * Simulate sub-agent orchestration based on strategy.
+ */
+async function simulateSubAgents(
+  agent: Agent,
+  options: MockRunOptions | undefined,
+  events: AgentEvent[],
+  toolCalls: Array<{ name: string; args: unknown; result: unknown }>,
+): Promise<Record<string, unknown>> {
+  const subResults: Record<string, unknown> = {};
+  const strategy = agent.strategy ?? 'handoff';
+  const subs = agent.agents ?? [];
+
+  if (subs.length === 0) return subResults;
+
+  switch (strategy) {
+    case 'handoff':
+    case 'router': {
+      // Simulate handoff to the first sub-agent
+      const target = subs[0];
+      events.push({ type: 'handoff', target: target.name });
+      const output = await simulateSubAgent(target, options, events, toolCalls);
+      subResults[target.name] = output;
+      break;
+    }
+
+    case 'sequential': {
+      // Run all sub-agents in order
+      for (const sub of subs) {
+        events.push({ type: 'handoff', target: sub.name });
+        const output = await simulateSubAgent(sub, options, events, toolCalls);
+        subResults[sub.name] = output;
+      }
+      break;
+    }
+
+    case 'parallel': {
+      // Run all sub-agents (simulated concurrently)
+      const promises = subs.map(async (sub) => {
+        events.push({ type: 'handoff', target: sub.name });
+        const output = await simulateSubAgent(sub, options, events, toolCalls);
+        subResults[sub.name] = output;
+      });
+      await Promise.all(promises);
+      break;
+    }
+
+    default: {
+      // For unknown strategies, hand off to first
+      if (subs.length > 0) {
+        const target = subs[0];
+        events.push({ type: 'handoff', target: target.name });
+        const output = await simulateSubAgent(target, options, events, toolCalls);
+        subResults[target.name] = output;
+      }
+    }
+  }
+
+  return subResults;
+}
+
+/**
+ * Execute an agent locally without a server connection.
+ *
+ * Walks agent.tools, attempts to extract a ToolDef for each,
+ * executes each tool once with empty args (or via mockTools override),
+ * collects events/toolCalls, and returns a completed AgentResult.
+ *
+ * For multi-agent setups, recursively simulates sub-agents based on the
+ * declared strategy, producing handoff and done events for each.
+ *
+ * This is a TESTING utility — it does not run a real LLM loop.
+ */
+export async function mockRun(
+  agent: Agent,
+  prompt: string,
+  options?: MockRunOptions,
+): Promise<AgentResult> {
+  const events: AgentEvent[] = [];
+  const toolCalls: Array<{ name: string; args: unknown; result: unknown }> = [];
+  let subResults: Record<string, unknown> = {};
+
+  // Execute this agent's own tools
+  await executeTools(agent, options, events, toolCalls);
+
+  // Simulate sub-agent orchestration
+  if (agent.agents && agent.agents.length > 0) {
+    subResults = await simulateSubAgents(agent, options, events, toolCalls);
+  }
 
   events.push({
     type: 'done',
@@ -75,5 +181,6 @@ export async function mockRun(
     events,
     toolCalls,
     messages: [{ role: 'user', content: prompt }],
+    subResults,
   });
 }

--- a/sdk/typescript/src/testing/recording.ts
+++ b/sdk/typescript/src/testing/recording.ts
@@ -1,90 +1,115 @@
-import type { AgentResult, AgentEvent } from '../types.js';
-import { Agent } from '../agent.js';
+// ── Record and replay agent execution traces ─────────────────────────
+//
+// Usage:
+//   record(result, "tests/recordings/weather.json");
+//   const replayed = replay("tests/recordings/weather.json");
+
+import type { AgentResult, AgentEvent, TokenUsage } from '../types.js';
 import { makeAgentResult } from '../result.js';
-import { mockRun, type MockRunOptions } from './mock.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-/**
- * Fixture format stored on disk.
- */
-export interface RecordingFixture {
-  agent: { name: string; model?: string };
-  prompt: string;
-  events: AgentEvent[];
-  result: {
-    output: Record<string, unknown>;
-    executionId: string;
-    status: string;
-    finishReason: string;
-    error?: string;
-    toolCalls: unknown[];
-    messages: unknown[];
-  };
-  timestamp: number;
+// ── Serialization helpers ────────────────────────────────────────────
+
+function eventToDict(event: AgentEvent): Record<string, unknown> {
+  const d: Record<string, unknown> = { type: event.type };
+  if (event.content != null) d.content = event.content;
+  if (event.toolName != null) d.toolName = event.toolName;
+  if (event.args != null) d.args = event.args;
+  if (event.result !== undefined) d.result = event.result;
+  if (event.target != null) d.target = event.target;
+  if (event.output !== undefined) d.output = event.output;
+  if (event.executionId) d.executionId = event.executionId;
+  if (event.guardrailName != null) d.guardrailName = event.guardrailName;
+  if (event.timestamp != null) d.timestamp = event.timestamp;
+  return d;
 }
 
-/**
- * Options for recording an agent execution.
- */
-export interface RecordOptions extends MockRunOptions {
-  /** Path to write the JSON fixture file. */
-  fixturePath: string;
+function dictToEvent(d: Record<string, unknown>): AgentEvent {
+  return {
+    type: (d.type as string) ?? '',
+    content: d.content as string | undefined,
+    toolName: d.toolName as string | undefined,
+    args: d.args as Record<string, unknown> | undefined,
+    result: d.result,
+    target: d.target as string | undefined,
+    output: d.output,
+    executionId: d.executionId as string | undefined,
+    guardrailName: d.guardrailName as string | undefined,
+    timestamp: d.timestamp as number | undefined,
+  };
 }
 
-/**
- * Run an agent via mockRun, capture all events to a JSON fixture file, and return the result.
- */
-export async function record(
-  agent: Agent,
-  prompt: string,
-  options: RecordOptions,
-): Promise<AgentResult> {
-  const { fixturePath, ...mockOptions } = options;
-  const result = await mockRun(agent, prompt, mockOptions);
-
-  const fixture: RecordingFixture = {
-    agent: { name: agent.name, model: agent.model },
-    prompt,
-    events: result.events,
-    result: {
-      output: result.output,
-      executionId: result.executionId,
-      status: result.status,
-      finishReason: result.finishReason,
-      error: result.error,
-      toolCalls: result.toolCalls,
-      messages: result.messages,
-    },
-    timestamp: Date.now(),
+function resultToDict(result: AgentResult): Record<string, unknown> {
+  const d: Record<string, unknown> = {
+    output: result.output,
+    executionId: result.executionId,
+    messages: result.messages,
+    toolCalls: result.toolCalls,
+    status: result.status,
+    finishReason: result.finishReason,
+    metadata: result.metadata,
+    events: result.events.map(eventToDict),
   };
+  if (result.correlationId) d.correlationId = result.correlationId;
+  if (result.error) d.error = result.error;
+  if (result.tokenUsage) {
+    d.tokenUsage = {
+      promptTokens: result.tokenUsage.promptTokens,
+      completionTokens: result.tokenUsage.completionTokens,
+      totalTokens: result.tokenUsage.totalTokens,
+    };
+  }
+  if (result.subResults) d.subResults = result.subResults;
+  return d;
+}
 
-  // Ensure directory exists
-  const dir = path.dirname(fixturePath);
+function dictToResult(d: Record<string, unknown>): AgentResult {
+  let tokenUsage: TokenUsage | undefined;
+  if (d.tokenUsage) {
+    const tu = d.tokenUsage as Record<string, number>;
+    tokenUsage = {
+      promptTokens: tu.promptTokens ?? 0,
+      completionTokens: tu.completionTokens ?? 0,
+      totalTokens: tu.totalTokens ?? 0,
+    };
+  }
+
+  return makeAgentResult({
+    output: d.output,
+    executionId: d.executionId as string,
+    correlationId: d.correlationId as string | undefined,
+    messages: (d.messages as unknown[]) ?? [],
+    toolCalls: (d.toolCalls as unknown[]) ?? [],
+    status: d.status as string,
+    finishReason: d.finishReason as string,
+    error: d.error as string | undefined,
+    tokenUsage,
+    metadata: d.metadata as Record<string, unknown> | undefined,
+    events: ((d.events as Record<string, unknown>[]) ?? []).map(dictToEvent),
+    subResults: d.subResults as Record<string, unknown> | undefined,
+  });
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Save an AgentResult to a JSON file.
+ */
+export function record(result: AgentResult, filePath: string): void {
+  const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-
-  fs.writeFileSync(fixturePath, JSON.stringify(fixture, null, 2), 'utf-8');
-
-  return result;
+  const data = resultToDict(result);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
 }
 
 /**
- * Load a JSON fixture and reconstruct an AgentResult.
+ * Load a recorded AgentResult from a JSON file.
  */
-export function replay(fixturePath: string): AgentResult {
-  const content = fs.readFileSync(fixturePath, 'utf-8');
-  const fixture = JSON.parse(content) as RecordingFixture;
-
-  return makeAgentResult({
-    output: fixture.result.output,
-    executionId: fixture.result.executionId,
-    status: fixture.result.status,
-    finishReason: fixture.result.finishReason,
-    error: fixture.result.error,
-    events: fixture.events,
-    toolCalls: fixture.result.toolCalls,
-    messages: fixture.result.messages,
-  });
+export function replay(filePath: string): AgentResult {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const data = JSON.parse(content) as Record<string, unknown>;
+  return dictToResult(data);
 }

--- a/sdk/typescript/src/testing/strategy.ts
+++ b/sdk/typescript/src/testing/strategy.ts
@@ -1,14 +1,351 @@
-import type { Strategy } from '../types.js';
-import { Agent } from '../agent.js';
+// ── Strategy validators — verify that an execution trace obeys strategy rules ──
+//
+// These validators inspect an AgentResult and the Agent definition to verify
+// that the orchestration pattern was actually followed. Unlike simple assertions,
+// these validate the structural correctness of the entire execution trace.
 
-/**
- * Validate that an agent's strategy matches the expected value.
- * Throws if it does not match.
- */
-export function validateStrategy(agent: Agent, expected: Strategy): void {
-  if (agent.strategy !== expected) {
-    throw new Error(
-      `Expected strategy "${expected}", got "${agent.strategy}"`,
+import type { AgentResult, AgentEvent } from '../types.js';
+import type { Agent } from '../agent.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function getAgentNames(agent: Agent): string[] {
+  return (agent.agents ?? []).map((a) => a.name);
+}
+
+function getHandoffTargets(result: AgentResult): string[] {
+  return result.events
+    .filter((ev) => ev.type === 'handoff' && ev.target)
+    .map((ev) => ev.target!);
+}
+
+function getStrategy(agent: Agent): string {
+  return agent.strategy ?? 'handoff';
+}
+
+// ── StrategyViolation ────────────────────────────────────────────────
+
+export class StrategyViolation extends Error {
+  readonly strategy: string;
+  readonly violations: string[];
+
+  constructor(strategy: string, violations: string[]) {
+    const msg =
+      `Strategy '${strategy}' violations:\n` +
+      violations.map((v) => `  - ${v}`).join('\n');
+    super(msg);
+    this.name = 'StrategyViolation';
+    this.strategy = strategy;
+    this.violations = violations;
+  }
+}
+
+// ── Individual strategy validators ───────────────────────────────────
+
+export function validateSequential(agent: Agent, result: AgentResult): void {
+  const expected = getAgentNames(agent);
+  if (expected.length === 0) return;
+
+  const handoffs = getHandoffTargets(result);
+  const violations: string[] = [];
+
+  // Rule 1: All agents must appear
+  const missing = expected.filter((n) => !handoffs.includes(n));
+  if (missing.length > 0) {
+    violations.push(
+      `Agents skipped (never ran): ${JSON.stringify(missing.sort())}. Expected all of: ${JSON.stringify(expected)}`,
     );
+  }
+
+  // Rule 2: Order must match definition order
+  const expectedSet = new Set(expected);
+  const relevant = handoffs.filter((h) => expectedSet.has(h));
+  let idx = 0;
+  for (const h of relevant) {
+    if (idx < expected.length && h === expected[idx]) {
+      idx++;
+    }
+  }
+  if (idx < expected.length && missing.length === 0) {
+    violations.push(
+      `Agents executed out of order. Expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(relevant)}`,
+    );
+  }
+
+  // Rule 3: No agent should run more than once
+  const counts = new Map<string, number>();
+  for (const h of relevant) {
+    counts.set(h, (counts.get(h) ?? 0) + 1);
+  }
+  const duplicates: Record<string, number> = {};
+  for (const [name, cnt] of counts) {
+    if (cnt > 1) duplicates[name] = cnt;
+  }
+  if (Object.keys(duplicates).length > 0) {
+    violations.push(
+      `Agents executed multiple times (should be once each): ${JSON.stringify(duplicates)}`,
+    );
+  }
+
+  if (violations.length > 0) {
+    throw new StrategyViolation('sequential', violations);
+  }
+}
+
+export function validateParallel(agent: Agent, result: AgentResult): void {
+  const expected = new Set(getAgentNames(agent));
+  if (expected.size === 0) return;
+
+  const handoffs = new Set(getHandoffTargets(result));
+  const violations: string[] = [];
+
+  const missing = [...expected].filter((n) => !handoffs.has(n));
+  if (missing.length > 0) {
+    const ran = [...expected].filter((n) => handoffs.has(n));
+    violations.push(
+      `Agents never executed (skipped): ${JSON.stringify(missing.sort())}. ` +
+        `In parallel strategy ALL agents must run. ` +
+        `Expected: ${JSON.stringify([...expected].sort())}, ran: ${JSON.stringify(ran.sort())}`,
+    );
+  }
+
+  if (violations.length > 0) {
+    throw new StrategyViolation('parallel', violations);
+  }
+}
+
+export function validateRoundRobin(agent: Agent, result: AgentResult): void {
+  const expected = getAgentNames(agent);
+  if (expected.length === 0) return;
+
+  const handoffs = getHandoffTargets(result);
+  const maxTurns = agent.maxTurns ?? 25;
+  const violations: string[] = [];
+
+  // Rule 1: All agents must participate
+  const missing = expected.filter((n) => !handoffs.includes(n));
+  if (missing.length > 0) {
+    violations.push(
+      `Agents never got a turn: ${JSON.stringify(missing.sort())}. ` +
+        `All agents must participate in round-robin.`,
+    );
+  }
+
+  // Rule 2: Agents must follow the rotation pattern
+  const expectedSet = new Set(expected);
+  const relevant = handoffs.filter((h) => expectedSet.has(h));
+  const numAgents = expected.length;
+  for (let i = 0; i < relevant.length; i++) {
+    const expectedAgent = expected[i % numAgents];
+    if (relevant[i] !== expectedAgent) {
+      violations.push(
+        `Turn ${i}: expected '${expectedAgent}' but got '${relevant[i]}'. ` +
+          `Round-robin pattern broken. ` +
+          `Expected rotation: ${JSON.stringify(expected)}, actual sequence: ${JSON.stringify(relevant)}`,
+      );
+      break;
+    }
+  }
+
+  // Rule 3: No agent runs twice in a row
+  for (let i = 1; i < relevant.length; i++) {
+    if (relevant[i] === relevant[i - 1]) {
+      violations.push(
+        `Agent '${relevant[i]}' ran twice in a row at positions ` +
+          `${i - 1} and ${i}. Round-robin must alternate.`,
+      );
+      break;
+    }
+  }
+
+  // Rule 4: Turn count
+  if (relevant.length > maxTurns) {
+    violations.push(
+      `Exceeded max_turns: ${relevant.length} turns taken, limit is ${maxTurns}.`,
+    );
+  }
+
+  if (violations.length > 0) {
+    throw new StrategyViolation('round_robin', violations);
+  }
+}
+
+export function validateRouter(agent: Agent, result: AgentResult): void {
+  const expected = new Set(getAgentNames(agent));
+  if (expected.size === 0) return;
+
+  const handoffs = getHandoffTargets(result);
+  const relevant = handoffs.filter((h) => expected.has(h));
+  const violations: string[] = [];
+
+  // Rule 1: At least one agent must be selected
+  if (relevant.length === 0) {
+    violations.push(
+      `No sub-agent was selected by the router. ` +
+        `Available agents: ${JSON.stringify([...expected].sort())}, handoffs: ${JSON.stringify(handoffs)}`,
+    );
+  }
+
+  // Rule 2: Only ONE agent should handle the request
+  const uniqueAgents = new Set(relevant);
+  if (uniqueAgents.size > 1) {
+    violations.push(
+      `Router selected multiple agents: ${JSON.stringify([...uniqueAgents].sort())}. ` +
+        `Router strategy should route to exactly ONE specialist per request.`,
+    );
+  }
+
+  // Rule 3: Selected agent must be a valid sub-agent
+  const invalid = relevant.filter((h) => !expected.has(h));
+  if (invalid.length > 0) {
+    violations.push(
+      `Router selected unknown agent(s): ${JSON.stringify([...new Set(invalid)].sort())}. ` +
+        `Valid agents: ${JSON.stringify([...expected].sort())}`,
+    );
+  }
+
+  if (violations.length > 0) {
+    throw new StrategyViolation('router', violations);
+  }
+}
+
+export function validateHandoff(agent: Agent, result: AgentResult): void {
+  const expected = new Set(getAgentNames(agent));
+  if (expected.size === 0) return;
+
+  const handoffs = getHandoffTargets(result);
+  const relevant = handoffs.filter((h) => expected.has(h));
+  const violations: string[] = [];
+
+  if (relevant.length === 0) {
+    violations.push(
+      `No handoff to any sub-agent occurred. ` +
+        `Handoff strategy expects the parent to delegate to a specialist. ` +
+        `Available agents: ${JSON.stringify([...expected].sort())}`,
+    );
+  }
+
+  const invalid = handoffs.filter((h) => !expected.has(h));
+  if (invalid.length > 0 && relevant.length === 0) {
+    violations.push(
+      `Handoff targets not in sub-agents: ${JSON.stringify([...new Set(invalid)].sort())}. ` +
+        `Valid sub-agents: ${JSON.stringify([...expected].sort())}`,
+    );
+  }
+
+  if (violations.length > 0) {
+    throw new StrategyViolation('handoff', violations);
+  }
+}
+
+export function validateSwarm(agent: Agent, result: AgentResult): void {
+  const expected = new Set(getAgentNames(agent));
+  if (expected.size === 0) return;
+
+  const handoffs = getHandoffTargets(result);
+  const maxTurns = agent.maxTurns ?? 25;
+  const violations: string[] = [];
+
+  // Rule 1: At least one agent must handle
+  const relevant = handoffs.filter((h) => expected.has(h));
+  if (relevant.length === 0) {
+    violations.push(
+      `No agent handled the request. Available agents: ${JSON.stringify([...expected].sort())}`,
+    );
+  }
+
+  // Rule 2: All transfers must go to valid agents
+  const invalid = handoffs.filter((h) => !expected.has(h));
+  if (invalid.length > 0 && relevant.length === 0) {
+    violations.push(
+      `Transfer to unknown agent(s): ${JSON.stringify([...new Set(invalid)].sort())}. ` +
+        `Valid agents: ${JSON.stringify([...expected].sort())}`,
+    );
+  }
+
+  // Rule 3: Detect transfer loops
+  if (relevant.length >= 2) {
+    const pairCounts = new Map<string, number>();
+    for (let i = 0; i < relevant.length - 1; i++) {
+      const key = `${relevant[i]}->${relevant[i + 1]}`;
+      pairCounts.set(key, (pairCounts.get(key) ?? 0) + 1);
+    }
+    const loops: Record<string, number> = {};
+    for (const [pair, cnt] of pairCounts) {
+      if (cnt > 2) loops[pair] = cnt;
+    }
+    if (Object.keys(loops).length > 0) {
+      violations.push(
+        `Possible transfer loop detected: ${JSON.stringify(loops)}. ` +
+          `Same transfer pair repeated excessively.`,
+      );
+    }
+  }
+
+  // Rule 4: Total handoffs should not exceed max_turns
+  if (relevant.length > maxTurns) {
+    violations.push(
+      `Too many transfers: ${relevant.length}, max_turns=${maxTurns}. Possible infinite loop.`,
+    );
+  }
+
+  if (violations.length > 0) {
+    throw new StrategyViolation('swarm', violations);
+  }
+}
+
+export function validateConstrainedTransitions(
+  agent: Agent,
+  result: AgentResult,
+): void {
+  const allowed = agent.allowedTransitions;
+  if (!allowed) return;
+
+  const expectedAgents = new Set(getAgentNames(agent));
+  const handoffs = getHandoffTargets(result).filter((h) =>
+    expectedAgents.has(h),
+  );
+  const violations: string[] = [];
+
+  for (let i = 0; i < handoffs.length - 1; i++) {
+    const src = handoffs[i];
+    const dst = handoffs[i + 1];
+    const allowedNext = new Set(allowed[src] ?? []);
+    if (!allowedNext.has(dst)) {
+      violations.push(
+        `Invalid transition: '${src}' → '${dst}' at turn ${i}. ` +
+          `Allowed from '${src}': ${JSON.stringify([...allowedNext].sort())}`,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new StrategyViolation('constrained_transitions', violations);
+  }
+}
+
+// ── Dispatch ─────────────────────────────────────────────────────────
+
+const VALIDATORS: Record<
+  string,
+  (agent: Agent, result: AgentResult) => void
+> = {
+  sequential: validateSequential,
+  parallel: validateParallel,
+  round_robin: validateRoundRobin,
+  router: validateRouter,
+  handoff: validateHandoff,
+  swarm: validateSwarm,
+};
+
+export function validateStrategy(agent: Agent, result: AgentResult): void {
+  const strategy = getStrategy(agent);
+  const validator = VALIDATORS[strategy];
+  if (validator) {
+    validator(agent, result);
+  }
+
+  if (agent.allowedTransitions) {
+    validateConstrainedTransitions(agent, result);
   }
 }

--- a/sdk/typescript/tests/unit/testing/assertions.test.ts
+++ b/sdk/typescript/tests/unit/testing/assertions.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import {
   assertToolUsed,
-  assertGuardrailPassed,
-  assertAgentRan,
-  assertHandoffTo,
+  assertToolNotUsed,
+  assertToolCalledWith,
+  assertToolCallOrder,
+  assertToolsUsedExactly,
+  assertOutputContains,
+  assertOutputMatches,
+  assertOutputType,
   assertStatus,
   assertNoErrors,
+  assertEventsContain,
+  assertEventSequence,
+  assertHandoffTo,
+  assertAgentRan,
+  assertGuardrailPassed,
+  assertGuardrailFailed,
+  assertMaxTurns,
 } from '../../../src/testing/assertions.js';
 import { makeAgentResult } from '../../../src/result.js';
 import type { AgentEvent } from '../../../src/types.js';
@@ -15,99 +26,266 @@ import type { AgentEvent } from '../../../src/types.js';
 function makeResult(opts: {
   events?: AgentEvent[];
   status?: string;
-  subResults?: Record<string, unknown>;
+  output?: unknown;
+  toolCalls?: unknown[];
 }) {
   return makeAgentResult({
     executionId: 'wf-test',
     status: opts.status ?? 'COMPLETED',
     events: opts.events ?? [],
-    subResults: opts.subResults,
+    output: opts.output,
+    toolCalls: opts.toolCalls,
   });
 }
 
-// ── assertToolUsed ───────────────────────────────────────
+// ── Tool assertions ──────────────────────────────────────
 
 describe('assertToolUsed', () => {
-  it('passes when tool_call event exists for the tool', () => {
+  it('passes when tool was used', () => {
     const result = makeResult({
-      events: [{ type: 'tool_call', toolName: 'search' }],
+      toolCalls: [{ name: 'search', args: {} }],
     });
     expect(() => assertToolUsed(result, 'search')).not.toThrow();
   });
 
   it('throws when tool was not used', () => {
-    const result = makeResult({ events: [] });
-    expect(() => assertToolUsed(result, 'search')).toThrow(
-      /Expected tool "search" to have been used/,
-    );
-  });
-
-  it('throws when a different tool was used', () => {
-    const result = makeResult({
-      events: [{ type: 'tool_call', toolName: 'fetch' }],
-    });
-    expect(() => assertToolUsed(result, 'search')).toThrow(
-      /Expected tool "search" to have been used/,
-    );
+    const result = makeResult({ toolCalls: [] });
+    expect(() => assertToolUsed(result, 'search')).toThrow(/search/);
   });
 });
 
-// ── assertGuardrailPassed ────────────────────────────────
-
-describe('assertGuardrailPassed', () => {
-  it('passes when guardrail_pass event exists', () => {
-    const result = makeResult({
-      events: [{ type: 'guardrail_pass', guardrailName: 'no_pii' }],
-    });
-    expect(() => assertGuardrailPassed(result, 'no_pii')).not.toThrow();
+describe('assertToolNotUsed', () => {
+  it('passes when tool was not used', () => {
+    const result = makeResult({ toolCalls: [] });
+    expect(() => assertToolNotUsed(result, 'search')).not.toThrow();
   });
 
-  it('throws when guardrail did not pass', () => {
-    const result = makeResult({ events: [] });
-    expect(() => assertGuardrailPassed(result, 'no_pii')).toThrow(
-      /Expected guardrail "no_pii" to have passed/,
-    );
+  it('throws when tool was used', () => {
+    const result = makeResult({
+      toolCalls: [{ name: 'search', args: {} }],
+    });
+    expect(() => assertToolNotUsed(result, 'search')).toThrow(/search/);
   });
 });
 
-// ── assertAgentRan ───────────────────────────────────────
-
-describe('assertAgentRan', () => {
-  it('passes when agent is in subResults', () => {
+describe('assertToolCalledWith', () => {
+  it('passes with matching args (subset)', () => {
     const result = makeResult({
-      subResults: { child_agent: { result: 'done' } },
+      toolCalls: [{ name: 'search', args: { q: 'test', limit: 10 } }],
     });
-    expect(() => assertAgentRan(result, 'child_agent')).not.toThrow();
+    expect(() =>
+      assertToolCalledWith(result, 'search', { q: 'test' }),
+    ).not.toThrow();
   });
 
-  it('passes when done event mentions agent name', () => {
+  it('throws when args do not match', () => {
     const result = makeResult({
-      events: [
-        {
-          type: 'done',
-          output: { result: 'Mock execution of child_agent' },
-        },
+      toolCalls: [{ name: 'search', args: { q: 'other' } }],
+    });
+    expect(() =>
+      assertToolCalledWith(result, 'search', { q: 'test' }),
+    ).toThrow(/never with matching args/);
+  });
+
+  it('throws when tool not found', () => {
+    const result = makeResult({ toolCalls: [] });
+    expect(() =>
+      assertToolCalledWith(result, 'search', { q: 'test' }),
+    ).toThrow(/to be called, but it was not/);
+  });
+
+  it('passes when args is null', () => {
+    const result = makeResult({
+      toolCalls: [{ name: 'search', args: {} }],
+    });
+    expect(() => assertToolCalledWith(result, 'search')).not.toThrow();
+  });
+});
+
+describe('assertToolCallOrder', () => {
+  it('passes when tools appear in subsequence order', () => {
+    const result = makeResult({
+      toolCalls: [
+        { name: 'search' },
+        { name: 'filter' },
+        { name: 'format' },
       ],
     });
-    expect(() => assertAgentRan(result, 'child_agent')).not.toThrow();
+    expect(() =>
+      assertToolCallOrder(result, ['search', 'format']),
+    ).not.toThrow();
   });
 
-  it('passes when handoff event targets agent', () => {
+  it('throws when order is violated', () => {
     const result = makeResult({
-      events: [{ type: 'handoff', target: 'child_agent' }],
+      toolCalls: [{ name: 'format' }, { name: 'search' }],
     });
-    expect(() => assertAgentRan(result, 'child_agent')).not.toThrow();
-  });
-
-  it('throws when agent did not run', () => {
-    const result = makeResult({ events: [] });
-    expect(() => assertAgentRan(result, 'child_agent')).toThrow(
-      /Expected agent "child_agent" to have run/,
-    );
+    expect(() =>
+      assertToolCallOrder(result, ['search', 'format']),
+    ).toThrow(/only matched up to/);
   });
 });
 
-// ── assertHandoffTo ──────────────────────────────────────
+describe('assertToolsUsedExactly', () => {
+  it('passes when exact set matches', () => {
+    const result = makeResult({
+      toolCalls: [{ name: 'search' }, { name: 'format' }],
+    });
+    expect(() =>
+      assertToolsUsedExactly(result, ['format', 'search']),
+    ).not.toThrow();
+  });
+
+  it('throws when sets differ', () => {
+    const result = makeResult({
+      toolCalls: [{ name: 'search' }],
+    });
+    expect(() =>
+      assertToolsUsedExactly(result, ['search', 'format']),
+    ).toThrow(/missing/);
+  });
+});
+
+// ── Output assertions ────────────────────────────────────
+
+describe('assertOutputContains', () => {
+  it('passes when output contains text', () => {
+    const result = makeResult({ output: { result: 'Hello World' } });
+    expect(() => assertOutputContains(result, 'Hello')).not.toThrow();
+  });
+
+  it('throws when output does not contain text', () => {
+    const result = makeResult({ output: { result: 'Goodbye' } });
+    expect(() => assertOutputContains(result, 'Hello')).toThrow(/Hello/);
+  });
+
+  it('respects caseSensitive flag', () => {
+    const result = makeResult({ output: { result: 'Hello World' } });
+    expect(() =>
+      assertOutputContains(result, 'hello', { caseSensitive: false }),
+    ).not.toThrow();
+  });
+});
+
+describe('assertOutputMatches', () => {
+  it('passes when pattern matches', () => {
+    const result = makeResult({ output: { result: 'order #123' } });
+    expect(() =>
+      assertOutputMatches(result, /order #\d+/),
+    ).not.toThrow();
+  });
+
+  it('throws when pattern does not match', () => {
+    const result = makeResult({ output: { result: 'no numbers' } });
+    expect(() => assertOutputMatches(result, /\d+/)).toThrow(/does not/);
+  });
+
+  it('accepts string pattern', () => {
+    const result = makeResult({ output: { result: 'hello world' } });
+    expect(() => assertOutputMatches(result, 'hello')).not.toThrow();
+  });
+});
+
+describe('assertOutputType', () => {
+  it('passes when type matches', () => {
+    const result = makeResult({ output: { result: 'test' } });
+    expect(() => assertOutputType(result, 'object')).not.toThrow();
+  });
+
+  it('throws when type does not match', () => {
+    const result = makeResult({ output: { result: 'test' } });
+    expect(() => assertOutputType(result, 'string')).toThrow(/object/);
+  });
+});
+
+// ── Status assertions ────────────────────────────────────
+
+describe('assertStatus', () => {
+  it('passes when status matches', () => {
+    const result = makeResult({ status: 'COMPLETED' });
+    expect(() => assertStatus(result, 'COMPLETED')).not.toThrow();
+  });
+
+  it('throws when status does not match', () => {
+    const result = makeResult({ status: 'COMPLETED' });
+    expect(() => assertStatus(result, 'FAILED')).toThrow(/FAILED.*COMPLETED/);
+  });
+});
+
+describe('assertNoErrors', () => {
+  it('passes when no errors', () => {
+    const result = makeResult({ events: [{ type: 'done' }] });
+    expect(() => assertNoErrors(result)).not.toThrow();
+  });
+
+  it('throws when errors exist', () => {
+    const result = makeResult({
+      events: [{ type: 'error', content: 'boom' }],
+    });
+    expect(() => assertNoErrors(result)).toThrow(/1 error/);
+  });
+});
+
+// ── Event assertions ─────────────────────────────────────
+
+describe('assertEventsContain', () => {
+  it('passes when event type exists', () => {
+    const result = makeResult({
+      events: [{ type: 'thinking', content: 'hmm' }],
+    });
+    expect(() => assertEventsContain(result, 'thinking')).not.toThrow();
+  });
+
+  it('throws when event type missing', () => {
+    const result = makeResult({ events: [] });
+    expect(() => assertEventsContain(result, 'thinking')).toThrow(
+      /none found/,
+    );
+  });
+
+  it('supports expected=false (negation)', () => {
+    const result = makeResult({ events: [] });
+    expect(() =>
+      assertEventsContain(result, 'error', { expected: false }),
+    ).not.toThrow();
+  });
+
+  it('throws on expected=false when event exists', () => {
+    const result = makeResult({
+      events: [{ type: 'error', content: 'x' }],
+    });
+    expect(() =>
+      assertEventsContain(result, 'error', { expected: false }),
+    ).toThrow(/NO event/);
+  });
+});
+
+describe('assertEventSequence', () => {
+  it('passes when types appear in subsequence', () => {
+    const result = makeResult({
+      events: [
+        { type: 'thinking' },
+        { type: 'tool_call', toolName: 'x' },
+        { type: 'tool_result', toolName: 'x' },
+        { type: 'done' },
+      ],
+    });
+    expect(() =>
+      assertEventSequence(result, ['thinking', 'tool_call', 'done']),
+    ).not.toThrow();
+  });
+
+  it('throws when sequence not found', () => {
+    const result = makeResult({
+      events: [{ type: 'done' }, { type: 'thinking' }],
+    });
+    expect(() =>
+      assertEventSequence(result, ['thinking', 'done']),
+    ).toThrow(/only matched/);
+  });
+});
+
+// ── Multi-agent assertions ───────────────────────────────
 
 describe('assertHandoffTo', () => {
   it('passes when handoff event targets the agent', () => {
@@ -120,89 +298,77 @@ describe('assertHandoffTo', () => {
   it('throws when no handoff to target', () => {
     const result = makeResult({ events: [] });
     expect(() => assertHandoffTo(result, 'specialist')).toThrow(
-      /Expected handoff to "specialist"/,
+      /specialist/,
     );
   });
+});
 
-  it('throws when handoff to different target', () => {
+describe('assertAgentRan', () => {
+  it('passes when handoff event targets agent (delegates to assertHandoffTo)', () => {
     const result = makeResult({
-      events: [{ type: 'handoff', target: 'other' }],
+      events: [{ type: 'handoff', target: 'child' }],
     });
-    expect(() => assertHandoffTo(result, 'specialist')).toThrow(
-      /Expected handoff to "specialist"/,
-    );
+    expect(() => assertAgentRan(result, 'child')).not.toThrow();
+  });
+
+  it('throws when agent did not run', () => {
+    const result = makeResult({ events: [] });
+    expect(() => assertAgentRan(result, 'child')).toThrow(/child/);
   });
 });
 
-// ── assertStatus ─────────────────────────────────────────
+// ── Guardrail assertions ─────────────────────────────────
 
-describe('assertStatus', () => {
-  it('passes when status matches', () => {
-    const result = makeResult({ status: 'COMPLETED' });
-    expect(() => assertStatus(result, 'COMPLETED')).not.toThrow();
+describe('assertGuardrailPassed', () => {
+  it('passes when guardrail_pass event exists', () => {
+    const result = makeResult({
+      events: [{ type: 'guardrail_pass', guardrailName: 'no_pii' }],
+    });
+    expect(() => assertGuardrailPassed(result, 'no_pii')).not.toThrow();
   });
 
-  it('throws when status does not match', () => {
-    const result = makeResult({ status: 'COMPLETED' });
-    expect(() => assertStatus(result, 'FAILED')).toThrow(
-      /Expected status "FAILED", got "COMPLETED"/,
-    );
-  });
-
-  it('works for FAILED status', () => {
-    const result = makeResult({ status: 'FAILED' });
-    expect(() => assertStatus(result, 'FAILED')).not.toThrow();
-  });
-
-  it('works for TIMED_OUT status', () => {
-    const result = makeResult({ status: 'TIMED_OUT' });
-    expect(() => assertStatus(result, 'TIMED_OUT')).not.toThrow();
+  it('throws when guardrail did not pass', () => {
+    const result = makeResult({ events: [] });
+    expect(() => assertGuardrailPassed(result, 'no_pii')).toThrow(/no_pii/);
   });
 });
 
-// ── assertNoErrors ───────────────────────────────────────
+describe('assertGuardrailFailed', () => {
+  it('passes when guardrail_fail event exists', () => {
+    const result = makeResult({
+      events: [{ type: 'guardrail_fail', guardrailName: 'no_pii' }],
+    });
+    expect(() => assertGuardrailFailed(result, 'no_pii')).not.toThrow();
+  });
 
-describe('assertNoErrors', () => {
-  it('passes when no error events exist', () => {
+  it('throws when guardrail did not fail', () => {
+    const result = makeResult({ events: [] });
+    expect(() => assertGuardrailFailed(result, 'no_pii')).toThrow(/no_pii/);
+  });
+});
+
+// ── Turn assertions ──────────────────────────────────────
+
+describe('assertMaxTurns', () => {
+  it('passes when turns are within limit', () => {
     const result = makeResult({
       events: [
-        { type: 'tool_call', toolName: 'search' },
+        { type: 'tool_call', toolName: 'x' },
         { type: 'done' },
       ],
     });
-    expect(() => assertNoErrors(result)).not.toThrow();
+    expect(() => assertMaxTurns(result, 5)).not.toThrow();
   });
 
-  it('passes for empty events', () => {
-    const result = makeResult({ events: [] });
-    expect(() => assertNoErrors(result)).not.toThrow();
-  });
-
-  it('throws when error events exist', () => {
-    const result = makeResult({
-      events: [{ type: 'error', content: 'something broke' }],
-    });
-    expect(() => assertNoErrors(result)).toThrow(
-      /Expected no errors, but found 1/,
-    );
-  });
-
-  it('includes error content in message', () => {
-    const result = makeResult({
-      events: [{ type: 'error', content: 'disk full' }],
-    });
-    expect(() => assertNoErrors(result)).toThrow(/disk full/);
-  });
-
-  it('reports count of multiple errors', () => {
+  it('throws when turns exceed limit', () => {
     const result = makeResult({
       events: [
-        { type: 'error', content: 'err1' },
-        { type: 'error', content: 'err2' },
+        { type: 'tool_call', toolName: 'a' },
+        { type: 'tool_call', toolName: 'b' },
+        { type: 'tool_call', toolName: 'c' },
+        { type: 'done' },
       ],
     });
-    expect(() => assertNoErrors(result)).toThrow(
-      /Expected no errors, but found 2/,
-    );
+    expect(() => assertMaxTurns(result, 2)).toThrow(/4/);
   });
 });

--- a/sdk/typescript/tests/unit/testing/expect.test.ts
+++ b/sdk/typescript/tests/unit/testing/expect.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { expectResult } from '../../../src/testing/expect.js';
+import { describe, it, expect as vitestExpect } from 'vitest';
+import {
+  expect as agentExpect,
+  AgentResultExpectation,
+} from '../../../src/testing/expect.js';
 import { makeAgentResult } from '../../../src/result.js';
 import type { AgentEvent } from '../../../src/types.js';
 
@@ -7,8 +10,8 @@ import type { AgentEvent } from '../../../src/types.js';
 
 function completedResult(extras?: {
   events?: AgentEvent[];
-  output?: Record<string, unknown>;
-  tokenUsage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+  output?: unknown;
+  toolCalls?: unknown[];
 }) {
   return makeAgentResult({
     executionId: 'wf-test',
@@ -16,7 +19,7 @@ function completedResult(extras?: {
     finishReason: 'stop',
     output: extras?.output ?? { result: 'done' },
     events: extras?.events ?? [],
-    tokenUsage: extras?.tokenUsage,
+    toolCalls: extras?.toolCalls,
   });
 }
 
@@ -31,138 +34,215 @@ function failedResult(error?: string) {
 
 // ── Tests ────────────────────────────────────────────────
 
-describe('expectResult', () => {
-  describe('toBeCompleted', () => {
-    it('passes for COMPLETED result', () => {
-      expect(() => expectResult(completedResult()).toBeCompleted()).not.toThrow();
-    });
-
-    it('throws for FAILED result', () => {
-      expect(() => expectResult(failedResult()).toBeCompleted()).toThrow(
-        /Expected COMPLETED, got FAILED/,
-      );
-    });
-
-    it('includes error message in thrown error', () => {
-      expect(() =>
-        expectResult(failedResult('timeout')).toBeCompleted(),
-      ).toThrow(/timeout/);
-    });
+describe('expect (fluent API)', () => {
+  it('returns an AgentResultExpectation', () => {
+    const e = agentExpect(completedResult());
+    vitestExpect(e).toBeInstanceOf(AgentResultExpectation);
   });
 
-  describe('toBeFailed', () => {
-    it('passes for FAILED result', () => {
-      expect(() => expectResult(failedResult()).toBeFailed()).not.toThrow();
-    });
-
-    it('throws for COMPLETED result', () => {
-      expect(() => expectResult(completedResult()).toBeFailed()).toThrow(
-        /Expected failed status/,
-      );
-    });
-  });
-
-  describe('toContainOutput', () => {
-    it('passes when output contains text', () => {
-      const result = completedResult({ output: { result: 'Hello World' } });
-      expect(() => expectResult(result).toContainOutput('Hello')).not.toThrow();
-    });
-
-    it('throws when output does not contain text', () => {
-      const result = completedResult({ output: { result: 'Goodbye' } });
-      expect(() => expectResult(result).toContainOutput('Hello')).toThrow(
-        /Output does not contain "Hello"/,
-      );
-    });
-  });
-
-  describe('toHaveUsedTool', () => {
-    it('passes when tool_call event exists', () => {
-      const result = completedResult({
-        events: [{ type: 'tool_call', toolName: 'search' }],
-      });
-      expect(() =>
-        expectResult(result).toHaveUsedTool('search'),
+  describe('completed / failed / status', () => {
+    it('completed() passes for COMPLETED result', () => {
+      vitestExpect(() =>
+        agentExpect(completedResult()).completed(),
       ).not.toThrow();
     });
 
-    it('throws when tool was not used', () => {
-      const result = completedResult({ events: [] });
-      expect(() => expectResult(result).toHaveUsedTool('search')).toThrow(
-        /Tool "search" was not used/,
-      );
+    it('completed() throws for FAILED result', () => {
+      vitestExpect(() =>
+        agentExpect(failedResult()).completed(),
+      ).toThrow(/FAILED/);
     });
 
-    it('throws when different tool was used', () => {
-      const result = completedResult({
-        events: [{ type: 'tool_call', toolName: 'fetch' }],
-      });
-      expect(() => expectResult(result).toHaveUsedTool('search')).toThrow(
-        /Tool "search" was not used/,
-      );
+    it('failed() passes for FAILED result', () => {
+      vitestExpect(() =>
+        agentExpect(failedResult()).failed(),
+      ).not.toThrow();
+    });
+
+    it('status() checks exact status', () => {
+      vitestExpect(() =>
+        agentExpect(completedResult()).status('COMPLETED'),
+      ).not.toThrow();
+
+      vitestExpect(() =>
+        agentExpect(completedResult()).status('FAILED'),
+      ).toThrow();
     });
   });
 
-  describe('toHavePassedGuardrail', () => {
-    it('passes when guardrail_pass event exists', () => {
+  describe('noErrors', () => {
+    it('passes when no errors', () => {
+      vitestExpect(() =>
+        agentExpect(completedResult()).noErrors(),
+      ).not.toThrow();
+    });
+
+    it('throws when error events exist', () => {
+      const result = completedResult({
+        events: [{ type: 'error', content: 'x' }],
+      });
+      vitestExpect(() => agentExpect(result).noErrors()).toThrow();
+    });
+  });
+
+  describe('usedTool / didNotUseTool', () => {
+    it('usedTool passes when tool was used', () => {
+      const result = completedResult({
+        toolCalls: [{ name: 'search', args: {} }],
+      });
+      vitestExpect(() =>
+        agentExpect(result).usedTool('search'),
+      ).not.toThrow();
+    });
+
+    it('usedTool with args checks args', () => {
+      const result = completedResult({
+        toolCalls: [{ name: 'search', args: { q: 'test' } }],
+      });
+      vitestExpect(() =>
+        agentExpect(result).usedTool('search', { args: { q: 'test' } }),
+      ).not.toThrow();
+    });
+
+    it('didNotUseTool passes when tool was not used', () => {
+      const result = completedResult({ toolCalls: [] });
+      vitestExpect(() =>
+        agentExpect(result).didNotUseTool('search'),
+      ).not.toThrow();
+    });
+  });
+
+  describe('toolCallOrder / toolsUsedExactly', () => {
+    it('toolCallOrder validates subsequence', () => {
+      const result = completedResult({
+        toolCalls: [
+          { name: 'search' },
+          { name: 'filter' },
+          { name: 'format' },
+        ],
+      });
+      vitestExpect(() =>
+        agentExpect(result).toolCallOrder(['search', 'format']),
+      ).not.toThrow();
+    });
+
+    it('toolsUsedExactly validates set equality', () => {
+      const result = completedResult({
+        toolCalls: [{ name: 'search' }, { name: 'format' }],
+      });
+      vitestExpect(() =>
+        agentExpect(result).toolsUsedExactly(['format', 'search']),
+      ).not.toThrow();
+    });
+  });
+
+  describe('outputContains / outputMatches / outputType', () => {
+    it('outputContains checks substring', () => {
+      const result = completedResult({ output: { result: 'Hello World' } });
+      vitestExpect(() =>
+        agentExpect(result).outputContains('Hello'),
+      ).not.toThrow();
+    });
+
+    it('outputMatches checks regex', () => {
+      const result = completedResult({ output: { result: 'order #123' } });
+      vitestExpect(() =>
+        agentExpect(result).outputMatches(/order #\d+/),
+      ).not.toThrow();
+    });
+
+    it('outputType checks typeof', () => {
+      const result = completedResult({ output: { result: 'test' } });
+      vitestExpect(() =>
+        agentExpect(result).outputType('object'),
+      ).not.toThrow();
+    });
+  });
+
+  describe('eventsContain / eventSequence', () => {
+    it('eventsContain checks event type existence', () => {
+      const result = completedResult({
+        events: [{ type: 'thinking', content: 'hmm' }],
+      });
+      vitestExpect(() =>
+        agentExpect(result).eventsContain('thinking'),
+      ).not.toThrow();
+    });
+
+    it('eventSequence checks subsequence', () => {
+      const result = completedResult({
+        events: [
+          { type: 'thinking' },
+          { type: 'tool_call', toolName: 'x' },
+          { type: 'done' },
+        ],
+      });
+      vitestExpect(() =>
+        agentExpect(result).eventSequence(['thinking', 'done']),
+      ).not.toThrow();
+    });
+  });
+
+  describe('handoffTo / agentRan', () => {
+    it('handoffTo checks handoff events', () => {
+      const result = completedResult({
+        events: [{ type: 'handoff', target: 'billing' }],
+      });
+      vitestExpect(() =>
+        agentExpect(result).handoffTo('billing'),
+      ).not.toThrow();
+    });
+
+    it('agentRan delegates to handoffTo', () => {
+      const result = completedResult({
+        events: [{ type: 'handoff', target: 'billing' }],
+      });
+      vitestExpect(() =>
+        agentExpect(result).agentRan('billing'),
+      ).not.toThrow();
+    });
+  });
+
+  describe('guardrailPassed / guardrailFailed', () => {
+    it('guardrailPassed checks guardrail_pass events', () => {
       const result = completedResult({
         events: [{ type: 'guardrail_pass', guardrailName: 'no_pii' }],
       });
-      expect(() =>
-        expectResult(result).toHavePassedGuardrail('no_pii'),
+      vitestExpect(() =>
+        agentExpect(result).guardrailPassed('no_pii'),
       ).not.toThrow();
     });
 
-    it('throws when guardrail did not pass', () => {
-      const result = completedResult({ events: [] });
-      expect(() =>
-        expectResult(result).toHavePassedGuardrail('no_pii'),
-      ).toThrow(/Guardrail "no_pii" did not pass/);
+    it('guardrailFailed checks guardrail_fail events', () => {
+      const result = completedResult({
+        events: [
+          { type: 'guardrail_fail', guardrailName: 'policy', content: 'bad' },
+        ],
+      });
+      vitestExpect(() =>
+        agentExpect(result).guardrailFailed('policy'),
+      ).not.toThrow();
     });
   });
 
-  describe('toHaveFinishReason', () => {
-    it('passes when finish reason matches', () => {
-      expect(() =>
-        expectResult(completedResult()).toHaveFinishReason('stop'),
-      ).not.toThrow();
-    });
-
-    it('throws when finish reason does not match', () => {
-      expect(() =>
-        expectResult(completedResult()).toHaveFinishReason('error'),
-      ).toThrow(/Expected finish reason "error", got "stop"/);
-    });
-  });
-
-  describe('toHaveTokenUsageBelow', () => {
-    it('passes when token usage is below max', () => {
+  describe('maxTurns', () => {
+    it('passes when within limit', () => {
       const result = completedResult({
-        tokenUsage: { promptTokens: 50, completionTokens: 30, totalTokens: 80 },
+        events: [{ type: 'tool_call', toolName: 'x' }, { type: 'done' }],
       });
-      expect(() =>
-        expectResult(result).toHaveTokenUsageBelow(100),
-      ).not.toThrow();
+      vitestExpect(() => agentExpect(result).maxTurns(5)).not.toThrow();
     });
 
-    it('throws when token usage exceeds max', () => {
+    it('throws when exceeding limit', () => {
       const result = completedResult({
-        tokenUsage: {
-          promptTokens: 100,
-          completionTokens: 200,
-          totalTokens: 300,
-        },
+        events: [
+          { type: 'tool_call', toolName: 'a' },
+          { type: 'tool_call', toolName: 'b' },
+          { type: 'tool_call', toolName: 'c' },
+          { type: 'done' },
+        ],
       });
-      expect(() =>
-        expectResult(result).toHaveTokenUsageBelow(250),
-      ).toThrow(/Token usage 300 exceeds 250/);
-    });
-
-    it('passes when no token usage is set (no usage to exceed)', () => {
-      const result = completedResult();
-      expect(() =>
-        expectResult(result).toHaveTokenUsageBelow(100),
-      ).not.toThrow();
+      vitestExpect(() => agentExpect(result).maxTurns(2)).toThrow();
     });
   });
 
@@ -170,30 +250,31 @@ describe('expectResult', () => {
     it('supports chaining multiple assertions', () => {
       const result = completedResult({
         output: { result: 'Hello World' },
+        toolCalls: [{ name: 'search', args: { q: 'test' } }],
         events: [
           { type: 'tool_call', toolName: 'search' },
           { type: 'guardrail_pass', guardrailName: 'safety' },
+          { type: 'done' },
         ],
       });
 
-      expect(() =>
-        expectResult(result)
-          .toBeCompleted()
-          .toContainOutput('Hello')
-          .toHaveUsedTool('search')
-          .toHavePassedGuardrail('safety')
-          .toHaveFinishReason('stop'),
+      vitestExpect(() =>
+        agentExpect(result)
+          .completed()
+          .noErrors()
+          .usedTool('search')
+          .outputContains('Hello')
+          .guardrailPassed('safety')
+          .maxTurns(10),
       ).not.toThrow();
     });
 
     it('throws on first failing assertion in chain', () => {
-      const result = failedResult();
-
-      expect(() =>
-        expectResult(result)
-          .toBeCompleted() // This should throw
-          .toContainOutput('test'),
-      ).toThrow(/Expected COMPLETED/);
+      vitestExpect(() =>
+        agentExpect(failedResult())
+          .completed()
+          .noErrors(),
+      ).toThrow();
     });
   });
 });

--- a/sdk/typescript/tests/unit/testing/mock.test.ts
+++ b/sdk/typescript/tests/unit/testing/mock.test.ts
@@ -1,89 +1,103 @@
-import { describe, it, expect, vi } from 'vitest';
-import { mockRun } from '../../../src/testing/mock.js';
+import { describe, it, expect } from 'vitest';
+import { MockEvent, mockRun } from '../../../src/testing/mock.js';
 import { Agent } from '../../../src/agent.js';
-import { tool } from '../../../src/tool.js';
-import { z } from 'zod';
 
-// ── Helper: create a simple tool ────────────────────────
+describe('MockEvent', () => {
+  it('creates a thinking event', () => {
+    const ev = MockEvent.thinking('hmm...');
+    expect(ev.type).toBe('thinking');
+    expect(ev.content).toBe('hmm...');
+  });
 
-function makeGreetTool() {
-  return tool(
-    async (args: { name?: string }) => `Hello, ${args.name ?? 'world'}!`,
-    {
-      name: 'greet',
-      description: 'Greet someone',
-      inputSchema: z.object({ name: z.string().optional() }),
-    },
-  );
-}
+  it('creates a tool_call event', () => {
+    const ev = MockEvent.toolCall('search', { query: 'test' });
+    expect(ev.type).toBe('tool_call');
+    expect(ev.toolName).toBe('search');
+    expect(ev.args).toEqual({ query: 'test' });
+  });
 
-function makeFailTool() {
-  return tool(
-    async () => {
-      throw new Error('Tool failed');
-    },
-    {
-      name: 'fail_tool',
-      description: 'A tool that always fails',
-      inputSchema: z.object({}),
-    },
-  );
-}
+  it('creates a tool_call event with default empty args', () => {
+    const ev = MockEvent.toolCall('search');
+    expect(ev.args).toEqual({});
+  });
 
-// ── Tests ────────────────────────────────────────────────
+  it('creates a tool_result event', () => {
+    const ev = MockEvent.toolResult('search', [{ title: 'result' }]);
+    expect(ev.type).toBe('tool_result');
+    expect(ev.toolName).toBe('search');
+    expect(ev.result).toEqual([{ title: 'result' }]);
+  });
+
+  it('creates a handoff event', () => {
+    const ev = MockEvent.handoff('specialist');
+    expect(ev.type).toBe('handoff');
+    expect(ev.target).toBe('specialist');
+  });
+
+  it('creates a message event', () => {
+    const ev = MockEvent.message('hello');
+    expect(ev.type).toBe('message');
+    expect(ev.content).toBe('hello');
+  });
+
+  it('creates a guardrail_pass event', () => {
+    const ev = MockEvent.guardrailPass('no_pii', 'clean');
+    expect(ev.type).toBe('guardrail_pass');
+    expect(ev.guardrailName).toBe('no_pii');
+    expect(ev.content).toBe('clean');
+  });
+
+  it('creates a guardrail_fail event', () => {
+    const ev = MockEvent.guardrailFail('no_pii', 'PII detected');
+    expect(ev.type).toBe('guardrail_fail');
+    expect(ev.guardrailName).toBe('no_pii');
+    expect(ev.content).toBe('PII detected');
+  });
+
+  it('creates a waiting event', () => {
+    const ev = MockEvent.waiting('awaiting input');
+    expect(ev.type).toBe('waiting');
+    expect(ev.content).toBe('awaiting input');
+  });
+
+  it('creates a done event', () => {
+    const ev = MockEvent.done({ answer: 42 });
+    expect(ev.type).toBe('done');
+    expect(ev.output).toEqual({ answer: 42 });
+  });
+
+  it('creates an error event', () => {
+    const ev = MockEvent.error('something broke');
+    expect(ev.type).toBe('error');
+    expect(ev.content).toBe('something broke');
+  });
+});
 
 describe('mockRun', () => {
-  it('executes agent tools and returns AgentResult', async () => {
-    const greet = makeGreetTool();
-    const agent = new Agent({
-      name: 'test-agent',
-      model: 'gpt-4',
-      tools: [greet],
+  it('builds AgentResult from scripted events', () => {
+    const agent = new Agent({ name: 'test-agent' });
+    const result = mockRun(agent, 'Hello', {
+      events: [
+        MockEvent.thinking('processing...'),
+        MockEvent.done('Hello back!'),
+      ],
     });
-
-    const result = await mockRun(agent, 'Say hello');
 
     expect(result.status).toBe('COMPLETED');
-    expect(result.finishReason).toBe('stop');
-    expect(result.isSuccess).toBe(true);
-    expect(result.output).toBeDefined();
-    expect(JSON.stringify(result.output)).toContain('test-agent');
-    expect(result.messages).toHaveLength(1);
-    expect(result.messages[0]).toEqual({ role: 'user', content: 'Say hello' });
+    expect(result.output).toEqual({ result: 'Hello back!' });
+    expect(result.executionId).toBe('mock');
+    expect(result.events).toHaveLength(2);
   });
 
-  it('generates tool_call and tool_result events', async () => {
-    const greet = makeGreetTool();
-    const agent = new Agent({
-      name: 'test-agent',
-      tools: [greet],
+  it('collects tool calls from events', () => {
+    const agent = new Agent({ name: 'test-agent' });
+    const result = mockRun(agent, 'search', {
+      events: [
+        MockEvent.toolCall('search', { query: 'test' }),
+        MockEvent.toolResult('search', ['result1']),
+        MockEvent.done('found it'),
+      ],
     });
-
-    const result = await mockRun(agent, 'hi');
-
-    const toolCallEvents = result.events.filter(
-      (e) => e.type === 'tool_call',
-    );
-    const toolResultEvents = result.events.filter(
-      (e) => e.type === 'tool_result',
-    );
-
-    expect(toolCallEvents).toHaveLength(1);
-    expect(toolCallEvents[0].toolName).toBe('greet');
-
-    expect(toolResultEvents).toHaveLength(1);
-    expect(toolResultEvents[0].toolName).toBe('greet');
-    expect(toolResultEvents[0].result).toBe('Hello, world!');
-  });
-
-  it('populates toolCalls array', async () => {
-    const greet = makeGreetTool();
-    const agent = new Agent({
-      name: 'test-agent',
-      tools: [greet],
-    });
-
-    const result = await mockRun(agent, 'hi');
 
     expect(result.toolCalls).toHaveLength(1);
     const tc = result.toolCalls[0] as {
@@ -91,118 +105,104 @@ describe('mockRun', () => {
       args: unknown;
       result: unknown;
     };
-    expect(tc.name).toBe('greet');
-    expect(tc.result).toBe('Hello, world!');
+    expect(tc.name).toBe('search');
+    expect(tc.args).toEqual({ query: 'test' });
+    expect(tc.result).toEqual(['result1']);
   });
 
-  it('emits a done event', async () => {
-    const agent = new Agent({ name: 'empty-agent' });
-    const result = await mockRun(agent, 'test');
-
-    const doneEvents = result.events.filter((e) => e.type === 'done');
-    expect(doneEvents).toHaveLength(1);
-  });
-
-  it('uses mockTools to override tool implementations', async () => {
-    const greet = makeGreetTool();
-    const agent = new Agent({
-      name: 'test-agent',
-      tools: [greet],
+  it('sets FAILED status on error event', () => {
+    const agent = new Agent({ name: 'test-agent' });
+    const result = mockRun(agent, 'fail', {
+      events: [MockEvent.error('boom')],
     });
 
-    const mockFn = vi.fn().mockResolvedValue('Mocked greeting!');
-
-    const result = await mockRun(agent, 'hi', {
-      mockTools: { greet: mockFn },
-    });
-
-    expect(mockFn).toHaveBeenCalledOnce();
-    const tc = result.toolCalls[0] as {
-      name: string;
-      result: unknown;
-    };
-    expect(tc.result).toBe('Mocked greeting!');
+    expect(result.status).toBe('FAILED');
   });
 
-  it('handles tool errors with error events', async () => {
-    const fail = makeFailTool();
-    const agent = new Agent({
-      name: 'test-agent',
-      tools: [fail],
+  it('stores prompt in messages', () => {
+    const agent = new Agent({ name: 'test-agent' });
+    const result = mockRun(agent, 'my prompt', {
+      events: [MockEvent.done('ok')],
     });
 
-    const result = await mockRun(agent, 'try');
-
-    const errorEvents = result.events.filter((e) => e.type === 'error');
-    expect(errorEvents).toHaveLength(1);
-    expect(errorEvents[0].content).toContain('Tool failed');
-    // The result should still be COMPLETED because mockRun always returns COMPLETED
-    expect(result.status).toBe('COMPLETED');
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toEqual({ role: 'user', content: 'my prompt' });
   });
 
-  it('handles agent with no tools', async () => {
-    const agent = new Agent({ name: 'no-tools' });
-    const result = await mockRun(agent, 'test');
+  it('handles empty events list', () => {
+    const agent = new Agent({ name: 'test-agent' });
+    const result = mockRun(agent, 'test', { events: [] });
 
     expect(result.status).toBe('COMPLETED');
     expect(result.toolCalls).toHaveLength(0);
-    // Only the done event
-    expect(result.events).toHaveLength(1);
-    expect(result.events[0].type).toBe('done');
+    expect(result.events).toHaveLength(0);
   });
 
-  it('includes prompt in output', async () => {
+  it('flushes pending tool call without result', () => {
     const agent = new Agent({ name: 'test-agent' });
-    const result = await mockRun(agent, 'my specific prompt');
-
-    expect(JSON.stringify(result.output)).toContain('my specific prompt');
-  });
-
-  it('handles multiple tools', async () => {
-    const greet = makeGreetTool();
-    const fail = makeFailTool();
-    const agent = new Agent({
-      name: 'multi',
-      tools: [greet, fail],
+    const result = mockRun(agent, 'test', {
+      events: [
+        MockEvent.toolCall('search', { q: 'test' }),
+        MockEvent.done('done'),
+      ],
+      autoExecuteTools: false,
     });
 
-    const result = await mockRun(agent, 'test');
-
-    // greet succeeds, fail errors
-    const toolCallEvents = result.events.filter(
-      (e) => e.type === 'tool_call',
-    );
-    expect(toolCallEvents).toHaveLength(2);
-
-    const errorEvents = result.events.filter((e) => e.type === 'error');
-    expect(errorEvents).toHaveLength(1);
-
-    // Only greet should be in toolCalls (fail_tool threw)
     expect(result.toolCalls).toHaveLength(1);
+    const tc = result.toolCalls[0] as { name: string; result?: unknown };
+    expect(tc.name).toBe('search');
+    expect(tc.result).toBeUndefined();
   });
 
-  it('accepts mockCredentials option', async () => {
-    const agent = new Agent({ name: 'creds-agent' });
-    const result = await mockRun(agent, 'test', {
-      mockCredentials: { API_KEY: 'mock-key-123' },
+  it('auto-executes tool functions when available', () => {
+    const searchFn = (args: Record<string, unknown>) => `found: ${args.q}`;
+    const agent = new Agent({
+      name: 'test-agent',
+      tools: [{ name: 'search', func: searchFn, description: 'search', inputSchema: {}, toolType: 'worker' }],
+    });
+    const result = mockRun(agent, 'test', {
+      events: [
+        MockEvent.toolCall('search', { q: 'hello' }),
+        MockEvent.done('ok'),
+      ],
     });
 
-    expect(result.status).toBe('COMPLETED');
+    expect(result.toolCalls).toHaveLength(1);
+    const tc = result.toolCalls[0] as { name: string; result: unknown };
+    expect(tc.result).toBe('found: hello');
+    // Auto-execute should add a tool_result event
+    expect(result.events.filter((e) => e.type === 'tool_result')).toHaveLength(1);
   });
 
-  it('accepts sessionId option', async () => {
-    const agent = new Agent({ name: 'session-agent' });
-    const result = await mockRun(agent, 'test', {
-      sessionId: 'sess-abc',
+  it('skips auto-execute when autoExecuteTools is false', () => {
+    const agent = new Agent({ name: 'test-agent' });
+    const result = mockRun(agent, 'test', {
+      events: [
+        MockEvent.toolCall('search', { q: 'hello' }),
+        MockEvent.toolResult('search', 'manual result'),
+        MockEvent.done('ok'),
+      ],
+      autoExecuteTools: false,
     });
 
-    expect(result.status).toBe('COMPLETED');
+    expect(result.toolCalls).toHaveLength(1);
+    const tc = result.toolCalls[0] as { name: string; result: unknown };
+    expect(tc.result).toBe('manual result');
   });
 
-  it('generates a executionId starting with mock-', async () => {
-    const agent = new Agent({ name: 'test' });
-    const result = await mockRun(agent, 'hi');
+  it('handles multiple tool calls', () => {
+    const agent = new Agent({ name: 'test-agent' });
+    const result = mockRun(agent, 'test', {
+      events: [
+        MockEvent.toolCall('search', { q: 'a' }),
+        MockEvent.toolResult('search', 'r1'),
+        MockEvent.toolCall('fetch', { url: 'b' }),
+        MockEvent.toolResult('fetch', 'r2'),
+        MockEvent.done('done'),
+      ],
+      autoExecuteTools: false,
+    });
 
-    expect(result.executionId).toMatch(/^mock-\d+$/);
+    expect(result.toolCalls).toHaveLength(2);
   });
 });

--- a/sdk/typescript/tests/unit/testing/strategy.test.ts
+++ b/sdk/typescript/tests/unit/testing/strategy.test.ts
@@ -1,71 +1,408 @@
 import { describe, it, expect } from 'vitest';
-import { validateStrategy } from '../../../src/testing/strategy.js';
+import {
+  validateStrategy,
+  validateSequential,
+  validateParallel,
+  validateRoundRobin,
+  validateRouter,
+  validateHandoff,
+  validateSwarm,
+  validateConstrainedTransitions,
+  StrategyViolation,
+} from '../../../src/testing/strategy.js';
 import { Agent } from '../../../src/agent.js';
+import { makeAgentResult } from '../../../src/result.js';
+import type { AgentEvent } from '../../../src/types.js';
 
-describe('validateStrategy', () => {
-  it('passes when strategy matches', () => {
-    const agent = new Agent({
+// ── Helpers ──────────────────────────────────────────────
+
+function makeResult(events: AgentEvent[]) {
+  return makeAgentResult({
+    executionId: 'wf-test',
+    status: 'COMPLETED',
+    events,
+  });
+}
+
+function makeAgent(opts: {
+  name: string;
+  strategy?: string;
+  agents?: Agent[];
+  maxTurns?: number;
+  allowedTransitions?: Record<string, string[]>;
+  router?: Agent;
+}) {
+  return new Agent({
+    name: opts.name,
+    strategy: opts.strategy as any,
+    agents: opts.agents,
+    maxTurns: opts.maxTurns,
+    allowedTransitions: opts.allowedTransitions,
+    router: opts.router,
+  });
+}
+
+// ── StrategyViolation ────────────────────────────────────
+
+describe('StrategyViolation', () => {
+  it('has strategy and violations properties', () => {
+    const err = new StrategyViolation('sequential', ['missed A', 'missed B']);
+    expect(err.strategy).toBe('sequential');
+    expect(err.violations).toEqual(['missed A', 'missed B']);
+    expect(err.message).toContain('sequential');
+    expect(err.message).toContain('missed A');
+  });
+});
+
+// ── validateSequential ───────────────────────────────────
+
+describe('validateSequential', () => {
+  it('passes when all agents run in order', () => {
+    const agent = makeAgent({
       name: 'pipeline',
       strategy: 'sequential',
-      agents: [],
+      agents: [
+        new Agent({ name: 'a' }),
+        new Agent({ name: 'b' }),
+        new Agent({ name: 'c' }),
+      ],
     });
-    expect(() => validateStrategy(agent, 'sequential')).not.toThrow();
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'c' },
+    ]);
+
+    expect(() => validateSequential(agent, result)).not.toThrow();
   });
 
-  it('passes for handoff strategy', () => {
-    const agent = new Agent({
-      name: 'coordinator',
-      strategy: 'handoff',
+  it('throws when agent is skipped', () => {
+    const agent = makeAgent({
+      name: 'pipeline',
+      strategy: 'sequential',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
     });
-    expect(() => validateStrategy(agent, 'handoff')).not.toThrow();
+    const result = makeResult([{ type: 'handoff', target: 'a' }]);
+
+    expect(() => validateSequential(agent, result)).toThrow(StrategyViolation);
   });
 
-  it('passes for parallel strategy', () => {
-    const agent = new Agent({
-      name: 'dispatcher',
+  it('throws when order is wrong', () => {
+    const agent = makeAgent({
+      name: 'pipeline',
+      strategy: 'sequential',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'a' },
+    ]);
+
+    expect(() => validateSequential(agent, result)).toThrow(StrategyViolation);
+  });
+
+  it('throws when agent runs multiple times', () => {
+    const agent = makeAgent({
+      name: 'pipeline',
+      strategy: 'sequential',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'a' },
+    ]);
+
+    expect(() => validateSequential(agent, result)).toThrow(/multiple times/);
+  });
+
+  it('passes with no sub-agents', () => {
+    const agent = makeAgent({ name: 'simple', strategy: 'sequential' });
+    const result = makeResult([]);
+    expect(() => validateSequential(agent, result)).not.toThrow();
+  });
+});
+
+// ── validateParallel ─────────────────────────────────────
+
+describe('validateParallel', () => {
+  it('passes when all agents run', () => {
+    const agent = makeAgent({
+      name: 'parallel',
       strategy: 'parallel',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
     });
-    expect(() => validateStrategy(agent, 'parallel')).not.toThrow();
+    const result = makeResult([
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'a' },
+    ]);
+
+    expect(() => validateParallel(agent, result)).not.toThrow();
   });
 
-  it('throws when strategy does not match', () => {
-    const agent = new Agent({
-      name: 'pipeline',
-      strategy: 'sequential',
+  it('throws when an agent is missing', () => {
+    const agent = makeAgent({
+      name: 'parallel',
+      strategy: 'parallel',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
     });
-    expect(() => validateStrategy(agent, 'parallel')).toThrow(
-      /Expected strategy "parallel", got "sequential"/,
-    );
+    const result = makeResult([{ type: 'handoff', target: 'a' }]);
+
+    expect(() => validateParallel(agent, result)).toThrow(StrategyViolation);
+  });
+});
+
+// ── validateRoundRobin ───────────────────────────────────
+
+describe('validateRoundRobin', () => {
+  it('passes with correct alternation', () => {
+    const agent = makeAgent({
+      name: 'rr',
+      strategy: 'round_robin',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+    ]);
+
+    expect(() => validateRoundRobin(agent, result)).not.toThrow();
   });
 
-  it('throws when agent has no strategy', () => {
-    const agent = new Agent({ name: 'simple' });
-    expect(() => validateStrategy(agent, 'handoff')).toThrow(
-      /Expected strategy "handoff", got "undefined"/,
-    );
+  it('throws on consecutive repeats', () => {
+    const agent = makeAgent({
+      name: 'rr',
+      strategy: 'round_robin',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'a' },
+    ]);
+
+    expect(() => validateRoundRobin(agent, result)).toThrow(StrategyViolation);
   });
 
-  it('supports router strategy', () => {
+  it('throws when exceeding max_turns', () => {
+    const agent = makeAgent({
+      name: 'rr',
+      strategy: 'round_robin',
+      maxTurns: 2,
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'a' },
+    ]);
+
+    expect(() => validateRoundRobin(agent, result)).toThrow(/max_turns/);
+  });
+});
+
+// ── validateRouter ───────────────────────────────────────
+
+describe('validateRouter', () => {
+  it('passes when exactly one agent selected', () => {
     const mockRouter = new Agent({ name: 'mock_router' });
-    const agent = new Agent({
+    const agent = makeAgent({
       name: 'router',
       strategy: 'router',
       router: mockRouter,
+      agents: [new Agent({ name: 'billing' }), new Agent({ name: 'tech' })],
     });
-    expect(() => validateStrategy(agent, 'router')).not.toThrow();
+    const result = makeResult([{ type: 'handoff', target: 'billing' }]);
+
+    expect(() => validateRouter(agent, result)).not.toThrow();
   });
 
-  it('throws when strategy=router without router param', () => {
-    expect(
-      () => new Agent({ name: 'bad_router', strategy: 'router' }),
-    ).toThrow(/no 'router' parameter was provided/);
+  it('throws when multiple agents selected', () => {
+    const mockRouter = new Agent({ name: 'mock_router' });
+    const agent = makeAgent({
+      name: 'router',
+      strategy: 'router',
+      router: mockRouter,
+      agents: [new Agent({ name: 'billing' }), new Agent({ name: 'tech' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'billing' },
+      { type: 'handoff', target: 'tech' },
+    ]);
+
+    expect(() => validateRouter(agent, result)).toThrow(/multiple agents/);
   });
 
-  it('supports swarm strategy', () => {
-    const agent = new Agent({
+  it('throws when no agent selected', () => {
+    const mockRouter = new Agent({ name: 'mock_router' });
+    const agent = makeAgent({
+      name: 'router',
+      strategy: 'router',
+      router: mockRouter,
+      agents: [new Agent({ name: 'billing' })],
+    });
+    const result = makeResult([]);
+
+    expect(() => validateRouter(agent, result)).toThrow(/No sub-agent/);
+  });
+});
+
+// ── validateHandoff ──────────────────────────────────────
+
+describe('validateHandoff', () => {
+  it('passes when handoff occurs to valid sub-agent', () => {
+    const agent = makeAgent({
+      name: 'coordinator',
+      strategy: 'handoff',
+      agents: [new Agent({ name: 'specialist' })],
+    });
+    const result = makeResult([{ type: 'handoff', target: 'specialist' }]);
+
+    expect(() => validateHandoff(agent, result)).not.toThrow();
+  });
+
+  it('throws when no handoff occurs', () => {
+    const agent = makeAgent({
+      name: 'coordinator',
+      strategy: 'handoff',
+      agents: [new Agent({ name: 'specialist' })],
+    });
+    const result = makeResult([]);
+
+    expect(() => validateHandoff(agent, result)).toThrow(/No handoff/);
+  });
+});
+
+// ── validateSwarm ────────────────────────────────────────
+
+describe('validateSwarm', () => {
+  it('passes with valid transfers', () => {
+    const agent = makeAgent({
       name: 'swarm',
       strategy: 'swarm',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
     });
-    expect(() => validateStrategy(agent, 'swarm')).not.toThrow();
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+    ]);
+
+    expect(() => validateSwarm(agent, result)).not.toThrow();
+  });
+
+  it('throws when no agent handles request', () => {
+    const agent = makeAgent({
+      name: 'swarm',
+      strategy: 'swarm',
+      agents: [new Agent({ name: 'a' })],
+    });
+    const result = makeResult([]);
+
+    expect(() => validateSwarm(agent, result)).toThrow(/No agent handled/);
+  });
+
+  it('detects transfer loops', () => {
+    const agent = makeAgent({
+      name: 'swarm',
+      strategy: 'swarm',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+    ]);
+
+    expect(() => validateSwarm(agent, result)).toThrow(/loop/);
+  });
+});
+
+// ── validateConstrainedTransitions ───────────────────────
+
+describe('validateConstrainedTransitions', () => {
+  it('passes when all transitions are allowed', () => {
+    const agent = makeAgent({
+      name: 'constrained',
+      strategy: 'handoff',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+      allowedTransitions: { a: ['b'], b: ['a'] },
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+    ]);
+
+    expect(() =>
+      validateConstrainedTransitions(agent, result),
+    ).not.toThrow();
+  });
+
+  it('throws on invalid transition', () => {
+    const agent = makeAgent({
+      name: 'constrained',
+      strategy: 'handoff',
+      agents: [
+        new Agent({ name: 'a' }),
+        new Agent({ name: 'b' }),
+        new Agent({ name: 'c' }),
+      ],
+      allowedTransitions: { a: ['b'], b: ['c'] },
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'c' },
+    ]);
+
+    expect(() =>
+      validateConstrainedTransitions(agent, result),
+    ).toThrow(/Invalid transition/);
+  });
+});
+
+// ── validateStrategy (dispatcher) ────────────────────────
+
+describe('validateStrategy', () => {
+  it('dispatches to the correct validator based on strategy', () => {
+    const agent = makeAgent({
+      name: 'pipeline',
+      strategy: 'sequential',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+    ]);
+
+    expect(() => validateStrategy(agent, result)).not.toThrow();
+  });
+
+  it('also validates constrained transitions when present', () => {
+    const agent = makeAgent({
+      name: 'constrained',
+      strategy: 'handoff',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+      allowedTransitions: { a: ['b'] },
+    });
+    const result = makeResult([
+      { type: 'handoff', target: 'a' },
+      { type: 'handoff', target: 'b' },
+    ]);
+
+    expect(() => validateStrategy(agent, result)).not.toThrow();
+  });
+
+  it('throws when strategy fails', () => {
+    const agent = makeAgent({
+      name: 'pipeline',
+      strategy: 'sequential',
+      agents: [new Agent({ name: 'a' }), new Agent({ name: 'b' })],
+    });
+    const result = makeResult([{ type: 'handoff', target: 'a' }]);
+
+    expect(() => validateStrategy(agent, result)).toThrow(StrategyViolation);
   });
 });

--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     testTimeout: 60_000,
-    include: ['tests/**/*.test.ts', '../../tests/e2e/*.test.ts'],
+    include: ['tests/**/*.test.ts', '../../tests/e2e/*.test.ts', 'examples/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- Add 5 progressive mock test examples per SDK (Python + TypeScript), from basic agent testing to advanced patterns
- Add `eval_case_from_result()` / `capture_eval_case()` (Python) and `evalCaseFromResult()` / `captureEvalCase()` (TypeScript) to auto-generate eval cases from observed agent behavior — no manual case authoring needed
- Enhance TypeScript `mockRun` to recursively simulate sub-agents with strategy-aware orchestration (handoff, sequential, parallel, router)
- Add comprehensive README docs for both SDKs with API reference, testing pyramid, and FAQ

## Details

### Test Examples (per SDK)
| File | Coverage |
|------|----------|
| 01 - Basic Agent | mockRun, status/output assertions, fluent API |
| 02 - Tool Assertions | arg validation, call ordering, output checking |
| 03 - Multi-Agent Strategies | handoff, sequential, parallel, router |
| 04 - Guardrails & Errors | guardrail events, error handling, HITL |
| 05 - Advanced Patterns | record/replay, strategy validation, nested strategies |

### Eval Capture
Auto-generate eval cases from live or mock runs:
```python
# Python
case, result = capture_eval_case(runtime, agent, "What's the weather in Tokyo?")
# case.expect_tools == ["get_weather"]
# case.expect_tool_args == {"get_weather": {"city": "Tokyo"}}
```
```typescript
// TypeScript
const [evalCase, result] = await captureEvalCase(agent, "Check AAPL stock");
```

### TypeScript mockRun Enhancement
`mockRun` now walks sub-agents based on declared strategy, producing handoff/done events for each. This enables testing multi-agent compositions without a server.

## Test plan
- [x] Python live eval: 5/5 cases pass against server
- [x] TypeScript mock tests: 49/49 pass
- [x] TypeScript full test suite: all existing tests still pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)