### PR TITLE
Fix TypeScript SDK CJS loading on Node 25

### DIFF
--- a/sdk/typescript/examples/README.md
+++ b/sdk/typescript/examples/README.md
@@ -51,13 +51,32 @@ See [63-deploy.ts](63-deploy.ts), [63b-serve.ts](63b-serve.ts), and
 
 ### 1. Install dependencies
 
-The core examples (numbered files in this directory) need the `agentspan` SDK:
+The core examples (numbered files in this directory) are repository examples.
+They intentionally import from `../src` or `../../src`, so they are meant to be
+run from this checkout of the SDK:
 
 ```bash
-npm install agentspan
+cd sdk/typescript
+npm install
 ```
 
 Framework-specific examples require additional packages. Install only what you need:
+
+### 1.1. Copy/paste into your own project
+
+If you want to copy an example into a separate project after `npm install`, switch
+its imports to the published package:
+
+```bash
+npm install @agentspan-ai/sdk zod
+```
+
+```ts
+import { Agent, AgentRuntime } from '@agentspan-ai/sdk';
+```
+
+The files under `examples/` are not copy/paste-ready as-is because they import the
+SDK source tree directly.
 
 #### Google ADK examples (`adk/`)
 
@@ -111,7 +130,7 @@ The `AGENTSPAN_LLM_MODEL` variable uses the `provider/model-name` format. Exampl
 ### 3. Run an example
 
 ```bash
-# Core SDK examples (via ts-node, tsx, or compile first)
+# Core SDK examples (run from sdk/typescript/)
 npx tsx examples/01-basic-agent.ts
 npx tsx examples/15-agent-discussion.ts
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -76,7 +76,8 @@
     "zod-to-json-schema": "^3.23.5"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && npm run verify:dist",
+    "verify:dist": "node ./scripts/verify-dist.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit"

--- a/sdk/typescript/scripts/verify-dist.mjs
+++ b/sdk/typescript/scripts/verify-dist.mjs
@@ -1,0 +1,14 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(here, '..');
+const distEsm = join(packageRoot, 'dist/index.js');
+const distCjs = join(packageRoot, 'dist/index.cjs');
+const require = createRequire(import.meta.url);
+
+await import(pathToFileURL(distEsm).href);
+require(distCjs);
+
+console.log('Verified dist ESM and CJS entrypoints.');

--- a/sdk/typescript/src/tool.ts
+++ b/sdk/typescript/src/tool.ts
@@ -1,8 +1,16 @@
 import { createRequire } from 'node:module';
+import { isAbsolute, join } from 'node:path';
 import type { ToolDef, ToolType, ToolContext, CredentialFile } from './types.js';
 import { ConfigurationError } from './errors.js';
 
-const require = createRequire(import.meta.url);
+// `import.meta.url` survives tsup's CJS build on Node 25 and breaks `require()`.
+// Use the current file when available in CJS, and fall back to the caller's
+// working tree in ESM so optional peer dependencies still resolve.
+const require = createRequire(
+  typeof __filename === 'string' && isAbsolute(__filename)
+    ? __filename
+    : join(process.cwd(), '__agentspan_sdk__.cjs'),
+);
 
 // ── Symbol for attaching ToolDef metadata ─────────────────
 


### PR DESCRIPTION
## Summary
- fix the TypeScript SDK CommonJS bundle on Node 25 by avoiding import.meta-based createRequire in the generated .cjs path
- add a dist verification script and run it from npm build so broken ESM/CJS artifacts fail before publish
- clarify in the examples README that examples/ are repo-local, fix the package install command, and show the correct consumer import path

## Verification
- npm run build
- npm test
- packed the SDK locally and verified require(), import(), and tsx loading in a clean temp project on Node 25.8.0