### PR TITLE
fix(runtime): skip ToolDef check for claude-code agents in _has_stateful_tools

### DIFF
--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -87,11 +87,18 @@ def _passthrough_task_def(name: str) -> Any:
 
 def _has_stateful_tools(agent: Any) -> bool:
     """Return True if the agent is stateful or any @tool has stateful=True."""
-    from agentspan.agents.tool import get_tool_defs
+    from agentspan.agents.tool import ToolDef, get_tool_defs
 
     if getattr(agent, "stateful", False):
         return True
-    for td in get_tool_defs(getattr(agent, "tools", [])):
+    # Only inspect tools that can carry stateful metadata — callables
+    # (@tool / @worker_task) and ToolDef instances.  Plain strings (e.g.
+    # built-in tool names) can never be stateful and must be skipped so
+    # get_tool_def() does not raise TypeError.
+    resolvable = [
+        t for t in getattr(agent, "tools", []) if callable(t) or isinstance(t, ToolDef)
+    ]
+    for td in get_tool_defs(resolvable):
         if getattr(td, "stateful", False):
             return True
     for sub in getattr(agent, "agents", []):

--- a/sdk/python/tests/unit/test_runtime.py
+++ b/sdk/python/tests/unit/test_runtime.py
@@ -592,6 +592,76 @@ class TestHasWorkerTools:
         assert runtime._has_worker_tools(parent) is True
 
 
+# ── _has_stateful_tools ─────────────────────────────────────────────────
+
+
+class TestHasStatefulTools:
+    """Test _has_stateful_tools() helper.
+
+    Regression: agents with string tool names (e.g. claude-code built-ins like
+    "Read", "Glob") must not crash with TypeError — strings are never stateful.
+    """
+
+    def test_string_tools_do_not_raise(self):
+        """Agents with string tool lists must not raise TypeError."""
+        from agentspan.agents.runtime.runtime import _has_stateful_tools
+
+        agent = Agent(name="cc", model="claude-code/sonnet", tools=["Read", "Glob", "Grep"])
+        # Must not raise, must return False (strings are never stateful)
+        assert _has_stateful_tools(agent) is False
+
+    def test_no_tools_returns_false(self):
+        from agentspan.agents.runtime.runtime import _has_stateful_tools
+
+        agent = Agent(name="plain", model="openai/gpt-4o")
+        assert _has_stateful_tools(agent) is False
+
+    def test_tool_def_stateful_true_returns_true(self):
+        from agentspan.agents.runtime.runtime import _has_stateful_tools
+        from agentspan.agents.tool import tool
+
+        @tool(stateful=True)
+        def stateful_tool(x: str) -> str:
+            """Stateful."""
+            return x
+
+        agent = Agent(name="stateful", model="openai/gpt-4o", tools=[stateful_tool])
+        assert _has_stateful_tools(agent) is True
+
+    def test_tool_def_stateful_false_returns_false(self):
+        from agentspan.agents.runtime.runtime import _has_stateful_tools
+        from agentspan.agents.tool import tool
+
+        @tool
+        def plain_tool(x: str) -> str:
+            """Plain."""
+            return x
+
+        agent = Agent(name="plain_tool", model="openai/gpt-4o", tools=[plain_tool])
+        assert _has_stateful_tools(agent) is False
+
+    def test_mixed_strings_and_tool_defs_not_stateful(self):
+        """A mix of strings and non-stateful @tool functions returns False."""
+        from agentspan.agents.runtime.runtime import _has_stateful_tools
+        from agentspan.agents.tool import tool
+
+        @tool
+        def helper(x: str) -> str:
+            """Helper."""
+            return x
+
+        agent = Agent(name="mixed", model="openai/gpt-4o", tools=[helper])
+        assert _has_stateful_tools(agent) is False
+
+    def test_sub_agent_with_string_tools_does_not_raise(self):
+        """String tools in sub-agents must also not raise."""
+        from agentspan.agents.runtime.runtime import _has_stateful_tools
+
+        sub = Agent(name="sub_cc", model="claude-code/sonnet", tools=["Bash", "Write"])
+        parent = Agent(name="parent", model="openai/gpt-4o", agents=[sub])
+        assert _has_stateful_tools(parent) is False
+
+
 # ── _extract_token_usage ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`_has_stateful_tools()` called `get_tool_defs()` on the raw `agent.tools` list unconditionally. When any tool entry was a plain string (e.g. built-in tool names like `"Read"`, `"Glob"`), `get_tool_def()` raised `TypeError` because it only handles callables and `ToolDef` instances.

Strings can never carry `stateful=True` metadata, so filter to callables and `ToolDef` instances before inspecting — regardless of agent type.

## Reproduction

```python
Agent(model="claude-code/sonnet", tools=["Read", "Glob", "Grep"])
# → TypeError: Expected a @tool-decorated function, @worker_task function, or ToolDef, got str
```

## Test plan

- [x] `uv run python examples/claude_agent_sdk/01_basic_agent.py` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)