### PR TITLE
fix(server): collapse multiple system messages for Gemini

### DIFF
--- a/server/src/main/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
+++ b/server/src/main/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
@@ -194,16 +194,28 @@ public class AgentChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletio
             sanitized.add(message);
         }
 
-        List<ChatMessage> collapsed = collapseSystemMessages(sanitized);
+        List<ChatMessage> collapsed =
+                requiresSingleSystemMessage(chatCompletion) ? collapseSystemMessages(sanitized) : sanitized;
 
         messages.clear();
         messages.addAll(collapsed);
     }
 
-    // Gemini (and some other providers) allow only one system message per request.
-    // Returns a new list where all SYSTEM entries are merged into a single
-    // SYSTEM message at the position of the first, joined with a blank line.
-    // Input list is not mutated.
+    // Gemini's generateContent API accepts only one top-level `systemInstruction`.
+    // Spring AI's GoogleGenAiChatModel enforces this by throwing when multiple
+    // SYSTEM messages are present. Other providers (OpenAI, Anthropic, ...) accept
+    // the message list unchanged.
+    private boolean requiresSingleSystemMessage(ChatCompletion chatCompletion) {
+        String provider = chatCompletion.getLlmProvider();
+        if (provider == null) {
+            return false;
+        }
+        String lowerCase = provider.toLowerCase();
+        return lowerCase.contains("google") || lowerCase.contains("gemini");
+    }
+
+    // Merge all SYSTEM entries into a single SYSTEM message at the position of
+    // the first, joined with a blank line. Returns a new list; input not mutated.
     private List<ChatMessage> collapseSystemMessages(List<ChatMessage> messages) {
         long systemCount = messages.stream()
                 .filter(m -> m.getRole() == ChatMessage.Role.system)

--- a/server/src/main/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
+++ b/server/src/main/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.ChatMessage;
@@ -193,8 +194,38 @@ public class AgentChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletio
             sanitized.add(message);
         }
 
+        List<ChatMessage> collapsed = collapseSystemMessages(sanitized);
+
         messages.clear();
-        messages.addAll(sanitized);
+        messages.addAll(collapsed);
+    }
+
+    // Gemini (and some other providers) allow only one system message per request.
+    // Returns a new list where all SYSTEM entries are merged into a single
+    // SYSTEM message at the position of the first, joined with a blank line.
+    // Input list is not mutated.
+    private List<ChatMessage> collapseSystemMessages(List<ChatMessage> messages) {
+        long systemCount = messages.stream()
+                .filter(m -> m.getRole() == ChatMessage.Role.system)
+                .count();
+        if (systemCount <= 1) {
+            return messages;
+        }
+        String mergedText = messages.stream()
+                .filter(m -> m.getRole() == ChatMessage.Role.system)
+                .map(ChatMessage::getMessage)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.joining("\n\n"));
+        ChatMessage mergedSystemChatMessage = new ChatMessage(ChatMessage.Role.system, mergedText);
+
+        List<ChatMessage> result = new ArrayList<>(messages.size());
+        result.add(mergedSystemChatMessage);
+        for (ChatMessage m : messages) {
+            if (m.getRole() != ChatMessage.Role.system) {
+                result.add(m);
+            }
+        }
+        return result;
     }
 
     void validateRunnableConversation(ChatCompletion chatCompletion) {

--- a/server/src/test/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapperTest.java
+++ b/server/src/test/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapperTest.java
@@ -280,8 +280,9 @@ class AgentChatCompleteTaskMapperTest {
     }
 
     @Test
-    void testSanitizeMessages_collapsesMultipleSystemMessages() {
+    void testSanitizeMessages_collapsesMultipleSystemMessages_forGemini() {
         ChatCompletion cc = new ChatCompletion();
+        cc.setLlmProvider("gemini");
         cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "instr A"));
         cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "feedback B"));
         cc.getMessages().add(new ChatMessage(ChatMessage.Role.user, "hello"));
@@ -296,8 +297,9 @@ class AgentChatCompleteTaskMapperTest {
     }
 
     @Test
-    void testSanitizeMessages_leavesSingleSystemMessageUntouched() {
+    void testSanitizeMessages_leavesSingleSystemMessageUntouched_forGemini() {
         ChatCompletion cc = new ChatCompletion();
+        cc.setLlmProvider("gemini");
         cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "only one"));
         cc.getMessages().add(new ChatMessage(ChatMessage.Role.user, "hello"));
 
@@ -305,6 +307,22 @@ class AgentChatCompleteTaskMapperTest {
 
         assertThat(cc.getMessages()).hasSize(2);
         assertThat(cc.getMessages().get(0).getMessage()).isEqualTo("only one");
+    }
+
+    @Test
+    void testSanitizeMessages_keepsMultipleSystemMessages_forOpenAI() {
+        ChatCompletion cc = new ChatCompletion();
+        cc.setLlmProvider("openai");
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "instr A"));
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "feedback B"));
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.user, "hello"));
+
+        mapper.sanitizeMessages(cc);
+
+        assertThat(cc.getMessages()).hasSize(3);
+        assertThat(cc.getMessages().get(0).getMessage()).isEqualTo("instr A");
+        assertThat(cc.getMessages().get(1).getMessage()).isEqualTo("feedback B");
+        assertThat(cc.getMessages().get(2).getRole()).isEqualTo(ChatMessage.Role.user);
     }
 
     @Test

--- a/server/src/test/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapperTest.java
+++ b/server/src/test/java/dev/agentspan/runtime/ai/AgentChatCompleteTaskMapperTest.java
@@ -280,6 +280,34 @@ class AgentChatCompleteTaskMapperTest {
     }
 
     @Test
+    void testSanitizeMessages_collapsesMultipleSystemMessages() {
+        ChatCompletion cc = new ChatCompletion();
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "instr A"));
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "feedback B"));
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.user, "hello"));
+
+        mapper.sanitizeMessages(cc);
+
+        assertThat(cc.getMessages()).hasSize(2);
+        assertThat(cc.getMessages().get(0).getRole()).isEqualTo(ChatMessage.Role.system);
+        assertThat(cc.getMessages().get(0).getMessage()).isEqualTo("instr A\n\nfeedback B");
+        assertThat(cc.getMessages().get(1).getRole()).isEqualTo(ChatMessage.Role.user);
+        assertThat(cc.getMessages().get(1).getMessage()).isEqualTo("hello");
+    }
+
+    @Test
+    void testSanitizeMessages_leavesSingleSystemMessageUntouched() {
+        ChatCompletion cc = new ChatCompletion();
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "only one"));
+        cc.getMessages().add(new ChatMessage(ChatMessage.Role.user, "hello"));
+
+        mapper.sanitizeMessages(cc);
+
+        assertThat(cc.getMessages()).hasSize(2);
+        assertThat(cc.getMessages().get(0).getMessage()).isEqualTo("only one");
+    }
+
+    @Test
     void testValidateRunnableConversation_rejectsMissingUserInput() {
         ChatCompletion cc = new ChatCompletion();
         cc.getMessages().add(new ChatMessage(ChatMessage.Role.system, "You are helpful."));


### PR DESCRIPTION
## Summary

- Fix `Only one system message is allowed in the prompt` error when running Gemini models through the HITL approval
  path (e.g. `sdk/python/examples/02_tools.py`).
- Root cause: `AgentCompiler` emits two SYSTEM entries (`instructions` + `_human_feedback` template) for agents with
  approval-required tools. OpenAI tolerates multiple system messages; Gemini's `generateContent`
  accepts only one top-level `systemInstruction`, and Spring AI's `GoogleGenAiChatModel` asserts this strictly.
- Gated to Gemini only — OpenAI/Anthropic/etc. paths unchanged.

## How to reproduce

```
export AGENTSPAN_LLM_MODEL="google_gemini/gemini-2.5-flash"
python examples/02_tools.py
```

Server log

```
32910 [http-nio-6767-exec-1] INFO  dev.agentspan.runtime.service.AgentService [] - Completed HUMAN task tool_demo_agent_approval_human__2 in execution c87b6f8d-8870-4097-bfc5-df92406adb55
36161 [system-task-worker-5] ERROR org.conductoross.conductor.core.execution.tasks.annotated.AnnotatedWorkflowSystemTask [] - Error executing annotated task LLM_CHAT_COMPLETE
java.lang.IllegalArgumentException: Only one system message is allowed in the prompt
        at org.springframework.util.Assert.isTrue(Assert.java:111) ~[spring-core-6.1.14.jar:6.1.14]
        at org.springframework.ai.google.genai.GoogleGenAiChatModel.createGeminiRequest(GoogleGenAiChatModel.java:823) ~[spring-ai-google-genai-1.1.2.jar:1.1.2]
        .
        .
        .
36182 [system-task-worker-5] INFO  dev.agentspan.runtime.service.AgentEventListener [] - onWorkflowTerminated: wfId=c87b6f8d-8870-4097-bfc5-df92406adb55, reason=Task 66a69422-f5ab-4b7f-810f-c0a60f5ef06b failed with status: FAILED and reason: 'Task execution failed: Only one system message is allowed in the prompt'
```

## Changes

- `AgentChatCompleteTaskMapper.sanitizeMessages` — when `llmProvider` is `gemini` / `google`, merge all SYSTEM entries
  into one (joined with `\n\n`) before dispatch.
- Collapse helper is pure: returns a new list, does not mutate input.

## Test plan

- [x] Unit Test: AgentChatCompleteTaskMapperTest updated with more test
- [x] E2E: `02_tools.py` works for all supported AI Provider including Gemini

## Follow-up

Long-term fix belongs upstream in Spring AI — `GoogleGenAiChatModel.createGeminiRequest` should flatten multiple system
Contents into one `systemInstruction` with multiple text parts, instead of asserting `size()
   <= 1`. This server shim can be removed once upstream ships.
