### PR TITLE
fix: Port defaults 8080->6767 and JAVA_HOME support

### DIFF
--- a/cli/internal/serverctl/serverctl.go
+++ b/cli/internal/serverctl/serverctl.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -203,20 +204,41 @@ func downloadJAR(url, dest string, progress func(float64, string)) error {
 	return nil
 }
 
+// javaCmd returns the java binary path, preferring $JAVA_HOME/bin/java when set.
+func javaCmd() string {
+	if jh := os.Getenv("JAVA_HOME"); jh != "" {
+		p := filepath.Join(jh, "bin", "java")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return "java"
+}
+
 // CheckJava returns (ok, versionString). ok=true means Java 21+ is available.
+// Prefers $JAVA_HOME/bin/java over PATH when JAVA_HOME is set.
 func CheckJava() (ok bool, version string) {
-	out, err := exec.Command("java", "-version").CombinedOutput()
+	out, err := exec.Command(javaCmd(), "-version").CombinedOutput()
 	if err != nil {
 		return false, ""
 	}
-	v := strings.TrimSpace(string(out))
-	// java -version outputs to stderr: 'openjdk version "21.0.3" ...'
-	for _, major := range []string{"21", "22", "23", "24", "25"} {
-		if strings.Contains(v, `"`+major) || strings.Contains(v, " "+major+".") {
-			return true, v
-		}
+
+	re := regexp.MustCompile(`version "(\d+[\d._]*)"`)
+	matches := re.FindStringSubmatch(string(out))
+	if len(matches) < 2 {
+		return false, strings.TrimSpace(string(out))
 	}
-	return false, v
+	ver := matches[1]
+
+	major := ver
+	if idx := strings.IndexAny(ver, "._"); idx > 0 {
+		major = ver[:idx]
+	}
+	majorNum, err := strconv.Atoi(major)
+	if err != nil {
+		return false, ver
+	}
+	return majorNum >= 21, ver
 }
 
 // CheckPortFree returns an error if the given port is already in use.
@@ -277,7 +299,7 @@ func Launch(jarPath string, opts Options, events chan<- StartEvent) (int, error)
 		env = append(env, "AGENT_DEFAULT_MODEL="+opts.Model)
 	}
 
-	proc := exec.Command("java", javaArgs...)
+	proc := exec.Command(javaCmd(), javaArgs...)
 	proc.Env = env
 	proc.Stdout = logF
 	proc.Stderr = logF

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -47,7 +47,7 @@ public class Main {
 Set environment variables:
 
 ```bash
-export AGENTSPAN_SERVER_URL=http://localhost:8080/api
+export AGENTSPAN_SERVER_URL=http://localhost:6767/api
 export AGENTSPAN_AUTH_KEY=your-key
 export AGENTSPAN_AUTH_SECRET=your-secret
 export AGENTSPAN_LLM_MODEL=openai/gpt-4o
@@ -60,7 +60,7 @@ import dev.agentspan.AgentConfig;
 import dev.agentspan.Agentspan;
 
 AgentConfig config = new AgentConfig(
-    "http://localhost:8080/api",
+    "http://localhost:6767/api",
     "my-key",
     "my-secret",
     100,  // poll interval ms

--- a/sdk/python/tests/run_compilation_comparison.sh
+++ b/sdk/python/tests/run_compilation_comparison.sh
@@ -9,7 +9,7 @@
 #   cd python && bash tests/run_compilation_comparison.sh
 #
 # Or with a custom server URL:
-#   SERVER_URL=http://myhost:8080/api bash tests/run_compilation_comparison.sh
+#   SERVER_URL=http://myhost:6767/api bash tests/run_compilation_comparison.sh
 
 set -euo pipefail
 
@@ -45,7 +45,7 @@ else
     # Wait for server to be ready (up to 60 seconds)
     echo -n "Waiting for server to start"
     for i in $(seq 1 30); do
-        if lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+        if lsof -i :6767 2>/dev/null | grep -q LISTEN; then
             echo -e " ${GREEN}ready${NC}"
             break
         fi
@@ -53,7 +53,7 @@ else
         sleep 2
     done
 
-    if ! lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+    if ! lsof -i :6767 2>/dev/null | grep -q LISTEN; then
         echo -e " ${RED}FAILED${NC}"
         echo "Server failed to start. Check /tmp/compilation-test-server.log"
         exit 1

--- a/sdk/python/validation/execution/server_pool.py
+++ b/sdk/python/validation/execution/server_pool.py
@@ -84,7 +84,7 @@ def _kill_server_on_port(port: int) -> bool:
 
 
 class ServerPool:
-    def __init__(self, base_port: int = 8080):
+    def __init__(self, base_port: int = 6767):
         self._base_port = base_port
         self._servers: dict[str, ServerInstance] = {}
         self._started = False

--- a/sdk/python/validation/orchestrator.py
+++ b/sdk/python/validation/orchestrator.py
@@ -310,14 +310,14 @@ def _run_single(
 
 
 def _parse_port(server_url: str) -> int:
-    """Extract port from URL like http://localhost:6767/api. Defaults to 8080."""
+    """Extract port from URL like http://localhost:6767/api. Defaults to 6767."""
     try:
         from urllib.parse import urlparse
 
         parsed = urlparse(server_url)
-        return parsed.port or 8080
+        return parsed.port or 6767
     except Exception:
-        return 8080
+        return 6767
 
 
 _API_KEY_VARS = {"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -50,6 +50,6 @@ WORKDIR /app
 
 COPY --from=builder /build/runtime.jar app.jar
 
-EXPOSE 8080
+EXPOSE 6767
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/ui/generate.mjs
+++ b/ui/generate.mjs
@@ -135,7 +135,7 @@ function formatTagName(tag) {
 }
 
 // Build output
-const serverUrl = spec.servers?.[0]?.url || 'http://localhost:8080';
+const serverUrl = spec.servers?.[0]?.url || 'http://localhost:6767';
 
 const categories = [];
 for (const [tag, endpoints] of tagMap.entries()) {


### PR DESCRIPTION
# fix(getting-started): port defaults 8080→6767 and JAVA_HOME support

## Summary

- Fixes port mismatch: all defaults updated from `8080` to `6767`
- `CheckJava` and `Launch` now prefer `$JAVA_HOME/bin/java` over PATH
- Java version detection replaced hardcoded list with regex — forward-compatible beyond Java 25

## Changes

| File | Change |
|------|--------|
| `cli/internal/serverctl/serverctl.go` | New `javaCmd()` helper; `CheckJava` + `Launch` use it; regex version parsing |
| `server/Dockerfile` | `EXPOSE 6767` (was `8080`) |
| `sdk/python/validation/execution/server_pool.py` | Default `base_port=6767` |
| `sdk/python/validation/orchestrator.py` | `_parse_port` fallback `6767` |
| `ui/generate.mjs` | Fallback `serverUrl` uses `6767` |

## Test plan

- [x] `agentspan server start` with Java 21 only under `JAVA_HOME`, not in `PATH` — server starts correctly
- [x] `agentspan server start` with no `JAVA_HOME`, Java 21 in `PATH` — unchanged behavior
- [x] `agentspan server start` with Java 17 — clear error message with version detected
- [x] `agentspan doctor` — Java check passes/fails correctly in both PATH and `JAVA_HOME` cases
- [ ] Dockerfile: container exposes and binds port `6767`
- [ ] Validation suite runs against default port without `--port` flag
