### PR TITLE
fix(ui): delete agent definitions via existing /api/agent/{name} endpoint

### DIFF
--- a/ui/src/pages/definitions/Agent.tsx
+++ b/ui/src/pages/definitions/Agent.tsx
@@ -411,7 +411,7 @@ export default function AgentDefinitions() {
               // @ts-ignore
               deleteWorkflowVersionAction.mutate({
                 method: "delete",
-                path: `agent/definitions/${encodeURIComponent(
+                path: `/agent/${encodeURIComponent(
                   confirmDelete.workflowName,
                 )}?version=${confirmDelete.workflowVersion}`,
               });


### PR DESCRIPTION
## Summary
- The Agent Definitions page posted `DELETE /agent/definitions/{name}?version=N`, a path that was never registered on the server, so every delete returned `HTTP 500 — Request method 'DELETE' is not supported`.
- Point the call at the existing `DELETE /api/agent/{name}?version=N` handler (`AgentController.deleteAgent`) — the same endpoint the Go CLI already uses (`cli/client/client.go:207`).
- One-line fix, no server change.

## Reproduction (before)
1. Open the Agent Definitions page.
2. Click the trash icon on any row, confirm.
3. Network tab: `DELETE http://localhost:6767/api/agent/definitions/{name}?version=1` → `500` with body `{"message":"Request method 'DELETE' is not supported"}`.

## After
Same flow → `200 OK`; row disappears from the table.

## Test plan
- [x] `pnpm --filter ui build` succeeds.
- [x] Start server (`./gradlew :server:bootRun`), deploy an agent via CLI (`agentspan deploy ...`), open the UI, click delete, confirm — row removed, no 500.
- [x] Deleting via the CLI (`agentspan delete <name>`) continues to work (unchanged endpoint).