### PR TITLE
feat: add Agent Signals — deterministic stop and persistent context injection

### DIFF
--- a/sdk/python/examples/75_wait_for_message.py
+++ b/sdk/python/examples/75_wait_for_message.py
@@ -64,7 +64,8 @@ with AgentRuntime() as runtime:
         print(f"  -> sending: {msg!r}")
         runtime.send_message(handle.execution_id, {"task": msg})
 
-    # Let the agent process all messages before exiting (~5-6s per message)
+    # Let the agent process all messages (~5-6s per message)
     time.sleep(30)
-    runtime.cancel(handle.execution_id)
+    handle.stop()
+    handle.join(timeout=30)
     print("\nDone.")

--- a/sdk/python/examples/75_wait_for_message.py
+++ b/sdk/python/examples/75_wait_for_message.py
@@ -18,7 +18,10 @@ Requirements:
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
 """
 
+import os
 import time
+
+os.environ.setdefault("AGENTSPAN_LOG_LEVEL", "WARNING")
 
 from agentspan.agents import Agent, AgentRuntime, wait_for_message_tool, tool
 from settings import settings

--- a/sdk/python/examples/76_wait_for_message_streaming.py
+++ b/sdk/python/examples/76_wait_for_message_streaming.py
@@ -18,8 +18,11 @@ Requirements:
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
 """
 
+import os
 import threading
 import time
+
+os.environ.setdefault("AGENTSPAN_LOG_LEVEL", "WARNING")
 
 from agentspan.agents import Agent, AgentRuntime, EventType, wait_for_message_tool, tool
 from settings import settings

--- a/sdk/python/examples/76_wait_for_message_streaming.py
+++ b/sdk/python/examples/76_wait_for_message_streaming.py
@@ -71,9 +71,9 @@ with AgentRuntime() as runtime:
             time.sleep(8)
             print(f"\n  [caller] sending -> {task!r}")
             runtime.send_message(handle.execution_id, {"task": task})
-        # Give the agent time to finish the last task then cancel
+        # Give the agent time to finish the last task then stop gracefully
         time.sleep(15)
-        runtime.cancel(handle.execution_id, reason="example complete")
+        handle.stop()
 
     threading.Thread(target=sender, daemon=True).start()
 

--- a/sdk/python/examples/76_wait_for_message_streaming.py
+++ b/sdk/python/examples/76_wait_for_message_streaming.py
@@ -64,15 +64,16 @@ with AgentRuntime() as runtime:
     handle = runtime.start(agent, "Begin. Wait for your first instruction.")
     print(f"Agent started: {handle.execution_id}\n")
 
-    # Push messages from a background thread while we stream events on the main thread
-    # Wait long enough between sends for the agent to finish processing each message
+    # Push messages from a background thread while we stream events on the main thread.
+    # Wait long enough between sends for the agent to finish processing each message.
+    # No sleep after the last send — handle.stream() on the main thread is already the
+    # barrier: it blocks until DONE, which only fires once the workflow reaches a
+    # terminal state (after stop() sets the flag and the current iteration completes).
     def sender():
         for task in TASKS:
             time.sleep(8)
             print(f"\n  [caller] sending -> {task!r}")
             runtime.send_message(handle.execution_id, {"task": task})
-        # Give the agent time to finish the last task then stop gracefully
-        time.sleep(15)
         handle.stop()
 
     threading.Thread(target=sender, daemon=True).start()

--- a/sdk/python/examples/78_approval_workflow.py
+++ b/sdk/python/examples/78_approval_workflow.py
@@ -107,16 +107,14 @@ agent = Agent(
         "You are an operations agent that processes system commands with a safety gate. "
         "Repeat this cycle indefinitely:\n\n"
         "1. Call wait_for_message to receive the next message.\n"
-        "2. If the message contains 'stop: true', respond with 'Stopping.' and call no "
-        "   further tools.\n"
-        "3. Otherwise assess the task:\n"
+        "2. Assess the task:\n"
         "   - SAFE (status checks, reads, listing): call execute_task immediately.\n"
         "   - RISKY (deletes, restarts, permission changes, writes): call flag_for_approval "
         "     with the task and a brief reason. It will block until the operator decides "
         "     and return 'approve' or 'reject'.\n"
-        "4. If flag_for_approval returned 'approve', call execute_task. "
+        "3. If flag_for_approval returned 'approve', call execute_task. "
         "   If it returned 'reject', call log_rejection.\n"
-        "5. Return to step 1 immediately."
+        "4. Return to step 1 immediately."
     ),
 )
 
@@ -155,8 +153,8 @@ try:
                 req.with_suffix(".decision").write_text(decision)
             time.sleep(0.1)
 
-        # Agent responds with no tool calls on stop — DoWhile exits as COMPLETED.
-        runtime.send_message(execution_id, {"stop": True})
+        # Deterministic stop — no stop-handling instructions needed.
+        handle.stop()
         handle.join(timeout=30)
         print("\nDone.")
 finally:

--- a/sdk/python/examples/78_approval_workflow.py
+++ b/sdk/python/examples/78_approval_workflow.py
@@ -40,10 +40,13 @@ Requirements:
 """
 
 import json
+import os
 import shutil
 import tempfile
 import time
 from pathlib import Path
+
+os.environ.setdefault("AGENTSPAN_LOG_LEVEL", "WARNING")
 
 from agentspan.agents import Agent, AgentRuntime, tool, wait_for_message_tool
 from settings import settings

--- a/sdk/python/examples/79_agent_message_bus.py
+++ b/sdk/python/examples/79_agent_message_bus.py
@@ -34,10 +34,13 @@ Requirements:
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
 """
 
+import os
 import shutil
 import tempfile
 import time
 from pathlib import Path
+
+os.environ.setdefault("AGENTSPAN_LOG_LEVEL", "WARNING")
 
 from agentspan.agents import Agent, AgentRuntime, tool, wait_for_message_tool
 from settings import settings

--- a/sdk/python/examples/79_agent_message_bus.py
+++ b/sdk/python/examples/79_agent_message_bus.py
@@ -8,13 +8,9 @@ Demonstrates:
       into another running agent's WMQ via runtime.send_message()
     - A tool that closes over an execution_id to forward results downstream
     - Parallel agent pipelines: researcher → writer running concurrently
-    - Filesystem-based IPC: forward_to_writer and stop_pipeline write sentinel
-      files so the main thread knows exactly when to send the stop signal —
-      no fixed sleeps, no streaming
-    - Stop signal propagation: the main script sends one stop to the Researcher,
-      which forwards it to the Writer via stop_pipeline() before itself stopping;
-      both workflows exit cleanly as COMPLETED (no tool calls on stop = DoWhile
-      loop condition goes false naturally)
+    - Filesystem-based IPC: forward_to_writer writes sentinel files so the main
+      thread knows when all topics have been forwarded
+    - Deterministic stop: handle.stop() exits each agent's loop gracefully
 
 How this differs from 06_sequential_pipeline:
     The >> operator in example 06 compiles a static DAG upfront — the workflow
@@ -64,7 +60,7 @@ def build_researcher(runtime: AgentRuntime, writer_execution_id: str) -> Agent:
 
     receive_topic = wait_for_message_tool(
         name="wait_for_topic",
-        description="Wait for the next research topic or a stop signal ({stop: true}).",
+        description="Wait for the next research topic.",
     )
 
     @tool
@@ -75,27 +71,19 @@ def build_researcher(runtime: AgentRuntime, writer_execution_id: str) -> Agent:
         (_FORWARDED_DIR / f"{time.time_ns()}.done").touch()
         return "forwarded"
 
-    @tool
-    def stop_pipeline() -> str:
-        """Forward the stop signal to the Writer and signal the main process."""
-        runtime.send_message(writer_execution_id, {"stop": True})
-        return "done"
-
     return Agent(
         name="researcher",
         model=settings.llm_model,
-        tools=[receive_topic, forward_to_writer, stop_pipeline],
+        tools=[receive_topic, forward_to_writer],
         max_turns=10000,
         stateful=True,
         instructions=(
             "You are a Researcher agent. Repeat indefinitely:\n"
             "1. Call wait_for_topic to receive the next message.\n"
-            "2. If the message contains 'stop: true', call stop_pipeline() then respond "
-            "   with 'Stopping.' and call no further tools.\n"
-            "3. Otherwise, write three concise bullet-point research notes on the topic "
+            "2. Write three concise bullet-point research notes on the topic "
             "   using your own knowledge.\n"
-            "4. Call forward_to_writer(topic, notes) with the topic and your bullet points.\n"
-            "5. Return to step 1 immediately."
+            "3. Call forward_to_writer(topic, notes) with the topic and your bullet points.\n"
+            "4. Return to step 1 immediately."
         ),
     )
 
@@ -107,7 +95,7 @@ def build_writer() -> Agent:
         name="wait_for_notes",
         description=(
             "Wait for research notes from the Researcher agent. "
-            "The payload contains 'topic' and 'notes' fields, or a stop signal ({stop: true})."
+            "The payload contains 'topic' and 'notes' fields."
         ),
     )
 
@@ -127,11 +115,9 @@ def build_writer() -> Agent:
         instructions=(
             "You are a Writer agent. Repeat indefinitely:\n"
             "1. Call wait_for_notes to receive the next message.\n"
-            "2. If the message contains 'stop: true', respond with 'Stopping.' and call "
-            "   no further tools.\n"
-            "3. Otherwise, turn the notes into a single polished paragraph (3–4 sentences).\n"
-            "4. Call publish(topic, paragraph) with the topic and your paragraph.\n"
-            "5. Return to step 1 immediately."
+            "2. Turn the notes into a single polished paragraph (3–4 sentences).\n"
+            "3. Call publish(topic, paragraph) with the topic and your paragraph.\n"
+            "4. Return to step 1 immediately."
         ),
     )
 
@@ -158,11 +144,9 @@ try:
         while len(list(_FORWARDED_DIR.iterdir())) < len(TOPICS):
             time.sleep(0.1)
 
-        # Send stop to Researcher — it calls stop_pipeline() to forward the stop to
-        # the Writer, then responds with no further tool calls so both loops exit.
-        runtime.send_message(researcher_id, {"stop": True})
-
-        # Wait for both agents to reach terminal state before the runtime exits.
+        # Deterministic stop — no stop-handling instructions needed.
+        researcher_handle.stop()
+        writer_handle.stop()
         researcher_handle.join(timeout=30)
         writer_handle.join(timeout=30)
 

--- a/sdk/python/examples/80_live_dashboard.py
+++ b/sdk/python/examples/80_live_dashboard.py
@@ -45,11 +45,14 @@ Requirements:
 
 import json
 import math
+import os
 import random
 import shutil
 import tempfile
 import time
 from pathlib import Path
+
+os.environ.setdefault("AGENTSPAN_LOG_LEVEL", "WARNING")
 
 from settings import settings
 

--- a/sdk/python/examples/80_live_dashboard.py
+++ b/sdk/python/examples/80_live_dashboard.py
@@ -75,8 +75,7 @@ def build_monitor() -> Agent:
         name="receive_metrics",
         description=(
             "Dequeue the next batch of up to 10 metric samples. "
-            "Each sample has 'metric', 'host', and 'value' fields. "
-            "A stop signal looks like {stop: true}."
+            "Each sample has 'metric', 'host', and 'value' fields."
         ),
         batch_size=10,
     )
@@ -101,14 +100,12 @@ def build_monitor() -> Agent:
         instructions=(
             "You are a real-time metrics monitor. Repeat indefinitely:\n"
             "1. Call receive_metrics — you will get a batch of 1–10 metric samples.\n"
-            "2. If any sample contains 'stop: true' (or the batch itself is a stop signal), "
-            "   respond with 'Shutting down.' and call no further tools.\n"
-            "3. Otherwise, compute per-metric statistics across the batch:\n"
+            "2. Compute per-metric statistics across the batch:\n"
             "   - Count of samples per metric name\n"
             "   - Min, max, and average value\n"
-            "4. Call display_dashboard with a compact one-line summary string like:\n"
+            "3. Call display_dashboard with a compact one-line summary string like:\n"
             "   'Batch 3 | cpu_pct: n=4 min=12.1 max=87.3 avg=45.2 | mem_mb: n=3 …'\n"
-            "5. Return to step 1 immediately."
+            "4. Return to step 1 immediately."
         ),
     )
 
@@ -122,7 +119,7 @@ def build_feeder(runtime: AgentRuntime) -> Agent:
 
     receive_signal = wait_for_message_tool(
         name="receive_signal",
-        description="Wait for a control signal from the orchestrator ({batches: N} or {stop: true}).",
+        description="Wait for a control signal from the orchestrator ({batches: N}).",
     )
 
     @tool
@@ -153,27 +150,18 @@ def build_feeder(runtime: AgentRuntime) -> Agent:
         (_BATCH_DIR / f"batch_{batch_number}_{time.time_ns()}.done").touch()
         return f"Pushed {len(samples)} samples in batch {batch_number}: {json.dumps(samples)}"
 
-    @tool
-    def stop_monitor() -> str:
-        """Send the stop signal to the Monitor agent and notify the main process."""
-        monitor_id = _MONITOR_ID_FILE.read_text().strip()
-        runtime.send_message(monitor_id, {"stop": True})
-        return "stop sent"
-
     return Agent(
         name="feeder_agent",
         model=settings.llm_model,
-        tools=[receive_signal, push_metrics_batch, stop_monitor],
+        tools=[receive_signal, push_metrics_batch],
         max_turns=10000,
         stateful=True,
         instructions=(
             "You are a metrics Feeder agent. Repeat indefinitely:\n"
             "1. Call receive_signal to get the next instruction.\n"
-            "2. If the signal contains 'stop: true', call stop_monitor() then respond "
-            "   with 'Stopping.' and call no further tools.\n"
-            "3. If the signal contains 'batches: N', call push_metrics_batch N times "
+            "2. If the signal contains 'batches: N', call push_metrics_batch N times "
             "   (once per batch, incrementing batch_number from 1 to N).\n"
-            "4. Return to step 1 immediately."
+            "3. Return to step 1 immediately."
         ),
     )
 
@@ -230,10 +218,9 @@ try:
                     seen.add(p.name)
             time.sleep(0.05)
 
-        print(f"\nAll {EXPECTED_DISPLAYS} batch reports received. Sending stop signal...\n")
-        runtime.send_message(feeder_id, {"stop": True})
-
-        # Wait for both agents to reach terminal state before the runtime exits.
+        print(f"\nAll {EXPECTED_DISPLAYS} batch reports received. Stopping...\n")
+        feeder_handle.stop()
+        monitor_handle.stop()
         feeder_handle.join(timeout=30)
         monitor_handle.join(timeout=30)
 

--- a/sdk/python/examples/81_chat_repl.py
+++ b/sdk/python/examples/81_chat_repl.py
@@ -126,9 +126,8 @@ def build_agent() -> Agent:
     receive_message = wait_for_message_tool(
         name="wait_for_message",
         description=(
-            "Wait for the next user message or a control signal. "
+            "Wait for the next user message or control signal. "
             "User messages have a 'text' field. "
-            "Stop signal: {stop: true}. "
             "New-tool notification: {tool_registered: name, tool_description: desc}."
         ),
     )
@@ -175,16 +174,14 @@ def build_agent() -> Agent:
             "You are a helpful conversational assistant in an interactive REPL. "
             "Repeat indefinitely:\n\n"
             "1. Call wait_for_message to receive the next event.\n"
-            "2. If the message contains 'stop: true', respond with 'Goodbye!' "
-            "   and call no further tools.\n"
-            "3. If the message contains 'tool_registered', acknowledge the new "
+            "2. If the message contains 'tool_registered', acknowledge the new "
             "   capability in your reply: say what the tool does and that you can "
             "   now use it. Call reply_to_user with your acknowledgment.\n"
-            "4. Otherwise, respond naturally to the user's 'text' field. "
+            "3. Otherwise, respond naturally to the user's 'text' field. "
             "   If a registered ephemeral task (via run_task) would help answer "
             "   the user's question, call it first and incorporate the result. "
             "   Always call reply_to_user with your final response.\n"
-            "5. Return to step 1 immediately."
+            "4. Return to step 1 immediately."
         ),
     )
 
@@ -274,9 +271,8 @@ try:
                 continue
 
             if user_input.lower() in ("quit", "exit"):
-                runtime.send_message(execution_id, {"stop": True})
-                reply = _wait_for_reply()
-                print(f"Agent: {reply}\n")
+                handle.stop()
+                print("Agent stopped.\n")
                 # Clean up session file — agent is stopped
                 if args.session_file.exists():
                     args.session_file.unlink()

--- a/sdk/python/examples/82_fan_out_fan_in.py
+++ b/sdk/python/examples/82_fan_out_fan_in.py
@@ -72,7 +72,7 @@ def build_collector() -> Agent:
         name="receive_result",
         description=(
             "Wait for the next worker result. "
-            "Payload: {question, worker_name, answer} or a stop signal {stop: true}."
+            "Payload: {question, worker_name, answer}."
         ),
     )
 
@@ -98,12 +98,10 @@ def build_collector() -> Agent:
             "Repeat indefinitely:\n"
             f"1. Call receive_result {NUM_WORKERS} times to collect all answers for "
             "   one question (they share the same 'question' field).\n"
-            "2. If any result is a stop signal {stop: true}, respond with 'Stopping.' "
-            "   and call no further tools.\n"
-            "3. Build a side-by-side comparison: for each worker list their name and "
+            "2. Build a side-by-side comparison: for each worker list their name and "
             "   a one-sentence summary of their answer.\n"
-            "4. Call save_report(question, report) with the formatted report string.\n"
-            "5. Return to step 1."
+            "3. Call save_report(question, report) with the formatted report string.\n"
+            "4. Return to step 1."
         ),
     )
 
@@ -115,10 +113,7 @@ def build_collector() -> Agent:
 def build_worker(worker_name: str, runtime: AgentRuntime, collector_id: str) -> Agent:
     receive_task = wait_for_message_tool(
         name=f"receive_task_{worker_name}",
-        description=(
-            f"Wait for the next task for worker {worker_name}. "
-            "Payload: {question} or a stop signal {stop: true}."
-        ),
+        description=f"Wait for the next task for worker {worker_name}. Payload: {{question}}.",
     )
 
     # Tool names must be unique across all workers so Conductor routes each
@@ -134,28 +129,19 @@ def build_worker(worker_name: str, runtime: AgentRuntime, collector_id: str) -> 
         (_ANSWERS_DIR / f"{worker_name}_{time.time_ns()}.done").touch()
         return "submitted"
 
-    @tool(name=f"stop_collector_{worker_name}")
-    def stop_collector() -> str:
-        """Forward the stop signal to the Collector and write a shutdown sentinel."""
-        runtime.send_message(collector_id, {"stop": True})
-        return "stop forwarded"
-
     return Agent(
         name=f"worker_{worker_name}",
         model=settings.llm_model,
-        tools=[receive_task, submit_answer, stop_collector],
+        tools=[receive_task, submit_answer],
         max_turns=10000,
         stateful=True,
         instructions=(
             f"You are Worker {worker_name.upper()}, one of {NUM_WORKERS} parallel analysts. "
             "Repeat indefinitely:\n"
             f"1. Call receive_task_{worker_name} to get the next assignment.\n"
-            "2. If the payload contains 'stop: true', call "
-            f"   stop_collector_{worker_name}() then respond with 'Stopping.' "
-            "   and call no further tools.\n"
-            "3. Otherwise write a concise 2–3 sentence answer to the question.\n"
-            f"4. Call submit_answer_{worker_name}(question, answer).\n"
-            "5. Return to step 1 immediately."
+            "2. Write a concise 2–3 sentence answer to the question.\n"
+            f"3. Call submit_answer_{worker_name}(question, answer).\n"
+            "4. Return to step 1 immediately."
         ),
     )
 
@@ -167,7 +153,7 @@ def build_worker(worker_name: str, runtime: AgentRuntime, collector_id: str) -> 
 def build_orchestrator(runtime: AgentRuntime, worker_ids: list) -> Agent:
     receive_question = wait_for_message_tool(
         name="receive_question",
-        description="Wait for the next question to fan out, or a stop signal {stop: true}.",
+        description="Wait for the next question to fan out.",
     )
 
     @tool
@@ -177,26 +163,17 @@ def build_orchestrator(runtime: AgentRuntime, worker_ids: list) -> Agent:
             runtime.send_message(wid, {"question": question})
         return f"broadcasted to {len(worker_ids)} workers"
 
-    @tool
-    def stop_all_workers() -> str:
-        """Send stop signals to all workers and write a shutdown sentinel."""
-        for wid in worker_ids:
-            runtime.send_message(wid, {"stop": True})
-        return "stop sent to all workers"
-
     return Agent(
         name="orchestrator_agent",
         model=settings.llm_model,
-        tools=[receive_question, fan_out, stop_all_workers],
+        tools=[receive_question, fan_out],
         max_turns=10000,
         stateful=True,
         instructions=(
             "You are an Orchestrator agent. Repeat indefinitely:\n"
-            "1. Call receive_question to get the next question or stop signal.\n"
-            "2. If the payload contains 'stop: true', call stop_all_workers() then "
-            "   respond with 'Stopping.' and call no further tools.\n"
-            "3. Otherwise call fan_out(question) to broadcast to all workers.\n"
-            "4. Return to step 1 immediately."
+            "1. Call receive_question to get the next question.\n"
+            "2. Call fan_out(question) to broadcast to all workers.\n"
+            "3. Return to step 1 immediately."
         ),
     )
 
@@ -268,10 +245,11 @@ try:
 
         print(f"All {len(QUESTIONS)} reports received. Shutting down...\n")
 
-        # Shutdown: Orchestrator → Workers → Collector (via stop_collector_<name>).
-        runtime.send_message(orchestrator_id, {"stop": True})
-
-        # Wait for all agents to reach terminal state before the runtime exits.
+        # Deterministic stop — no stop-handling instructions needed.
+        orch_handle.stop()
+        for wh in worker_handles:
+            wh.stop()
+        collector_handle.stop()
         orch_handle.join(timeout=60)
         for wh in worker_handles:
             wh.join(timeout=30)

--- a/sdk/python/examples/84_deterministic_stop.py
+++ b/sdk/python/examples/84_deterministic_stop.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Deterministic Stop — exit an agent loop without LLM cooperation.
+
+Demonstrates:
+    - handle.stop(): graceful, deterministic loop exit via workflow variable
+    - No stop-handling instructions needed in the agent's prompt
+    - Execution reaches COMPLETED status with last output preserved
+    - Works with both blocking and non-blocking WMQ agents
+
+How it works:
+    The server compiles every agent's DoWhile loop with a ``_stop_requested``
+    workflow variable in its condition.  When ``handle.stop()`` is called, the
+    SDK sets this variable to ``true`` via Conductor's ``updateVariables`` API.
+    The loop condition evaluates to ``false`` on the next check, and the loop
+    exits.  The LLM cannot override this — it's checked by Conductor, not the
+    LLM.
+
+    For blocking WMQ agents, ``stop()`` also sends a ``{"_signal": "stop"}``
+    WMQ message to unblock the ``PULL_WORKFLOW_MESSAGES`` task so the current
+    iteration can finish.
+
+stop() vs cancel():
+    - stop()   → graceful, current iteration finishes, status=COMPLETED
+    - cancel() → immediate, workflow killed, status=TERMINATED
+
+The old pattern (still works, but non-deterministic):
+    Previously, stopping required LLM cooperation — the agent's instructions
+    had to include "if you see {stop: true}, respond with no tool calls".
+    The LLM could ignore this.  handle.stop() makes this unnecessary.
+
+Requirements:
+    - Agentspan server (with _stop_requested support in compiler)
+    - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
+    - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+"""
+
+import time
+
+from agentspan.agents import Agent, AgentRuntime, tool, wait_for_message_tool
+from settings import settings
+
+
+@tool
+def process_task(task: str) -> str:
+    """Process a task and return the result."""
+    print(f"  [processing] {task}")
+    return f"Completed: {task}"
+
+
+receive = wait_for_message_tool(
+    name="wait_for_task",
+    description="Wait for the next task to process.",
+)
+
+# Note: NO stop-handling instructions!
+# No "if stop: true, respond with no tools" — handle.stop() handles it.
+agent = Agent(
+    name="stoppable_agent",
+    model=settings.llm_model,
+    tools=[receive, process_task],
+    max_turns=10000,
+    stateful=True,
+    instructions=(
+        "You are a task processor. Loop forever: "
+        "1. Call wait_for_task to receive the next task. "
+        "2. Call process_task with the task. "
+        "3. Go back to step 1."
+    ),
+)
+
+TASKS = [
+    "analyze server logs",
+    "generate weekly report",
+    "send status summary to team",
+]
+
+with AgentRuntime() as runtime:
+    handle = runtime.start(agent, "Begin processing tasks.")
+    print(f"Agent started: {handle.execution_id}")
+    print(f"Domain: {handle.run_id}\n")
+
+    # Wait for agent to reach its first wait_for_task call
+    time.sleep(3)
+
+    # Send tasks
+    for task in TASKS:
+        print(f"  → sending: {task!r}")
+        runtime.send_message(handle.execution_id, {"task": task})
+        time.sleep(6)
+
+    # Deterministic stop — no instructions, no LLM cooperation needed
+    print("\nSending stop signal (deterministic)...")
+    handle.stop()
+
+    # Wait for the agent to complete gracefully
+    result = handle.join(timeout=30)
+    print(f"\nStatus: {result.status}")   # COMPLETED (not TERMINATED)
+    print(f"Output: {result.output}")
+    print("Done.")

--- a/sdk/python/examples/84_deterministic_stop.py
+++ b/sdk/python/examples/84_deterministic_stop.py
@@ -36,7 +36,10 @@ Requirements:
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
 """
 
+import os
 import time
+
+os.environ.setdefault("AGENTSPAN_LOG_LEVEL", "WARNING")
 
 from agentspan.agents import Agent, AgentRuntime, tool, wait_for_message_tool
 from settings import settings

--- a/sdk/python/src/agentspan/agents/result.py
+++ b/sdk/python/src/agentspan/agents/result.py
@@ -59,6 +59,7 @@ class FinishReason(str, Enum):
     TIMEOUT = "timeout"  # Execution timed out
     GUARDRAIL = "guardrail"  # Blocked by guardrail
     REJECTED = "rejected"  # HITL tool was rejected
+    STOPPED = "stopped"  # Graceful stop via handle.stop()
 
 
 # ── TokenUsage ──────────────────────────────────────────────────────────
@@ -282,6 +283,19 @@ class AgentHandle:
         """Cancel the agent workflow."""
         self._runtime.cancel(self.execution_id, reason)
 
+    def stop(self) -> None:
+        """Gracefully stop the agent execution.
+
+        The loop exits after the current iteration completes.  The
+        execution reaches ``COMPLETED`` status with the last LLM output
+        preserved.  This is deterministic — it does not depend on the LLM
+        following stop instructions.
+
+        For immediate termination (``TERMINATED`` status), use
+        :meth:`cancel` instead.
+        """
+        self._runtime.stop(self.execution_id)
+
     # ── Streaming ────────────────────────────────────────────────────
 
     def stream(self) -> "AgentStream":
@@ -330,6 +344,10 @@ class AgentHandle:
     async def cancel_async(self, reason: str = "") -> None:
         """Async version of :meth:`cancel`."""
         await self._runtime.cancel_async(self.execution_id, reason)
+
+    async def stop_async(self) -> None:
+        """Async version of :meth:`stop`."""
+        await self._runtime.stop_async(self.execution_id)
 
     def stream_async(self) -> "AsyncAgentStream":
         """Async streaming view. Returns an :class:`AsyncAgentStream`."""

--- a/sdk/python/src/agentspan/agents/runtime/http_client.py
+++ b/sdk/python/src/agentspan/agents/runtime/http_client.py
@@ -124,6 +124,26 @@ class AgentHttpClient:
         except httpx.HTTPStatusError as exc:
             _raise_api_error(exc, url=url)
 
+    async def stop(self, execution_id: str) -> None:
+        """POST /agent/{id}/stop — graceful deterministic stop."""
+        client = await self._get_client()
+        url = self._url(f"/{execution_id}/stop")
+        resp = await client.post(url)
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            _raise_api_error(exc, url=url)
+
+    async def signal(self, execution_id: str, message: str) -> None:
+        """POST /agent/{id}/signal — inject persistent context."""
+        client = await self._get_client()
+        url = self._url(f"/{execution_id}/signal")
+        resp = await client.post(url, json={"message": message})
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            _raise_api_error(exc, url=url)
+
     async def stream_sse(self, execution_id: str) -> AsyncIterator[Dict[str, Any]]:
         """GET /agent/stream/{id} — consume SSE events.
 

--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -4634,6 +4634,70 @@ class AgentRuntime:
             run_id=domain,
         )
 
+    def stop(self, execution_id: str) -> None:
+        """Gracefully stop an agent execution.
+
+        Sets the ``_stop_requested`` workflow variable to ``true``.  The
+        agent's DoWhile loop checks this flag on each iteration and exits
+        when it is set.  The execution reaches ``COMPLETED`` status with
+        the last LLM output preserved.
+
+        Also sends a WMQ unblock message for agents waiting on a blocking
+        ``PULL_WORKFLOW_MESSAGES`` task.
+
+        This is deterministic — it does not depend on the LLM following
+        stop instructions in the prompt.
+
+        For immediate termination (``TERMINATED`` status), use
+        :meth:`cancel` instead.
+
+        Args:
+            execution_id: The Conductor execution ID.
+        """
+        import requests as req_lib
+
+        url = self._agent_api_url(f"/{execution_id}/stop")
+        resp = req_lib.post(url, headers=self._agent_api_headers(), timeout=30)
+        try:
+            resp.raise_for_status()
+        except req_lib.exceptions.HTTPError as exc:
+            _raise_api_error(exc, url=url)
+
+        # Also unblock any blocking PULL_WORKFLOW_MESSAGES wait.
+        try:
+            self._workflow_client.send_message(
+                execution_id, {"_signal": "stop"}
+            )
+        except Exception:
+            pass  # best-effort — agent may not have a WMQ tool
+
+    def signal(self, execution_id: str, message: str) -> None:
+        """Inject a persistent signal into a running agent's context.
+
+        Sets the ``_signal_injection`` workflow variable.  The agent's
+        context injection reads this variable on each iteration and
+        prepends it to the LLM's user message as ``[SIGNALS]...[/SIGNALS]``.
+
+        The signal persists until overwritten by another ``signal()`` call.
+        To clear it, call ``signal(execution_id, "")``.
+
+        This works on **all** agents — no ``wait_for_message_tool`` needed.
+        It's a separate channel from WMQ: ``signal()`` writes to a workflow
+        variable, ``send_message()`` writes to the message queue.
+
+        Args:
+            execution_id: The Conductor execution ID.
+            message: The signal text.  Empty string clears the signal.
+        """
+        import requests as req_lib
+
+        url = self._agent_api_url(f"/{execution_id}/signal")
+        resp = req_lib.post(url, json={"message": message}, headers=self._agent_api_headers(), timeout=30)
+        try:
+            resp.raise_for_status()
+        except req_lib.exceptions.HTTPError as exc:
+            _raise_api_error(exc, url=url)
+
     async def resume_async(
         self,
         execution_id: str,
@@ -4729,6 +4793,22 @@ class AgentRuntime:
                 reason=reason,
             ),
         )
+
+    async def stop_async(self, execution_id: str) -> None:
+        """Async version of :meth:`stop`."""
+        await self._http.stop(execution_id)
+        # Also unblock any blocking PULL_WORKFLOW_MESSAGES wait.
+        try:
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(
+                None, self._workflow_client.send_message, execution_id, {"_signal": "stop"}
+            )
+        except Exception:
+            pass
+
+    async def signal_async(self, execution_id: str, message: str) -> None:
+        """Async version of :meth:`signal`."""
+        await self._http.signal(execution_id, message)
 
     # ── Session continuity helpers ────────────────────────────────────
 

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -938,14 +938,23 @@ def wait_for_message_tool(
     name: str,
     description: str,
     batch_size: int = 1,
+    blocking: bool = True,
 ) -> ToolDef:
-    """Create a tool that pauses execution until a workflow message is received
+    """Create a tool that dequeues messages from the Workflow Message Queue
     (Conductor ``PULL_WORKFLOW_MESSAGES`` task).
 
     When the LLM calls this tool, the workflow dequeues up to *batch_size*
-    messages from its Workflow Message Queue (WMQ).  The task stays
-    ``IN_PROGRESS`` while the queue is empty and completes once messages
-    arrive, returning them to the next LLM turn as tool output.
+    messages from its WMQ.
+
+    In **blocking** mode (default), the task stays ``IN_PROGRESS`` while the
+    queue is empty and completes once messages arrive.
+
+    In **non-blocking** mode, the task completes immediately — returning
+    whatever messages are in the queue (or an empty result if none).  This
+    is useful for polling patterns where the agent should not stall waiting
+    for messages.  Non-blocking agents are also more responsive to
+    :meth:`~AgentHandle.stop` signals since the loop condition is checked
+    after each iteration.
 
     No worker process is needed — the Conductor server handles the
     ``PULL_WORKFLOW_MESSAGES`` task directly.  Use
@@ -957,6 +966,8 @@ def wait_for_message_tool(
         description: Human-readable description for the LLM.
         batch_size: Maximum number of messages to dequeue per invocation
             (server cap is 100, default 1).
+        blocking: If ``True`` (default), the task blocks until at least one
+            message is available.  If ``False``, the task returns immediately.
 
     Example::
 
@@ -975,12 +986,15 @@ def wait_for_message_tool(
         # From the caller side:
         runtime.send_message(workflow_id, {"text": "hello"})
     """
+    config = {"batchSize": batch_size}
+    if not blocking:
+        config["blocking"] = False
     return ToolDef(
         name=name,
         description=description,
         input_schema={"type": "object", "properties": {}},
         tool_type="pull_workflow_messages",
-        config={"batchSize": batch_size},
+        config=config,
     )
 
 

--- a/sdk/python/tests/unit/test_result.py
+++ b/sdk/python/tests/unit/test_result.py
@@ -353,7 +353,7 @@ class TestFinishReasonEnum:
         assert FinishReason.REJECTED == "rejected"
 
     def test_all_values(self):
-        assert len(FinishReason) == 8
+        assert len(FinishReason) == 9
 
 
 class TestAgentResultProperties:

--- a/sdk/python/tests/unit/test_signals.py
+++ b/sdk/python/tests/unit/test_signals.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Unit tests for deterministic stop signal and signal methods."""
+
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from agentspan.agents.result import AgentHandle, FinishReason
+
+
+# ── FinishReason.STOPPED ────────────────────────────────────────────────
+
+
+class TestFinishReasonStopped:
+    """STOPPED is a valid FinishReason."""
+
+    def test_stopped_exists(self):
+        assert FinishReason.STOPPED == "stopped"
+
+    def test_stopped_string_comparison(self):
+        assert FinishReason.STOPPED == "stopped"
+
+
+# ── AgentHandle.stop() ─────────────────────────────────────────────────
+
+
+class TestHandleStop:
+    """handle.stop() sends a stop signal to the runtime."""
+
+    def test_stop_calls_runtime_stop(self):
+        runtime = MagicMock()
+        handle = AgentHandle(execution_id="wf-1", runtime=runtime)
+        handle.stop()
+        runtime.stop.assert_called_once_with("wf-1")
+
+    def test_stop_is_stateless(self):
+        """Multiple stop calls all delegate — server handles idempotency."""
+        runtime = MagicMock()
+        handle = AgentHandle(execution_id="wf-1", runtime=runtime)
+        handle.stop()
+        handle.stop()
+        assert runtime.stop.call_count == 2
+
+
+class TestHandleStopAsync:
+    """handle.stop_async() is the async variant."""
+
+    @pytest.mark.asyncio
+    async def test_stop_async_calls_runtime(self):
+        runtime = MagicMock()
+        runtime.stop_async = AsyncMock()
+        handle = AgentHandle(execution_id="wf-1", runtime=runtime)
+        await handle.stop_async()
+        runtime.stop_async.assert_called_once_with("wf-1")
+
+
+# ── AgentRuntime.stop() ────────────────────────────────────────────────
+
+
+class TestRuntimeStop:
+    """AgentRuntime.stop() calls the server stop endpoint and sends WMQ unblock."""
+
+    @patch("agentspan.agents.runtime.runtime.req_lib", create=True)
+    def test_stop_calls_server_endpoint(self, mock_requests):
+        from agentspan.agents.runtime.runtime import AgentRuntime
+
+        rt = AgentRuntime.__new__(AgentRuntime)
+        rt._workflow_client = MagicMock()
+        rt._agent_api_url = MagicMock(return_value="http://localhost/api/agent/wf-1/stop")
+        rt._agent_api_headers = MagicMock(return_value={})
+
+        # Mock requests.post
+        import requests as req_lib
+        with patch.object(req_lib, "post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+            rt.stop("wf-1")
+            mock_post.assert_called_once()
+
+    def test_stop_sends_wmq_unblock(self):
+        from agentspan.agents.runtime.runtime import AgentRuntime
+
+        rt = AgentRuntime.__new__(AgentRuntime)
+        rt._workflow_client = MagicMock()
+        rt._agent_api_url = MagicMock(return_value="http://localhost/api/agent/wf-1/stop")
+        rt._agent_api_headers = MagicMock(return_value={})
+
+        import requests as req_lib
+        with patch.object(req_lib, "post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+            rt.stop("wf-1")
+            rt._workflow_client.send_message.assert_called_once_with(
+                "wf-1", {"_signal": "stop"}
+            )
+
+    def test_stop_wmq_failure_is_swallowed(self):
+        """If WMQ send fails, stop still succeeds."""
+        from agentspan.agents.runtime.runtime import AgentRuntime
+
+        rt = AgentRuntime.__new__(AgentRuntime)
+        rt._workflow_client = MagicMock()
+        rt._workflow_client.send_message.side_effect = Exception("no WMQ")
+        rt._agent_api_url = MagicMock(return_value="http://localhost/api/agent/wf-1/stop")
+        rt._agent_api_headers = MagicMock(return_value={})
+
+        import requests as req_lib
+        with patch.object(req_lib, "post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+            rt.stop("wf-1")  # should not raise
+
+
+# ── AgentRuntime.signal() ──────────────────────────────────────────────
+
+
+class TestRuntimeSignal:
+    """AgentRuntime.signal() calls the server signal endpoint."""
+
+    def test_signal_calls_server_endpoint(self):
+        from agentspan.agents.runtime.runtime import AgentRuntime
+
+        rt = AgentRuntime.__new__(AgentRuntime)
+        rt._agent_api_url = MagicMock(return_value="http://localhost/api/agent/wf-1/signal")
+        rt._agent_api_headers = MagicMock(return_value={})
+
+        import requests as req_lib
+        with patch.object(req_lib, "post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+            rt.signal("wf-1", "budget cut, wrap up")
+            mock_post.assert_called_once_with(
+                "http://localhost/api/agent/wf-1/signal",
+                json={"message": "budget cut, wrap up"},
+                headers={},
+                timeout=30,
+            )
+
+    def test_signal_clear(self):
+        from agentspan.agents.runtime.runtime import AgentRuntime
+
+        rt = AgentRuntime.__new__(AgentRuntime)
+        rt._agent_api_url = MagicMock(return_value="http://localhost/api/agent/wf-1/signal")
+        rt._agent_api_headers = MagicMock(return_value={})
+
+        import requests as req_lib
+        with patch.object(req_lib, "post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            mock_post.return_value.raise_for_status = MagicMock()
+            rt.signal("wf-1", "")
+            mock_post.assert_called_once()
+
+
+# ── wait_for_message_tool blocking parameter ────────────────────────────
+
+
+class TestWaitForMessageToolBlocking:
+    """wait_for_message_tool supports a blocking parameter."""
+
+    def test_default_is_blocking(self):
+        from agentspan.agents.tool import wait_for_message_tool
+
+        td = wait_for_message_tool(name="wait", description="Wait")
+        # Default blocking=True means no explicit "blocking" key in config
+        assert "blocking" not in td.config
+
+    def test_non_blocking_sets_config(self):
+        from agentspan.agents.tool import wait_for_message_tool
+
+        td = wait_for_message_tool(name="poll", description="Poll", blocking=False)
+        assert td.config["blocking"] is False
+
+    def test_batch_size_preserved(self):
+        from agentspan.agents.tool import wait_for_message_tool
+
+        td = wait_for_message_tool(name="poll", description="Poll", batch_size=5, blocking=False)
+        assert td.config["batchSize"] == 5
+        assert td.config["blocking"] is False

--- a/server/src/main/java/dev/agentspan/runtime/compiler/AgentCompiler.java
+++ b/server/src/main/java/dev/agentspan/runtime/compiler/AgentCompiler.java
@@ -209,12 +209,13 @@ public class AgentCompiler {
         // Build termination condition
         String guardrailContinue = buildGuardrailContinue(guardrailRefs);
         String termCondition = String.format(
-                "if ( $.%s['iteration'] < %d && ($.%s['finishReason'] == 'LENGTH' || $.%s['finishReason'] == 'MAX_TOKENS' || (%s)) ) { true; } else { false; }",
+                "if ( $.%s['iteration'] < %d && $._stop_requested != true && ($.%s['finishReason'] == 'LENGTH' || $.%s['finishReason'] == 'MAX_TOKENS' || (%s)) ) { true; } else { false; }",
                 loopRef, maxTurns, llmRef, llmRef, guardrailContinue);
 
         Map<String, Object> loopInputs = new LinkedHashMap<>();
         loopInputs.put(loopRef, "${" + loopRef + "}");
         loopInputs.put(llmRef, "${" + llmRef + "}");
+        loopInputs.put("_stop_requested", "${workflow.variables._stop_requested}");
         addGuardrailInputs(loopInputs, guardrailRefs);
         WorkflowTask loop = buildDoWhile(loopRef, termCondition, loopTasks, loopInputs);
 
@@ -320,7 +321,7 @@ public class AgentCompiler {
         // Build loop body
         List<WorkflowTask> loopTasks = new ArrayList<>();
 
-        // Context injection: prepend _agent_state JSON to user prompt (with size limits)
+        // Context injection: prepend _agent_state JSON + signals to user prompt (with size limits)
         String ctxInjectRef = config.getName() + "_ctx_inject";
         WorkflowTask ctxInject = new WorkflowTask();
         ctxInject.setType("INLINE");
@@ -328,6 +329,7 @@ public class AgentCompiler {
         Map<String, Object> ctxInjectInputs = new LinkedHashMap<>();
         ctxInjectInputs.put("evaluatorType", "graaljs");
         ctxInjectInputs.put("state", "${workflow.variables._agent_state}");
+        ctxInjectInputs.put("signals", "${workflow.variables._signal_injection}");
         ctxInjectInputs.put("prompt", "${workflow.input.prompt}");
         ctxInjectInputs.put("maxSize", contextMaxSizeBytes);
         ctxInjectInputs.put("maxValueSize", contextMaxValueSizeBytes);
@@ -442,7 +444,7 @@ public class AgentCompiler {
 
         StringBuilder termCondition = new StringBuilder();
         termCondition.append(String.format(
-                "if ( $.%s['iteration'] < %d && ($.%s['finishReason'] == 'LENGTH' || $.%s['finishReason'] == 'MAX_TOKENS' || %s)",
+                "if ( $.%s['iteration'] < %d && $._stop_requested != true && ($.%s['finishReason'] == 'LENGTH' || $.%s['finishReason'] == 'MAX_TOKENS' || %s)",
                 loopRef, maxTurns, llmRef, llmRef, loopReason));
         if (stopWhenRef != null) {
             termCondition.append(String.format(" && $.%s.should_continue == true", stopWhenRef));
@@ -455,6 +457,7 @@ public class AgentCompiler {
         Map<String, Object> loopInputs = new LinkedHashMap<>();
         loopInputs.put(loopRef, "${" + loopRef + "}");
         loopInputs.put(llmRef, "${" + llmRef + "}");
+        loopInputs.put("_stop_requested", "${workflow.variables._stop_requested}");
         if (stopWhenRef != null) loopInputs.put(stopWhenRef, "${" + stopWhenRef + "}");
         if (terminationRef != null) loopInputs.put(terminationRef, "${" + terminationRef + "}");
         addGuardrailInputs(loopInputs, guardrailRefs);
@@ -488,6 +491,8 @@ public class AgentCompiler {
         // Initialize workflow variables
         Map<String, Object> initVars = new LinkedHashMap<>();
         initVars.put("_agent_state", "${" + ctxResolveRef + ".output.result}");
+        initVars.put("_stop_requested", false);
+        initVars.put("_signal_injection", "");
         if (hasApproval) {
             // Pre-initialize to empty string so the system message doesn't
             // have null content on the first loop iteration.
@@ -655,7 +660,7 @@ public class AgentCompiler {
         // Build loop body
         List<WorkflowTask> loopTasks = new ArrayList<>();
 
-        // Context injection for hybrid loop (with size limits)
+        // Context injection for hybrid loop (with size limits + signals)
         String hybridCtxInjectRef = config.getName() + "_ctx_inject";
         WorkflowTask hybridCtxInject = new WorkflowTask();
         hybridCtxInject.setType("INLINE");
@@ -663,6 +668,7 @@ public class AgentCompiler {
         Map<String, Object> hybridCtxInjectInputs = new LinkedHashMap<>();
         hybridCtxInjectInputs.put("evaluatorType", "graaljs");
         hybridCtxInjectInputs.put("state", "${workflow.variables._agent_state}");
+        hybridCtxInjectInputs.put("signals", "${workflow.variables._signal_injection}");
         hybridCtxInjectInputs.put("prompt", "${workflow.input.prompt}");
         hybridCtxInjectInputs.put("maxSize", contextMaxSizeBytes);
         hybridCtxInjectInputs.put("maxValueSize", contextMaxValueSizeBytes);
@@ -746,12 +752,13 @@ public class AgentCompiler {
         }
 
         String termCondition = String.format(
-                "if ( $.%s['iteration'] < %d && ($.%s['finishReason'] == 'LENGTH' || $.%s['finishReason'] == 'MAX_TOKENS' || (%s && %s)) ) { true; } else { false; }",
+                "if ( $.%s['iteration'] < %d && $._stop_requested != true && ($.%s['finishReason'] == 'LENGTH' || $.%s['finishReason'] == 'MAX_TOKENS' || (%s && %s)) ) { true; } else { false; }",
                 loopRef, maxTurns, llmRef, llmRef, loopReason, notTransfer);
 
         Map<String, Object> loopInputs = new LinkedHashMap<>();
         loopInputs.put(loopRef, "${" + loopRef + "}");
         loopInputs.put(llmRef, "${" + llmRef + "}");
+        loopInputs.put("_stop_requested", "${workflow.variables._stop_requested}");
         loopInputs.put(checkTransferRef, "${" + checkTransferRef + "}");
         addGuardrailInputs(loopInputs, guardrailRefs);
         WorkflowTask loop = buildDoWhile(loopRef, termCondition, loopTasks, loopInputs);
@@ -790,6 +797,8 @@ public class AgentCompiler {
         // Initialize workflow variables
         Map<String, Object> initHybridVars = new LinkedHashMap<>();
         initHybridVars.put("_agent_state", "${" + hybridCtxResolveRef + ".output.result}");
+        initHybridVars.put("_stop_requested", false);
+        initHybridVars.put("_signal_injection", "");
         if (hasApproval) {
             initHybridVars.put("_human_feedback", "");
         }

--- a/server/src/main/java/dev/agentspan/runtime/controller/AgentController.java
+++ b/server/src/main/java/dev/agentspan/runtime/controller/AgentController.java
@@ -177,6 +177,19 @@ public class AgentController {
         agentService.cancelAgent(executionId, reason);
     }
 
+    /** Gracefully stop an agent execution (loop exits after current iteration). */
+    @PostMapping("/{executionId}/stop")
+    public void stopAgent(@PathVariable String executionId) {
+        agentService.stopAgent(executionId);
+    }
+
+    /** Inject a persistent signal into a running agent's context. */
+    @PostMapping("/{executionId}/signal")
+    public void signalAgent(@PathVariable String executionId, @RequestBody Map<String, Object> body) {
+        String message = body != null ? (String) body.getOrDefault("message", "") : "";
+        agentService.signalAgent(executionId, message);
+    }
+
     /**
      * Get the current status of an agent execution.
      * Lightweight polling fallback when SSE is not available.

--- a/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -35,6 +35,7 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.service.ExecutionService;
+import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.service.WorkflowService;
 
 import dev.agentspan.runtime.auth.RequestContextHolder;
@@ -485,7 +486,7 @@ public class AgentService {
     public void stopAgent(String executionId) {
         // Set the stop flag — the DoWhile loop condition checks this variable.
         // Get the workflow model, update its variables map, and persist.
-        com.netflix.conductor.model.WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
+        WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
         workflow.getVariables().put("_stop_requested", true);
         executionDAO.updateWorkflow(workflow);
         // Note: the SDK also sends a WMQ unblock message via the Conductor client
@@ -500,7 +501,7 @@ public class AgentService {
      * LLM's user message as {@code [SIGNALS]...[/SIGNALS]}.</p>
      */
     public void signalAgent(String executionId, String message) {
-        com.netflix.conductor.model.WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
+        WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
         workflow.getVariables().put("_signal_injection", message != null ? message : "");
         executionDAO.updateWorkflow(workflow);
     }

--- a/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -34,8 +34,8 @@ import com.netflix.conductor.core.execution.StartWorkflowInput;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
-import com.netflix.conductor.service.ExecutionService;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.ExecutionService;
 import com.netflix.conductor.service.WorkflowService;
 
 import dev.agentspan.runtime.auth.RequestContextHolder;

--- a/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -32,6 +32,7 @@ import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.core.execution.StartWorkflowInput;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.service.ExecutionService;
 import com.netflix.conductor.service.WorkflowService;
@@ -56,6 +57,7 @@ public class AgentService {
 
     private final AgentCompiler agentCompiler;
     private final NormalizerRegistry normalizerRegistry;
+    private final ExecutionDAO executionDAO;
     private final MetadataDAO metadataDAO;
     private final WorkflowExecutor workflowExecutor;
     private final WorkflowService workflowService;
@@ -70,6 +72,7 @@ public class AgentService {
     AgentService(
             AgentCompiler agentCompiler,
             NormalizerRegistry normalizerRegistry,
+            ExecutionDAO executionDAO,
             MetadataDAO metadataDAO,
             WorkflowExecutor workflowExecutor,
             WorkflowService workflowService,
@@ -79,6 +82,7 @@ public class AgentService {
             ExecutionTokenService executionTokenService) {
         this.agentCompiler = agentCompiler;
         this.normalizerRegistry = normalizerRegistry;
+        this.executionDAO = executionDAO;
         this.metadataDAO = metadataDAO;
         this.workflowExecutor = workflowExecutor;
         this.workflowService = workflowService;
@@ -468,6 +472,37 @@ public class AgentService {
     /** Cancel a running agent execution. */
     public void cancelAgent(String executionId, String reason) {
         workflowService.terminateWorkflow(executionId, reason != null ? reason : "Cancelled by user");
+    }
+
+    /**
+     * Gracefully stop an agent execution by setting the _stop_requested flag.
+     *
+     * <p>The loop exits after the current iteration completes and the workflow
+     * reaches COMPLETED status with the last LLM output as the result.
+     * Also sends a WMQ message to unblock agents waiting on
+     * PULL_WORKFLOW_MESSAGES.</p>
+     */
+    public void stopAgent(String executionId) {
+        // Set the stop flag — the DoWhile loop condition checks this variable.
+        // Get the workflow model, update its variables map, and persist.
+        com.netflix.conductor.model.WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
+        workflow.getVariables().put("_stop_requested", true);
+        executionDAO.updateWorkflow(workflow);
+        // Note: the SDK also sends a WMQ unblock message via the Conductor client
+        // to wake agents blocked on PULL_WORKFLOW_MESSAGES.
+    }
+
+    /**
+     * Inject a persistent signal into a running agent's context.
+     *
+     * <p>Sets the {@code _signal_injection} workflow variable. The context
+     * injection script reads this on each iteration and prepends it to the
+     * LLM's user message as {@code [SIGNALS]...[/SIGNALS]}.</p>
+     */
+    public void signalAgent(String executionId, String message) {
+        com.netflix.conductor.model.WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
+        workflow.getVariables().put("_signal_injection", message != null ? message : "");
+        executionDAO.updateWorkflow(workflow);
     }
 
     /**

--- a/server/src/main/java/dev/agentspan/runtime/util/JavaScriptBuilder.java
+++ b/server/src/main/java/dev/agentspan/runtime/util/JavaScriptBuilder.java
@@ -1172,17 +1172,19 @@ public class JavaScriptBuilder {
                 // since bracket notation may not work for Java Maps.
                 "var rawState = $.state;"
                         + "var prompt = $.prompt || '';"
-                        + "if (!rawState) return prompt;"
+                        + "var signals = $.signals || '';"
+                        + "if (!rawState && !signals) return prompt;"
                         + "var maxSize = $.maxSize || 32768;"
                         + "var maxValueSize = $.maxValueSize || 4096;"
                         // Collect map entries via for-in (works on Java Maps in GraalJS)
                         + "var state = {};"
-                        + "for (var k in rawState) {"
-                        + "  var v = rawState.get(k);"
-                        + "  if (v != null) state[k] = '' + v;"
+                        + "if (rawState) {"
+                        + "  for (var k in rawState) {"
+                        + "    var v = rawState.get(k);"
+                        + "    if (v != null) state[k] = '' + v;"
+                        + "  }"
                         + "}"
                         + "var keys = Object.keys(state);"
-                        + "if (keys.length === 0) return prompt;"
                         // Per-value truncation
                         + "var truncated = {};"
                         + "for (var i = 0; i < keys.length; i++) {"
@@ -1198,9 +1200,16 @@ public class JavaScriptBuilder {
                         + "  delete truncated[tKeys.shift()];"
                         + "  json = JSON.stringify(truncated);"
                         + "}"
-                        + "if (Object.keys(truncated).length === 0) return prompt;"
-                        + "return 'Context:\\n```json\\n' + JSON.stringify(truncated, null, 2) + '\\n```\\n\\n' + prompt;");
+                        // Build result: signals (if any) + context (if any) + prompt
+                        + "var parts = [];"
+                        + "if (signals) { parts.push('[SIGNALS]\\n' + signals + '\\n[/SIGNALS]'); }"
+                        + "if (Object.keys(truncated).length > 0) {"
+                        + "  parts.push('Context:\\n```json\\n' + JSON.stringify(truncated, null, 2) + '\\n```');"
+                        + "}"
+                        + "parts.push(prompt);"
+                        + "return parts.join('\\n\\n');");
     }
+
 
     /**
      * Namespaced parallel merge script: merges parent context with

--- a/server/src/main/java/dev/agentspan/runtime/util/JavaScriptBuilder.java
+++ b/server/src/main/java/dev/agentspan/runtime/util/JavaScriptBuilder.java
@@ -1210,7 +1210,6 @@ public class JavaScriptBuilder {
                         + "return parts.join('\\n\\n');");
     }
 
-
     /**
      * Namespaced parallel merge script: merges parent context with
      * each child's context namespaced under its agent name.

--- a/server/src/test/java/dev/agentspan/runtime/service/AgentServiceTokenTest.java
+++ b/server/src/test/java/dev/agentspan/runtime/service/AgentServiceTokenTest.java
@@ -36,6 +36,9 @@ class AgentServiceTokenTest {
     private dev.agentspan.runtime.compiler.AgentCompiler agentCompiler;
 
     @Mock
+    private com.netflix.conductor.dao.ExecutionDAO executionDAO;
+
+    @Mock
     private com.netflix.conductor.dao.MetadataDAO metadataDAO;
 
     @Mock
@@ -65,6 +68,7 @@ class AgentServiceTokenTest {
         agentService = new AgentService(
                 agentCompiler,
                 normalizerRegistry,
+                executionDAO,
                 metadataDAO,
                 workflowExecutor,
                 workflowService,


### PR DESCRIPTION
## What is this?

Agent Signals gives you two ways to communicate with a running agent from outside the workflow:

1. **`handle.stop()`** — Deterministic loop exit. The agent finishes its current iteration and the workflow completes gracefully. The LLM cannot ignore or override it.

2. **`runtime.signal(eid, message)`** — Persistent context injection. The message is injected into the LLM's context on every subsequent iteration until overwritten or cleared. Works on any agent — no special tools or instructions required.

Both operate through Conductor workflow variables.

## Why?

Previously, stopping a long-running agent required the LLM to cooperate:

```python
# Non-deterministic — the LLM could ignore it
runtime.send_message(eid, {"stop": True})
```

Multi-agent scenarios were worse: stop signals had to propagate through dedicated forwarding tools (`stop_pipeline()`, `stop_monitor()`, `stop_all_workers()`), each requiring its own instructions.

There was no way to inject context mid-run. If an agent was on a 10-iteration research task and going off-topic, you had no channel to redirect it.

## How it works

### Deterministic stop

The compiler adds `_stop_requested` to every workflow and checks it in every DoWhile loop condition:

```javascript
&& ${workflow.variables._stop_requested} != true
```

`handle.stop()` sets this variable, then unblocks any iteration waiting on a message so the current loop can finish.

```python
handle.stop()
result = handle.join(timeout=30)  # status: COMPLETED, output preserved
```

Multi-agent shutdown:

```python
orch_handle.stop()
for wh in worker_handles:
    wh.stop()
collector_handle.stop()
```

| | `handle.stop()` | `handle.cancel()` |
|---|---|---|
| Mechanism | Workflow variable flag | `terminateWorkflow` |
| Timing | After current iteration | Immediate |
| Final status | `COMPLETED` | `TERMINATED` |
| Output preserved | Yes | No |

### Signal injection

`runtime.signal()` sets the `_signal_injection` workflow variable. The context injection script reads it and prepends a `[SIGNALS]...[/SIGNALS]` block to the LLM's user message each iteration.

```python
runtime.signal(eid, "Focus on alignment research, not sci-fi scenarios")

# Overwrite:
runtime.signal(eid, "New priority: focus on governance frameworks")

# Clear:
runtime.signal(eid, "")
```

## Signal injection: current implementation and future direction

### Current: workflow variables

`runtime.signal(eid, msg)` sets the `_signal_injection` workflow variable directly via Conductor's `updateVariables` API. The context injection script reads this variable at the start of each loop iteration and prepends signal content to the LLM's user message. Zero extra tasks per iteration. Simple and functional.

**Limitation:** last-writer-wins. If two signals are sent between iterations, the first is lost. This matters for multi-signaler scenarios — a supervisor agent and a monitoring system both sending corrections, or a human and an automated guardrail both redirecting simultaneously.

### Future: named WMQ queues

Conductor's Workflow Message Queue will be extended to support named queues. Each workflow gets multiple independent queues partitioned by name. The signal implementation will move from workflow variables to a dedicated `_signals` queue:

```python
# SDK API stays the same
runtime.signal(eid, "Focus on alignment research")
runtime.signal(eid, "Also cover governance frameworks")
# Both signals are queued and delivered on the next iteration
```

**Why named queues are the right architecture:**

- **Queuing** — all signals are preserved in FIFO order. No lost messages regardless of send rate or number of concurrent signalers.
- **Atomic consumption** — `PULL_WORKFLOW_MESSAGES` dequeues atomically. No race window between read and clear.
- **No contention** — the `_signals` queue is independent from the default WMQ queue used by `send_message()` / `wait_for_message_tool`.
- **Reuses existing infrastructure** — WMQ's durability, ordering, and consumption mechanics are battle-tested. Named queues add one column (`queue_name`) to the existing storage.

**What the compiler adds to each loop (3 tasks, only active when signals are pending):**

```
PULL_WORKFLOW_MESSAGES(queue="_signals", blocking=false, batchSize=10)
  → INLINE: format dequeued messages into text
  → SET_VARIABLE: store in _signal_injection for context injection
```

Non-blocking pull returns instantly when the queue is empty — near-zero overhead for agents that receive no signals.

### Migration path

The SDK API (`runtime.signal(eid, msg)` / `handle.stop()`) does not change. Only the internal transport shifts from `update_variables` to `send_message(queue="_signals")`. No user-facing migration, no breaking changes.

## Test plan

- [x] 13 unit tests for stop, signal, and blocking parameter
- [x] Full unit suite passes (1485 tests, 0 failures)
- [x] Server: compile workflow → verify loop condition contains `_stop_requested`
- [x] Server: compile workflow → verify context injection reads `_signal_injection`
- [x] Run examples 75–82 and 84 against live server
