### PR TITLE
Add parallel code review blog example

### DIFF
--- a/sdk/python/examples/blog_and_videos/parallel_execution/02_code_review_parallel.py
+++ b/sdk/python/examples/blog_and_videos/parallel_execution/02_code_review_parallel.py
@@ -1,0 +1,113 @@
+import warnings
+import logging
+
+warnings.filterwarnings("ignore")
+logging.disable(logging.CRITICAL)
+
+"""Parallel Code Review — Bug Reviewer | Security Reviewer | Style Reviewer
+
+Three agents review the same code simultaneously, each looking for
+different issues. Results arrive together.
+
+Demonstrates:
+    - Parallel strategy with Strategy.PARALLEL
+    - AgentRuntime for durable execution
+    - sub_results for per-agent outputs
+
+Setup:
+    pip install agentspan
+    agentspan server start
+    python 02_code_review_parallel.py
+"""
+
+from agentspan.agents import Agent, AgentRuntime, Strategy
+
+
+# ── Agents ────────────────────────────────────────────────────────
+
+bug_reviewer = Agent(
+    name="bug_reviewer",
+    model="openai/gpt-4o",
+    instructions=(
+        "You are a senior software engineer reviewing code for bugs. "
+        "Find: logic errors, unhandled edge cases, crashes, incorrect "
+        "behavior, and anything that doesn't match the stated intent. "
+        "Be specific — reference the function name and explain what's "
+        "wrong and how to fix it. If the code is correct, say so."
+    ),
+)
+
+security_reviewer = Agent(
+    name="security_reviewer",
+    model="openai/gpt-4o",
+    instructions=(
+        "You are an application security engineer reviewing code for "
+        "vulnerabilities. Find: injection flaws (SQL, command, path "
+        "traversal), insecure defaults, data exposure, missing input "
+        "validation, and OWASP Top 10 issues. Rate each finding as "
+        "Critical, High, Medium, or Low. If the code is clean, say so."
+    ),
+)
+
+style_reviewer = Agent(
+    name="style_reviewer",
+    model="openai/gpt-4o",
+    instructions=(
+        "You are a Python code quality reviewer. Check for: missing "
+        "type hints, missing docstrings, hardcoded values that should "
+        "be constants or config, print statements that should use "
+        "logging, naming conventions, and general readability. Keep "
+        "feedback constructive and actionable."
+    ),
+)
+
+# ── Parallel Review ──────────────────────────────────────────────
+
+review = Agent(
+    name="code_review",
+    model="openai/gpt-4o",
+    agents=[bug_reviewer, security_reviewer, style_reviewer],
+    strategy=Strategy.PARALLEL,
+)
+
+
+# ── Sample Input ─────────────────────────────────────────────────
+
+SAMPLE_CODE = """
+Review this code:
+
+import os
+
+def process_upload(filename, data):
+    path = f"/uploads/{filename}"
+    with open(path, "wb") as f:
+        f.write(data)
+    os.chmod(path, 0o777)
+    return path
+
+def get_user(db, user_id):
+    query = f"SELECT * FROM users WHERE id = {user_id}"
+    return db.execute(query).fetchone()
+
+def send_welcome(user):
+    print(f"Welcome {user['name']}!")
+    return True
+"""
+
+
+# ── Run ───────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    with AgentRuntime() as runtime:
+        print("Starting parallel code review...\n")
+        result = runtime.run(review, SAMPLE_CODE)
+
+        # Print each reviewer's findings
+        if result.sub_results:
+            for agent_name, sub in result.sub_results.items():
+                print(f"\n{'=' * 50}")
+                print(f"  {agent_name}")
+                print(f"{'=' * 50}")
+                print(sub if isinstance(sub, str) else sub.get("result", sub))
+        else:
+            result.print_result()


### PR DESCRIPTION
## Summary
- Add `blog_and_videos/parallel_execution/` folder under `sdk/python/examples/`
- `02_code_review_parallel.py` — three agents (bug, security, style) review the same code simultaneously using `Strategy.PARALLEL`

For the blog post: "Three Reviewers, One PR, Zero Wait: Build a Parallel AI Agent Pipeline"

## Test plan
- [ ] `agentspan server start` then `python 02_code_review_parallel.py` runs end to end
- [ ] `result.sub_results` contains output from all three reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)