### PR TITLE
Fix #150: Allow retry configuration on @tool decorator

### DIFF
--- a/sdk/python/src/agentspan/agents/config_serializer.py
+++ b/sdk/python/src/agentspan/agents/config_serializer.py
@@ -246,6 +246,12 @@ class AgentConfigSerializer:
         if td.timeout_seconds is not None:
             result["timeoutSeconds"] = td.timeout_seconds
 
+        if td.retry_count is not None:
+            result["retryCount"] = td.retry_count
+
+        if td.retry_delay_seconds is not None:
+            result["retryDelaySeconds"] = td.retry_delay_seconds
+
         if td.config:
             if td.tool_type == "agent_tool" and "agent" in td.config:
                 serialized_config = dict(td.config)

--- a/sdk/python/src/agentspan/agents/runtime/tool_registry.py
+++ b/sdk/python/src/agentspan/agents/runtime/tool_registry.py
@@ -66,9 +66,14 @@ class ToolRegistry:
             if td.func is not None and td.tool_type in ("worker", "cli"):
                 guardrails = td.guardrails if td.guardrails else None
                 wrapper = make_tool_worker(td.func, td.name, guardrails=guardrails, tool_def=td)
+                task_def = _default_task_def(td.name)
+                if td.retry_count is not None:
+                    task_def.retry_count = td.retry_count
+                if td.retry_delay_seconds is not None:
+                    task_def.retry_delay_seconds = td.retry_delay_seconds
                 worker_task(
                     task_definition_name=td.name,
-                    task_def=_default_task_def(td.name),
+                    task_def=task_def,
                     register_task_def=True,
                     overwrite_task_def=True,
                     domain=domain if (agent_stateful or td.stateful) else None,

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -80,6 +80,8 @@ class ToolDef:
     isolated: bool = True
     credentials: List[Any] = field(default_factory=list)
     stateful: bool = False
+    retry_count: Optional[int] = None
+    retry_delay_seconds: Optional[int] = None
 
 
 # ── @tool decorator ─────────────────────────────────────────────────────
@@ -100,6 +102,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -114,6 +118,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Any:
     """Register a Python function as a Conductor agent tool.
 
@@ -160,6 +166,8 @@ def tool(
             isolated=isolated,
             credentials=list(credentials) if credentials else [],
             stateful=stateful,
+            retry_count=retry_count,
+            retry_delay_seconds=retry_delay_seconds,
         )
 
         @functools.wraps(fn)


### PR DESCRIPTION
Fixes #150

## Summary
Users were unable to override the hardcoded `retry_count=2` and `retry_delay_seconds=2` values set in `_default_task_def` in `runtime.py`. This change adds `retry_count` and `retry_delay_seconds` as optional parameters on the `@tool` decorator, allowing users to configure retry behaviour per tool.

## Changes
- `sdk/python/src/agentspan/agents/tool.py`: Added `retry_count` and `retry_delay_seconds` optional parameters to the `@tool` decorator signature.
- `sdk/python/src/agentspan/agents/runtime/tool_registry.py`: Passed the new retry parameters through to the Conductor `TaskDef` when the tool is registered.
- `sdk/python/src/agentspan/agents/config_serializer.py`: Updated serialization to include retry configuration from the tool decorator.

## Usage
```python
@tool(retry_count=10, retry_delay_seconds=5)
def call_flaky_api(query: str) -> str:
    ...

@tool(retry_count=0)  # fail immediately, no retries
def process_payment(amount: float) -> dict:
    ...
```

## Testing
Changes were verified against the modified files. No existing tests were broken by this change.