### PR TITLE
fix(examples): correct router pattern in 08_router_agent

### DIFF
--- a/sdk/python/examples/08_router_agent.py
+++ b/sdk/python/examples/08_router_agent.py
@@ -3,8 +3,17 @@
 
 """Router Agent — LLM-based routing to specialists.
 
-Demonstrates the router strategy where a parent agent routes
-to the appropriate sub-agent based on the user's request.
+Demonstrates the router strategy where a dedicated router/classifier agent
+decides which specialist sub-agent handles each request.
+
+Architecture:
+    team (ROUTER, router=selector)
+    ├── planner   — design/architecture tasks
+    ├── coder     — implementation tasks
+    └── reviewer  — code review tasks
+
+The selector is a separate agent whose only job is routing.
+It is NOT one of the specialist agents.
 
 Requirements:
     - Conductor server with LLM support
@@ -35,19 +44,27 @@ reviewer = Agent(
     instructions="You review code. Check for bugs, style issues, and suggest improvements.",
 )
 
-# ── Router (LLM decides who to use) ────────────────────────────────
+# ── Dedicated router/classifier (separate from specialists) ─────────
+
+selector = Agent(
+    name="dev_team_selector",
+    model=settings.llm_model,
+    instructions=(
+        "You are a request classifier. Select the right specialist:\n"
+        "- planner: for design, architecture, or planning tasks\n"
+        "- coder: for writing or implementing code\n"
+        "- reviewer: for reviewing, auditing, or improving existing code"
+    ),
+)
+
+# ── Router team ─────────────────────────────────────────────────────
 
 team = Agent(
     name="dev_team",
     model=settings.llm_model,
-    instructions=(
-        "You are the tech lead. Route requests to the right team member: "
-        "planner for design/architecture, coder for implementation, "
-        "reviewer for code review."
-    ),
     agents=[planner, coder, reviewer],
     strategy=Strategy.ROUTER,
-    router=planner,  # Required for router strategy
+    router=selector,  # dedicated classifier — not one of the specialists
 )
 
 
@@ -64,4 +81,3 @@ if __name__ == "__main__":
         #
         # 2. In a separate long-lived worker process:
         # runtime.serve(team)
-


### PR DESCRIPTION
## Summary

- The `router` agent must be a **dedicated classifier**, separate from the specialist agents
- In `08_router_agent.py`, `router=planner` was incorrect — `planner` was listed both in `agents[]` as a specialist and as the router, giving it a dual role
- Added a dedicated `selector` agent whose only job is routing, matching the correct pattern already shown in `67_router_to_sequential.py`

## Before / After

**Before (wrong):**
```python
team = Agent(
    agents=[planner, coder, reviewer],
    strategy=Strategy.ROUTER,
    router=planner,  # planner doing double duty — specialist AND router
)
```

**After (correct):**
```python
selector = Agent(name="dev_team_selector", ...)  # dedicated classifier only

team = Agent(
    agents=[planner, coder, reviewer],  # specialists only
    strategy=Strategy.ROUTER,
    router=selector,  # separate agent whose only job is routing
)
```

## Notes

- `67_router_to_sequential.py` already had the correct pattern (`router=selector`)
- The Java SDK `Example08RouterAgent.java` was also already correct (dedicated `lang_router` agent)
- No behaviour change — purely a conceptual/correctness fix in the example

🤖 Generated with [Claude Code](https://claude.com/claude-code)