### PR TITLE
docs(examples): update 76-82 requirements to reference AgentSpan server

### DIFF
--- a/sdk/python/examples/76_wait_for_message_streaming.py
+++ b/sdk/python/examples/76_wait_for_message_streaming.py
@@ -13,7 +13,7 @@ receives (by calling wait_for_message again), then waits again.  The caller
 drives the conversation by sending messages and reading streamed events.
 
 Requirements:
-    - Conductor server with WMQ support (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
 """

--- a/sdk/python/examples/77_kafka_consumer_agent.py
+++ b/sdk/python/examples/77_kafka_consumer_agent.py
@@ -16,7 +16,7 @@ The agent loops forever:
 
 Requirements:
     - Kafka broker on localhost:9092 with topic le_random_topic
-    - Conductor server with WMQ support (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
     - confluent-kafka  (uv pip install confluent-kafka)

--- a/sdk/python/examples/78_approval_workflow.py
+++ b/sdk/python/examples/78_approval_workflow.py
@@ -34,7 +34,7 @@ Scenario:
     blocks on flag_for_approval until the operator responds.
 
 Requirements:
-    - Conductor server with WMQ support (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
 """

--- a/sdk/python/examples/79_agent_message_bus.py
+++ b/sdk/python/examples/79_agent_message_bus.py
@@ -29,7 +29,7 @@ Scenario:
     Researcher autonomously drives the Writer.
 
 Requirements:
-    - Conductor server with WMQ support (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
     - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
 """

--- a/sdk/python/examples/80_live_dashboard.py
+++ b/sdk/python/examples/80_live_dashboard.py
@@ -38,7 +38,7 @@ How this differs from 79_agent_message_bus:
     content pipeline.
 
 Requirements:
-    - Conductor server with WMQ support (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
     - AGENTSPAN_LLM_MODEL=anthropic/claude-sonnet-4-20250514 as environment variable
 """

--- a/sdk/python/examples/81_chat_repl.py
+++ b/sdk/python/examples/81_chat_repl.py
@@ -44,7 +44,7 @@ Ephemeral tools via /tool <name>:
         bullet_split — split input into one bullet point per sentence
 
 Requirements:
-    - Conductor server with WMQ support (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
     - AGENTSPAN_LLM_MODEL=anthropic/claude-sonnet-4-20250514 as environment variable
 """

--- a/sdk/python/examples/82_coding_agent.py
+++ b/sdk/python/examples/82_coding_agent.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Agentspan
 # Licensed under the MIT License. See LICENSE file in the project root for details.
 
-"""Coding Agent REPL — a filesystem-aware coding assistant backed by the Conductor server.
+"""Coding Agent REPL — a filesystem-aware coding assistant backed by AgentSpan runtime.
 
 This example is a Claude Code-style assistant you can actually use in a working session.
 It runs as a durable Conductor workflow, giving you things a local agent cannot:
@@ -18,7 +18,7 @@ Usage:
     python 82_coding_agent.py --resume             # resume last session
 
 Requirements:
-    - Conductor server (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api
     - AGENTSPAN_LLM_MODEL=anthropic/claude-sonnet-4-20250514
 """

--- a/sdk/python/examples/82_fan_out_fan_in.py
+++ b/sdk/python/examples/82_fan_out_fan_in.py
@@ -28,8 +28,8 @@ Scenario:
     aggregates the three answers into a side-by-side comparison report.
 
 Requirements:
-    - Conductor server with WMQ support
-    - AGENTSPAN_SERVER_URL=http://host.docker.internal:6767/api
+    - AgentSpan server running at http://localhost:6767
+    - AGENTSPAN_SERVER_URL=http://localhost:6767/api
     - AGENTSPAN_LLM_MODEL=anthropic/claude-sonnet-4-20250514
 """
 

--- a/sdk/python/examples/82b_coding_agent_tui.py
+++ b/sdk/python/examples/82b_coding_agent_tui.py
@@ -15,7 +15,7 @@ Usage:
 
 Requirements:
     - pip install prompt_toolkit
-    - Conductor server (conductor.workflow-message-queue.enabled=true)
+    - AgentSpan server running at http://localhost:6767
     - AGENTSPAN_SERVER_URL=http://localhost:6767/api
     - AGENTSPAN_LLM_MODEL=anthropic/claude-sonnet-4-20250514
 """


### PR DESCRIPTION
Replace Conductor/WMQ references in the Requirements docstring of examples 76-82 (plus 82b) with `- AgentSpan server running at http://localhost:6767`. Also update `82_coding_agent.py` summary line to say "backed by AgentSpan runtime".