### PR TITLE
chore: add Java build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 .DS_Store
 .idea/
 __pycache__/
+
+# Java build artifacts
+*.class
+target/
+sdk/java/examples/target/
+sdk/java/target/
 sdk/python/.coverage
 sdk/python/.env
 sdk/python/validation/.env


### PR DESCRIPTION
## Why

PR #136 accidentally included 125 compiled `.class` files from `sdk/java/examples/target/` because `target/` was not in `.gitignore`. This broke the CI build (Spotless tried to check Java formatting on binary files).

## What

Added to `.gitignore`:
- `*.class` — compiled Java class files
- `target/` — Maven build output directory
- `sdk/java/examples/target/` — explicit path for the examples module
- `sdk/java/target/` — explicit path for the SDK module

🤖 Generated with [Claude Code](https://claude.com/claude-code)