### PR TITLE
feat(sdk): add AgentHandle.join() — block until agent execution completes

### DIFF
--- a/sdk/python/examples/78_approval_workflow.py
+++ b/sdk/python/examples/78_approval_workflow.py
@@ -157,7 +157,7 @@ try:
 
         # Agent responds with no tool calls on stop — DoWhile exits as COMPLETED.
         runtime.send_message(execution_id, {"stop": True})
-        time.sleep(5)
+        handle.join(timeout=30)
         print("\nDone.")
 finally:
     shutil.rmtree(_ipc_dir, ignore_errors=True)

--- a/sdk/python/examples/79_agent_message_bus.py
+++ b/sdk/python/examples/79_agent_message_bus.py
@@ -79,7 +79,6 @@ def build_researcher(runtime: AgentRuntime, writer_execution_id: str) -> Agent:
     def stop_pipeline() -> str:
         """Forward the stop signal to the Writer and signal the main process."""
         runtime.send_message(writer_execution_id, {"stop": True})
-        (_ipc_dir / "pipeline_stopped").touch()
         return "done"
 
     return Agent(
@@ -163,10 +162,9 @@ try:
         # the Writer, then responds with no further tool calls so both loops exit.
         runtime.send_message(researcher_id, {"stop": True})
 
-        # Wait for stop_pipeline to confirm it ran before exiting (workers are killed
-        # when AgentRuntime exits — stop_pipeline must complete first)
-        while not (_ipc_dir / "pipeline_stopped").exists():
-            time.sleep(0.1)
+        # Wait for both agents to reach terminal state before the runtime exits.
+        researcher_handle.join(timeout=30)
+        writer_handle.join(timeout=30)
 
         print("Done.")
 finally:

--- a/sdk/python/examples/80_live_dashboard.py
+++ b/sdk/python/examples/80_live_dashboard.py
@@ -158,7 +158,6 @@ def build_feeder(runtime: AgentRuntime) -> Agent:
         """Send the stop signal to the Monitor agent and notify the main process."""
         monitor_id = _MONITOR_ID_FILE.read_text().strip()
         runtime.send_message(monitor_id, {"stop": True})
-        (_ipc_dir / "feeder_stopped").touch()
         return "stop sent"
 
     return Agent(
@@ -234,10 +233,9 @@ try:
         print(f"\nAll {EXPECTED_DISPLAYS} batch reports received. Sending stop signal...\n")
         runtime.send_message(feeder_id, {"stop": True})
 
-        # Wait for stop_monitor() to complete before the runtime exits
-        # (workers are killed when AgentRuntime.__exit__ runs).
-        while not (_ipc_dir / "feeder_stopped").exists():
-            time.sleep(0.1)
+        # Wait for both agents to reach terminal state before the runtime exits.
+        feeder_handle.join(timeout=30)
+        monitor_handle.join(timeout=30)
 
         print("Done.")
 finally:

--- a/sdk/python/examples/82_fan_out_fan_in.py
+++ b/sdk/python/examples/82_fan_out_fan_in.py
@@ -138,7 +138,6 @@ def build_worker(worker_name: str, runtime: AgentRuntime, collector_id: str) -> 
     def stop_collector() -> str:
         """Forward the stop signal to the Collector and write a shutdown sentinel."""
         runtime.send_message(collector_id, {"stop": True})
-        (_ipc_dir / f"worker_{worker_name}_stopped").touch()
         return "stop forwarded"
 
     return Agent(
@@ -183,7 +182,6 @@ def build_orchestrator(runtime: AgentRuntime, worker_ids: list) -> Agent:
         """Send stop signals to all workers and write a shutdown sentinel."""
         for wid in worker_ids:
             runtime.send_message(wid, {"stop": True})
-        (_ipc_dir / "orchestrator_stopped").touch()
         return "stop sent to all workers"
 
     return Agent(
@@ -218,12 +216,14 @@ try:
 
         # Start Workers — Orchestrator needs their IDs.
         worker_ids: list = []
+        worker_handles: list = []
         for name in WORKER_NAMES:
             wh = runtime.start(
                 build_worker(name, runtime, collector_id),
                 f"Begin. You are worker {name.upper()}. Wait for tasks.",
             )
             worker_ids.append(wh.execution_id)
+            worker_handles.append(wh)
             print(f"Worker {name:5s}  started: {wh.execution_id}")
 
         # Start Orchestrator last.
@@ -271,12 +271,11 @@ try:
         # Shutdown: Orchestrator → Workers → Collector (via stop_collector_<name>).
         runtime.send_message(orchestrator_id, {"stop": True})
 
-        while not (_ipc_dir / "orchestrator_stopped").exists():
-            time.sleep(0.1)
-
-        for name in WORKER_NAMES:
-            while not (_ipc_dir / f"worker_{name}_stopped").exists():
-                time.sleep(0.1)
+        # Wait for all agents to reach terminal state before the runtime exits.
+        orch_handle.join(timeout=60)
+        for wh in worker_handles:
+            wh.join(timeout=30)
+        collector_handle.join(timeout=30)
 
         print("Done.")
 finally:

--- a/sdk/python/src/agentspan/agents/result.py
+++ b/sdk/python/src/agentspan/agents/result.py
@@ -335,7 +335,129 @@ class AgentHandle:
         """Async streaming view. Returns an :class:`AsyncAgentStream`."""
         return AsyncAgentStream(handle=self, runtime=self._runtime)
 
+    # ── join() — block until terminal ────────────────────────────────
+
+    def join(self, timeout: Optional[float] = None) -> "AgentResult":
+        """Block until the agent execution reaches a terminal state.
+
+        Analogous to ``Thread.join()``.  Polls the server at 1-second
+        intervals until the execution is complete, then returns a full
+        :class:`AgentResult`.
+
+        Args:
+            timeout: Maximum time to wait in **seconds** (not milliseconds).
+                ``None`` means wait forever.
+
+        Returns:
+            An :class:`AgentResult` with output, status, finish_reason,
+            token_usage, and error populated.
+
+        Raises:
+            TimeoutError: If ``timeout`` is set and the agent execution has not
+                reached a terminal state before the deadline.
+
+        Warning:
+            The :class:`AgentRuntime` that created this handle **must remain
+            open** (i.e. its ``with`` block must still be active) while
+            ``join()`` runs.  Closing the runtime cancels Conductor workers,
+            which may stall the execution.
+
+        Example::
+
+            with AgentRuntime() as runtime:
+                handle = runtime.start(agent, "Hello")
+                result = handle.join(timeout=120)
+                print(result.output)
+        """
+        import time
+
+        poll_interval = 1
+        elapsed: float = 0.0
+
+        while True:
+            status = self._runtime.get_status(self.execution_id)
+            if status.is_complete:
+                break
+            if timeout is not None and elapsed >= timeout:
+                raise TimeoutError(
+                    f"Agent execution {self.execution_id!r} did not complete "
+                    f"within {timeout}s."
+                )
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+
+        return self._build_result(status)
+
+    async def join_async(self, timeout: Optional[float] = None) -> "AgentResult":
+        """Async version of :meth:`join`.
+
+        Awaits until the agent execution reaches a terminal state.
+
+        Args:
+            timeout: Maximum time to wait in **seconds**.  ``None`` means
+                wait forever.
+
+        Returns:
+            An :class:`AgentResult`.
+
+        Raises:
+            TimeoutError: If ``timeout`` is set and the deadline is reached
+                before the agent execution completes.
+
+        Warning:
+            The :class:`AgentRuntime` must remain open while this coroutine
+            runs (same constraint as :meth:`join`).
+
+        Example::
+
+            async with AgentRuntime() as runtime:
+                handle = await runtime.start_async(agent, "Hello")
+                result = await handle.join_async(timeout=120)
+                print(result.output)
+        """
+        import asyncio
+
+        poll_interval = 1
+        elapsed: float = 0.0
+
+        while True:
+            status = await self._runtime.get_status_async(self.execution_id)
+            if status.is_complete:
+                break
+            if timeout is not None and elapsed >= timeout:
+                raise TimeoutError(
+                    f"Agent execution {self.execution_id!r} did not complete "
+                    f"within {timeout}s."
+                )
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+
+        return self._build_result(status)
+
+    def _build_result(self, status: "AgentStatus") -> "AgentResult":
+        """Convert a terminal :class:`AgentStatus` into a full :class:`AgentResult`.
+
+        Reuses the same normalisation logic as :meth:`AgentRuntime.run`.
+        """
+        output = self._runtime._normalize_output(status.output, status.status, status.reason)
+        token_usage = self._runtime._extract_token_usage(self.execution_id)
+        return AgentResult(
+            output=output,
+            execution_id=self.execution_id,
+            correlation_id=self.correlation_id,
+            status=status.status,
+            finish_reason=self._runtime._derive_finish_reason(status.status, status.output),
+            error=status.reason if status.status in ("FAILED", "TERMINATED") else None,
+            token_usage=token_usage,
+        )
+
     def __repr__(self) -> str:
+        """Return a developer-friendly string representation.
+
+        Key methods: ``get_status()``, ``join()``, ``join_async()``,
+        ``stream()``, ``respond()``, ``approve()``, ``reject()``,
+        ``pause()``, ``resume()``, ``cancel()``.
+        """
         return f"AgentHandle(execution_id={self.execution_id!r})"
 
 

--- a/sdk/python/tests/unit/test_agent_handle_join.py
+++ b/sdk/python/tests/unit/test_agent_handle_join.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Unit tests for AgentHandle.join() and AgentHandle.join_async()."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentspan.agents.result import (
+    AgentHandle,
+    AgentResult,
+    AgentStatus,
+    FinishReason,
+    Status,
+)
+
+
+def _make_runtime(*, statuses, token_usage=None):
+    """Build a minimal mock runtime that drives join().
+
+    ``statuses`` is a list of AgentStatus objects that get_status()
+    returns in sequence (one per poll iteration).
+    """
+    runtime = MagicMock()
+    runtime.get_status.side_effect = list(statuses)
+
+    async def _async_get_status(execution_id):
+        if len(statuses) > 1:
+            return statuses.pop(0)
+        return statuses[0]
+
+    runtime.get_status_async = AsyncMock(side_effect=_async_get_status)
+    runtime._normalize_output.side_effect = lambda output, raw_status, reason=None: (
+        output if isinstance(output, dict) else {"result": output}
+    )
+    runtime._derive_finish_reason.return_value = FinishReason.STOP
+    runtime._extract_token_usage.return_value = token_usage
+    return runtime
+
+
+class TestAgentHandleJoinSync:
+    """Tests for AgentHandle.join()."""
+
+    def test_join_returns_agent_result_when_complete(self):
+        """join() returns AgentResult when execution completes on first poll."""
+        completed = AgentStatus(
+            execution_id="wf-1",
+            is_complete=True,
+            status="COMPLETED",
+            output={"result": "hello"},
+        )
+        runtime = _make_runtime(statuses=[completed])
+        handle = AgentHandle(execution_id="wf-1", runtime=runtime)
+
+        with patch("time.sleep"):
+            result = handle.join()
+
+        assert isinstance(result, AgentResult)
+        assert result.execution_id == "wf-1"
+        assert result.status == Status.COMPLETED
+
+    def test_join_polls_until_complete(self):
+        """join() keeps polling until is_complete=True."""
+        running = AgentStatus(execution_id="wf-1", is_complete=False, is_running=True, status="RUNNING", output=None)
+        completed = AgentStatus(
+            execution_id="wf-1", is_complete=True, status="COMPLETED", output={"result": "done"}
+        )
+        runtime = _make_runtime(statuses=[running, running, completed])
+        handle = AgentHandle(execution_id="wf-1", runtime=runtime)
+
+        with patch("time.sleep"):
+            result = handle.join()
+
+        assert isinstance(result, AgentResult)
+        assert result.status == Status.COMPLETED
+
+    def test_join_raises_timeout_error_when_exhausted(self):
+        """join(timeout=2) raises TimeoutError if execution never completes."""
+        running = AgentStatus(
+            execution_id="wf-99", is_complete=False, is_running=True, status="RUNNING", output=None
+        )
+        runtime = _make_runtime(statuses=[running] * 100)
+        handle = AgentHandle(execution_id="wf-99", runtime=runtime)
+
+        with patch("time.sleep"):
+            with pytest.raises(TimeoutError) as exc_info:
+                handle.join(timeout=2)
+
+        assert "wf-99" in str(exc_info.value)
+        assert "2" in str(exc_info.value)
+
+    def test_join_timeout_none_uses_no_deadline(self):
+        """join(timeout=None) polls until complete with no timeout guard."""
+        completed = AgentStatus(
+            execution_id="wf-2", is_complete=True, status="COMPLETED", output={"result": "ok"}
+        )
+        runtime = _make_runtime(statuses=[completed])
+        handle = AgentHandle(execution_id="wf-2", runtime=runtime)
+
+        with patch("time.sleep"):
+            result = handle.join(timeout=None)
+
+        assert result.execution_id == "wf-2"
+
+    def test_join_result_carries_finish_reason(self):
+        """join() sets finish_reason from _derive_finish_reason."""
+        completed = AgentStatus(
+            execution_id="wf-3", is_complete=True, status="COMPLETED", output={"result": "x"}
+        )
+        runtime = _make_runtime(statuses=[completed])
+        runtime._derive_finish_reason.return_value = FinishReason.STOP
+        handle = AgentHandle(execution_id="wf-3", runtime=runtime)
+
+        with patch("time.sleep"):
+            result = handle.join()
+
+        assert result.finish_reason == FinishReason.STOP
+
+    def test_join_result_carries_error_on_failure(self):
+        """join() sets error field when execution failed."""
+        failed = AgentStatus(
+            execution_id="wf-4",
+            is_complete=True,
+            status="FAILED",
+            output=None,
+            reason="API key invalid",
+        )
+        runtime = _make_runtime(statuses=[failed])
+        runtime._derive_finish_reason.return_value = FinishReason.ERROR
+        handle = AgentHandle(execution_id="wf-4", runtime=runtime)
+
+        with patch("time.sleep"):
+            result = handle.join()
+
+        assert result.error == "API key invalid"
+        assert result.status == Status.FAILED
+
+    def test_join_timeout_error_message_contains_execution_id_and_seconds(self):
+        """TimeoutError message includes execution_id and timeout value."""
+        running = AgentStatus(
+            execution_id="exec-abc", is_complete=False, status="RUNNING", output=None
+        )
+        runtime = _make_runtime(statuses=[running] * 100)
+        handle = AgentHandle(execution_id="exec-abc", runtime=runtime)
+
+        with patch("time.sleep"):
+            with pytest.raises(TimeoutError) as exc_info:
+                handle.join(timeout=5)
+
+        msg = str(exc_info.value)
+        assert "exec-abc" in msg
+        assert "5" in msg
+
+
+class TestAgentHandleJoinAsync:
+    """Tests for AgentHandle.join_async()."""
+
+    @pytest.mark.asyncio
+    async def test_join_async_returns_agent_result(self):
+        """join_async() returns AgentResult when execution completes."""
+        completed = AgentStatus(
+            execution_id="wf-a1",
+            is_complete=True,
+            status="COMPLETED",
+            output={"result": "async done"},
+        )
+        runtime = MagicMock()
+
+        async def _get_status_async(eid):
+            return completed
+
+        runtime.get_status_async = AsyncMock(side_effect=_get_status_async)
+        runtime._normalize_output.side_effect = lambda o, s, reason=None: o if isinstance(o, dict) else {"result": o}
+        runtime._derive_finish_reason.return_value = FinishReason.STOP
+        runtime._extract_token_usage.return_value = None
+
+        handle = AgentHandle(execution_id="wf-a1", runtime=runtime)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await handle.join_async()
+
+        assert isinstance(result, AgentResult)
+        assert result.execution_id == "wf-a1"
+        assert result.status == Status.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_join_async_raises_timeout_error(self):
+        """join_async(timeout=2) raises TimeoutError if never complete."""
+        running = AgentStatus(
+            execution_id="wf-a2", is_complete=False, status="RUNNING", output=None
+        )
+        runtime = MagicMock()
+        runtime.get_status_async = AsyncMock(return_value=running)
+        runtime._normalize_output.side_effect = lambda o, s, reason=None: {"result": o}
+        runtime._derive_finish_reason.return_value = FinishReason.STOP
+        runtime._extract_token_usage.return_value = None
+
+        handle = AgentHandle(execution_id="wf-a2", runtime=runtime)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TimeoutError) as exc_info:
+                await handle.join_async(timeout=2)
+
+        assert "wf-a2" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_join_async_polls_until_complete(self):
+        """join_async() keeps polling until is_complete."""
+        responses = [
+            AgentStatus(execution_id="wf-a3", is_complete=False, status="RUNNING", output=None),
+            AgentStatus(execution_id="wf-a3", is_complete=False, status="RUNNING", output=None),
+            AgentStatus(execution_id="wf-a3", is_complete=True, status="COMPLETED", output={"result": "yes"}),
+        ]
+        idx = {"i": 0}
+
+        async def _get(eid):
+            val = responses[min(idx["i"], len(responses) - 1)]
+            idx["i"] += 1
+            return val
+
+        runtime = MagicMock()
+        runtime.get_status_async = AsyncMock(side_effect=_get)
+        runtime._normalize_output.side_effect = lambda o, s, reason=None: o if isinstance(o, dict) else {"result": o}
+        runtime._derive_finish_reason.return_value = FinishReason.STOP
+        runtime._extract_token_usage.return_value = None
+
+        handle = AgentHandle(execution_id="wf-a3", runtime=runtime)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await handle.join_async()
+
+        assert result.status == Status.COMPLETED
+        assert runtime.get_status_async.call_count == 3


### PR DESCRIPTION
## Summary

- Add `AgentHandle.join(timeout=None)` and `AgentHandle.join_async(timeout=None)` — block until an agent execution reaches a terminal state and return a full `AgentResult`, analogous to `Thread.join()`
- Replace file-based sentinel polling with `handle.join()` in examples 78, 79, 80, 82 and clean up dead sentinel writes

## Detail

### New API

`join()` polls `get_status()` at 1-second intervals until `is_complete` is true, then builds a full `AgentResult` using the runtime's normalization helpers. Raises `TimeoutError` if the deadline is exceeded. `timeout` is in **seconds** (not milliseconds).

**Sync:**

```python
with AgentRuntime() as runtime:
    handle = runtime.start(agent, "Hello")
    result = handle.join(timeout=120)
    print(result.output)
```

**Async:**

```python
async with AgentRuntime() as runtime:
    handle = await runtime.start_async(agent, "Hello")
    result = await handle.join_async(timeout=120)
    print(result.output)
```

**Shutdown pattern (replaces sleep/sentinel polling):**

```python
# Before: arbitrary sleep or file-polling loop
runtime.send_message(execution_id, {"stop": True})
time.sleep(5)  # hope it's enough

# After: deterministic wait for completion
runtime.send_message(execution_id, {"stop": True})
handle.join(timeout=30)
```

**Multi-agent shutdown (example 82 — fan-out/fan-in):**

```python
runtime.send_message(orchestrator_id, {"stop": True})

orch_handle.join(timeout=60)
for wh in worker_handles:
    wh.join(timeout=30)
collector_handle.join(timeout=30)
```

### Examples updated

| Example | Before | After |
|---|---|---|
| 78 (approval_workflow) | `time.sleep(5)` after stop signal | `handle.join(timeout=30)` |
| 79 (agent_message_bus) | File-polling loop for `pipeline_stopped` | `researcher_handle.join()` + `writer_handle.join()` |
| 80 (live_dashboard) | File-polling loop for `feeder_stopped` | `feeder_handle.join()` + `monitor_handle.join()` |
| 82 (fan_out_fan_in) | File-polling for `orchestrator_stopped` + `worker_*_stopped` | `orch_handle.join()` + worker/collector `.join()` |

Dead sentinel file writes (`.touch()`) removed from tool functions in examples 79, 80, 82.

## Test plan

- [x] 10 unit tests added in `tests/unit/test_agent_handle_join.py` — sync and async, polling, timeout, error propagation
- [x] Full unit suite passes (1472 tests, 0 failures)
- [ ] Run affected examples (78, 79, 80, 82) against a live server to verify shutdown behavior