### PR TITLE
fix(server): harden SQLite busy_timeout + upload test reports on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@ jobs:
           name: server-test-reports
           path: server/build/reports/tests/test/
           retention-days: 7
+      - name: Server Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          check_name: 'Server Tests'
+          check_title_template: '{{SUITE_NAME}} | {{TEST_NAME}} | {{CLASS_NAME}}'
+          report_paths: 'server/build/test-results/test/TEST-*.xml'
+          check_retries: true
+          fail_on_failure: true
+          detailed_summary: true
+          include_passed: false
+          flaky_summary: true
 
   # ── Go CLI Tests ─────────────────────────────────────────────────
   cli-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
           distribution: 'corretto'
       - name: Run server tests
         run: ./gradlew build
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-test-reports
+          path: server/build/reports/tests/test/
+          retention-days: 7
 
   # ── Go CLI Tests ─────────────────────────────────────────────────
   cli-tests:

--- a/server/src/main/java/dev/agentspan/runtime/credentials/CredentialDataSourceConfig.java
+++ b/server/src/main/java/dev/agentspan/runtime/credentials/CredentialDataSourceConfig.java
@@ -85,6 +85,12 @@ public class CredentialDataSourceConfig {
             config.setMaximumPoolSize(1);
             config.setMinimumIdle(1);
             config.setConnectionTestQuery("SELECT 1");
+            // busy_timeout: wait up to 15s when another connection holds a write lock.
+            // The production URL sets this via ?busy_timeout=15000, but the test URL uses
+            // SQLite's file: URI syntax (?mode=memory&cache=shared) where JDBC-level
+            // parameters are not parsed, so the PRAGMA never gets applied from the URL.
+            // connectionInitSql ensures it is set uniformly in all environments.
+            config.setConnectionInitSql("PRAGMA busy_timeout = 15000");
         }
 
         log.info(

--- a/server/src/test/java/dev/agentspan/runtime/credentials/CredentialDataSourceConfigTest.java
+++ b/server/src/test/java/dev/agentspan/runtime/credentials/CredentialDataSourceConfigTest.java
@@ -1,6 +1,9 @@
 package dev.agentspan.runtime.credentials;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,5 +40,30 @@ class CredentialDataSourceConfigTest {
                     .as("table %s should exist and be queryable", table)
                     .doesNotThrowAnyException();
         }
+    }
+
+    /**
+     * Confirms that busy_timeout is non-zero on credential pool connections.
+     *
+     * <p>The test URL uses SQLite's file: URI syntax (?mode=memory&cache=shared), which means
+     * ?-parameters are SQLite URI params parsed by the SQLite engine — not JDBC connection
+     * properties parsed by the xerial driver. busy_timeout is not a SQLite URI parameter, so it
+     * cannot be set via the test URL.
+     *
+     * <p>busy_timeout is applied via two sources:
+     * <ol>
+     *   <li>Our credentialDataSource.connectionInitSql sets 15000ms on every new connection.
+     *   <li>Conductor's SqliteConfiguration.initializeSqlite() overrides to 30000ms at startup.
+     * </ol>
+     * The connectionInitSql is the safety net for connections created after startup (e.g. after
+     * HikariCP evicts and recreates the connection). Without it, a new connection would have
+     * busy_timeout=0.
+     */
+    @Test
+    void credentialConnection_hasBusyTimeoutConfigured() {
+        Integer busyTimeout = credentialJdbc.queryForObject("PRAGMA busy_timeout", Map.of(), Integer.class);
+        assertThat(busyTimeout)
+                .as("busy_timeout must be > 0 to prevent immediate failure when another connection holds a write lock")
+                .isGreaterThanOrEqualTo(15000);
     }
 }

--- a/server/src/test/resources/application-test.properties
+++ b/server/src/test/resources/application-test.properties
@@ -3,7 +3,7 @@ spring.application.name=conductor
 server.port=0
 
 conductor.db.type=sqlite
-spring.datasource.url=jdbc:sqlite:file:agentspan_test?mode=memory&cache=shared
+spring.datasource.url=jdbc:sqlite:agentspan_test.db?busy_timeout=15000&journal_mode=WAL
 
 conductor.indexing.enabled=true
 conductor.elasticsearch.version=0


### PR DESCRIPTION
## Summary

- **Root cause fix**: switch test SQLite from in-memory shared-cache (`cache=shared`) to file-based WAL mode. `SQLITE_LOCKED_SHAREDCACHE` (error 517) fires when two connections sharing a cache hold conflicting table locks — `busy_timeout` has no effect on this error class. File-based WAL eliminates shared-cache contention entirely, matching the production URL format.
- **CI**: add `mikepenz/action-junit-report@v5` — test results are now visible inline on every CI run (not just failures). You can view per-test pass/fail directly on the GitHub Actions summary page, or download the `server-test-reports` artifact for the full HTML report.

## Context

`EncryptedDbCredentialStoreProviderTest` and `CredentialAwareHttpTaskTest` failed intermittently with `[SQLITE_LOCKED_SHAREDCACHE] database table is locked`. The test URL was `jdbc:sqlite:file:agentspan_test?mode=memory&cache=shared`; the new URL is `jdbc:sqlite:agentspan_test.db?busy_timeout=15000&journal_mode=WAL`.

## Test plan

- [x] All credential tests pass locally
- [x] CI run shows per-test results inline on the Actions summary page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
