### PR TITLE
feat(ui): remove run and tag row actions from agent definitions table

### DIFF
--- a/ui/src/pages/definitions/Agent.tsx
+++ b/ui/src/pages/definitions/Agent.tsx
@@ -3,7 +3,6 @@ import {
   CopySimple as CopyIcon,
   Trash as DeleteIcon,
   ArrowClockwise as RefreshIcon,
-  Tag as TagIcon,
 } from "@phosphor-icons/react";
 import { Button, DataTable, IconButton, NavLink, Paper } from "components";
 import { FilterObjectItem } from "components/DataTable/state";
@@ -12,7 +11,6 @@ import Header from "components/Header";
 import NoDataComponent from "components/NoDataComponent";
 import { SnackbarMessage } from "components/SnackbarMessage";
 import ConfirmChoiceDialog from "components/ConfirmChoiceDialog";
-import AddTagDialog, { TagDialogProps } from "components/tags/AddTagDialog";
 import TagList from "components/v1/TagList";
 import PlayIcon from "components/v1/icons/PlayIcon";
 import { MessageContext } from "components/v1/layout/MessageContext";
@@ -20,7 +18,6 @@ import { removeDeletedWorkflow } from "pages/runWorkflow/runWorkflowUtils";
 import { useCallback, useContext, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
 import { UseQueryResult } from "react-query";
-import { useNavigate } from "react-router";
 import SectionContainer from "shared/SectionContainer";
 import SectionHeader from "shared/SectionHeader";
 import SectionHeaderActions from "shared/SectionHeaderActions";
@@ -42,14 +39,10 @@ import { getUniqueWorkflows } from "utils/workflow";
 import CloneAgentDialog from "./dialog/CloneAgentDialog";
 
 export default function AgentDefinitions() {
-  const navigate = useNavigate();
   const { isTrialExpired } = useAuth();
 
   const { data, isFetching, refetch }: UseQueryResult<WorkflowDef[]> =
     useWorkflowDefs();
-  const [showAddTagDialog, setShowAddTagDialog] = useState(false);
-  const [addTagDialogData, setAddTagDialogData] =
-    useState<TagDialogProps | null>(null);
 
   const [selectedWorkflowWithAction, setSelectedWorkflowWithAction] = useState<{
     selectedWorkflow: WorkflowDef | null;
@@ -242,37 +235,6 @@ export default function AgentDefinitions() {
         renderer: (name: string, workflowRowData: WorkflowDef) => {
           return (
             <Box style={{ display: "flex", justifyContent: "space-evenly" }}>
-              <Tooltip title={"Run agent"}>
-                <IconButton
-                  id={`run-${workflowRowData.name}-btn`}
-                  disabled={isTrialExpired}
-                  onClick={() => {
-                    navigate("/runWorkflow", {
-                      state: {
-                        execution: {
-                          workflowName: workflowRowData.name,
-                          workflowVersion: workflowRowData.version,
-                          input: workflowRowData?.inputParameters
-                            ? Object.fromEntries(
-                                workflowRowData.inputParameters.map((key) => [
-                                  key,
-                                  "",
-                                ]),
-                              )
-                            : {},
-                        },
-                      },
-                    });
-                  }}
-                  size="small"
-                  sx={{
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  <PlayIcon size={22} />
-                </IconButton>
-              </Tooltip>
-
               <Tooltip title={"Clone agent"}>
                 <IconButton
                   onClick={() =>
@@ -288,23 +250,6 @@ export default function AgentDefinitions() {
                   }}
                 >
                   <CopyIcon size={20} />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title={"Add/Edit tags"}>
-                <IconButton
-                  id={`add-tags-${workflowRowData.name}-btn`}
-                  disabled={isTrialExpired}
-                  onClick={() => {
-                    setAddTagDialogData({
-                      tags: workflowRowData.tags || [],
-                      itemName: workflowRowData.name,
-                      itemType: "workflow",
-                    } as TagDialogProps);
-                    setShowAddTagDialog(true);
-                  }}
-                  size="small"
-                >
-                  <TagIcon size={20} />
                 </IconButton>
               </Tooltip>
 
@@ -335,7 +280,7 @@ export default function AgentDefinitions() {
         },
       },
     ],
-    [data, navigate, isTrialExpired],
+    [data, isTrialExpired],
   );
 
   const handleFilterChange = useCallback(
@@ -387,22 +332,6 @@ export default function AgentDefinitions() {
             workflowList={data ?? []}
           />
         )}
-
-      <AddTagDialog
-        open={showAddTagDialog && !!addTagDialogData}
-        tags={addTagDialogData?.tags || []}
-        itemType={addTagDialogData?.itemType}
-        itemName={addTagDialogData?.itemName}
-        onClose={() => {
-          setShowAddTagDialog(false);
-          setAddTagDialogData(null);
-        }}
-        onSuccess={() => {
-          setShowAddTagDialog(false);
-          setAddTagDialogData(null);
-          refetch();
-        }}
-      />
 
       {confirmDelete && (
         <ConfirmChoiceDialog

--- a/ui/src/pages/definitions/__tests__/Agent.test.tsx
+++ b/ui/src/pages/definitions/__tests__/Agent.test.tsx
@@ -1,0 +1,141 @@
+import { render } from "@testing-library/react";
+import { createContext } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
+import AgentDefinitions from "../Agent";
+
+vi.mock("utils/query", () => ({
+  useWorkflowDefs: () => ({
+    data: [
+      {
+        name: "test_agent",
+        version: 1,
+        createTime: 0,
+        tags: [],
+        inputParameters: [],
+      },
+    ],
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+  useActionWithPath: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("shared/auth", () => ({
+  useAuth: () => ({ isTrialExpired: false }),
+}));
+
+vi.mock("components/v1/layout/MessageContext", () => ({
+  MessageContext: createContext({ setMessage: () => {} }),
+}));
+
+vi.mock("utils/hooks/usePushHistory", () => ({
+  usePushHistory: () => vi.fn(),
+}));
+
+vi.mock("utils/hooks/useCustomPagination", () => ({
+  default: () => [
+    { filterParam: "", pageParam: "1", searchParam: "" },
+    {
+      setFilterParam: vi.fn(),
+      setSearchParam: vi.fn(),
+      handlePageChange: vi.fn(),
+    },
+  ],
+}));
+
+vi.mock("pages/runWorkflow/runWorkflowUtils", () => ({
+  removeDeletedWorkflow: vi.fn(),
+}));
+
+vi.mock("utils/workflow", () => ({
+  getUniqueWorkflows: (data: any[]) => data,
+}));
+
+// Render DataTable minimally: invoke the `actions` column renderer with row data
+vi.mock("components", () => ({
+  Button: ({ children, ...p }: any) => <button {...p}>{children}</button>,
+  DataTable: ({ columns, data }: any) => {
+    const actionsCol = columns.find((c: any) => c.id === "actions");
+    return (
+      <div>
+        {data.map((row: any) => (
+          <div key={row.name}>{actionsCol.renderer(row.name, row)}</div>
+        ))}
+      </div>
+    );
+  },
+  IconButton: ({ children, id, ...p }: any) => (
+    <button id={id} {...p}>
+      {children}
+    </button>
+  ),
+  NavLink: ({ children }: any) => <a>{children}</a>,
+  Paper: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("components/Header", () => ({
+  default: () => null,
+}));
+vi.mock("components/NoDataComponent", () => ({
+  default: () => null,
+}));
+vi.mock("components/SnackbarMessage", () => ({
+  SnackbarMessage: () => null,
+}));
+vi.mock("components/ConfirmChoiceDialog", () => ({
+  default: () => null,
+}));
+vi.mock("components/tags/AddTagDialog", () => ({
+  default: () => null,
+}));
+vi.mock("components/v1/TagList", () => ({
+  default: () => null,
+}));
+vi.mock("components/v1/icons/PlayIcon", () => ({
+  default: () => null,
+}));
+vi.mock("shared/SectionHeader", () => ({
+  default: ({ title }: any) => <h1>{title}</h1>,
+}));
+vi.mock("shared/SectionHeaderActions", () => ({
+  default: () => null,
+}));
+vi.mock("shared/SectionContainer", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock("./dialog/CloneAgentDialog", () => ({
+  default: () => null,
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("AgentDefinitions row actions", () => {
+  it("does not render a Run action button for the row", () => {
+    render(<AgentDefinitions />, { wrapper });
+    expect(
+      document.getElementById("run-test_agent-btn"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render an Add/Edit Tags action button for the row", () => {
+    render(<AgentDefinitions />, { wrapper });
+    expect(
+      document.getElementById("add-tags-test_agent-btn"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still renders the Delete action button for the row", () => {
+    render(<AgentDefinitions />, { wrapper });
+    expect(
+      document.getElementById("delete-test_agent-btn"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the per-row **Run agent** and **Add/Edit tags** icon buttons from the Actions column on the agent definitions page.
- The Clone and Delete row actions remain; the page-level **Run agent** header button is untouched.
- Drop now-unused `AddTagDialog` render, related state, and imports (`useNavigate`, `TagIcon`, `TagDialogProps`).
- Add vitest coverage in `ui/src/pages/definitions/__tests__/Agent.test.tsx`.

## Why
Conductor OSS 3.30 has no tag endpoint, so the per-row Tags action is broken. The per-row Run button was also being trimmed as part of simplifying the row action set — the page-level Run button on the header is the intended entry point.

## Test plan
- [x] Write failing test first (RED): ran on unmodified code → Run + Tag button assertions failed as expected, Delete assertion passed.
- [x] Apply code change, rerun (GREEN): all 3 tests pass.
- [x] `pnpm typecheck` produces no new errors (pre-existing `@mui/types` error in `Dropdown.tsx` unrelated to this change).
- [x] Manually verify in the UI: Agent definitions table shows only Clone + Delete icons per row; top-right "Run agent" button still works.

<img width="1200" height="542" alt="Screenshot 2026-04-17 at 21 23 12" src="https://github.com/user-attachments/assets/9db980ac-9a23-4fed-af4f-c45f8765eb3d" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)