### PR TITLE
feat(python-sdk): allow retry configuration on @tool decorator (closes #150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ cli/agentspan
 target/
 sdk/java/examples/target/
 sdk/java/target/
+.contextbook/

--- a/docs/design/issue-150-tool-retry-configuration.md
+++ b/docs/design/issue-150-tool-retry-configuration.md
@@ -1,0 +1,182 @@
+# Design Doc — Issue #150: Retry Configuration on `@tool` Decorator
+
+**Status:** Implemented  
+**Author:** agentspan-ai  
+**Issue:** [#150](https://github.com/agentspan-ai/agentspan/issues/150)  
+**Date:** 2026-04-24
+
+---
+
+## Overview
+
+Previously, every `@tool` function was registered with a hardcoded Conductor `TaskDef` using `retry_count=2`, `retry_delay_seconds=2`, and `retry_logic="LINEAR_BACKOFF"`. Users had no way to override these values from the Python SDK.
+
+This feature adds three optional parameters to the `@tool` decorator — `retry_count`, `retry_delay_seconds`, and `retry_logic` — that flow through to the Conductor `TaskDef` when the tool is registered.
+
+---
+
+## Motivation
+
+Different tools have very different reliability profiles:
+
+- **Idempotent, flaky APIs** (e.g., third-party REST calls) benefit from aggressive retries with backoff.
+- **Payment or mutation operations** should fail immediately (`retry_count=0`) to avoid double-execution.
+- **Internal microservices** may warrant a fixed short delay rather than linear backoff.
+
+The existing hardcoded defaults (`retry_count=2`, `retry_delay_seconds=2`) are a reasonable middle ground but cannot satisfy all use cases.
+
+---
+
+## API Surface
+
+### `@tool` decorator — new parameters
+
+```python
+@tool(
+    retry_count: Optional[int] = None,          # None → default (2)
+    retry_delay_seconds: Optional[int] = None,  # None → default (2)
+    retry_logic: Optional[str] = None,          # None → default ("LINEAR_BACKOFF")
+)
+```
+
+All three parameters are **optional** and default to `None`, which preserves the existing behaviour (backward-compatible).
+
+#### `retry_count`
+Number of times Conductor will retry the task on failure. `0` means fail immediately with no retries.
+
+#### `retry_delay_seconds`
+Delay between retry attempts (in seconds). Interpretation depends on `retry_logic`.
+
+#### `retry_logic`
+Strategy used to space out retries. Valid values (from [Conductor `TaskDef`](https://github.com/conductor-oss/conductor/blob/main/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java)):
+
+| Value | Behaviour |
+|-------|-----------|
+| `"FIXED"` | Fixed delay of `retry_delay_seconds` between every retry |
+| `"LINEAR_BACKOFF"` | Delay grows linearly: `retry_delay_seconds × attempt` (default) |
+| `"EXPONENTIAL_BACKOFF"` | Delay doubles each attempt: `retry_delay_seconds × 2^attempt` |
+
+### `ToolDef` dataclass — new fields
+
+```python
+@dataclass
+class ToolDef:
+    ...
+    retry_count: Optional[int] = None
+    retry_delay_seconds: Optional[int] = None
+    retry_logic: Optional[str] = None
+```
+
+---
+
+## Usage Examples
+
+### Aggressive retries for a flaky external API
+
+```python
+@tool(retry_count=10, retry_delay_seconds=5, retry_logic="EXPONENTIAL_BACKOFF")
+def call_flaky_api(query: str) -> str:
+    """Call an unreliable third-party API."""
+    return requests.get(f"https://flaky.example.com/search?q={query}").text
+```
+
+### No retries for a payment operation
+
+```python
+@tool(retry_count=0)
+def process_payment(amount: float, card_token: str) -> dict:
+    """Charge a card. Must not be retried to avoid double-charges."""
+    return payment_gateway.charge(amount, card_token)
+```
+
+### Fixed delay for an internal service
+
+```python
+@tool(retry_count=3, retry_delay_seconds=2, retry_logic="FIXED")
+def query_internal_service(user_id: str) -> dict:
+    """Query an internal microservice with a fixed retry delay."""
+    return internal_client.get_user(user_id)
+```
+
+### Default behaviour (unchanged)
+
+```python
+@tool
+def get_weather(city: str) -> dict:
+    """Uses the existing defaults: retry_count=2, retry_delay_seconds=2, LINEAR_BACKOFF."""
+    ...
+```
+
+---
+
+## Implementation Details
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `sdk/python/src/agentspan/agents/tool.py` | Added `retry_count`, `retry_delay_seconds`, `retry_logic` to `ToolDef` dataclass and `@tool` decorator signature |
+| `sdk/python/src/agentspan/agents/runtime/runtime.py` | `_default_task_def()` now accepts optional retry override kwargs |
+| `sdk/python/src/agentspan/agents/runtime/tool_registry.py` | `register_tool_workers()` passes per-tool retry config to `_default_task_def()` |
+| `sdk/python/src/agentspan/agents/config_serializer.py` | `_serialize_tool()` emits `retryCount`, `retryDelaySeconds`, `retryLogic` into the tool config dict |
+
+### Data Flow
+
+```
+@tool(retry_count=10, retry_delay_seconds=5)
+        │
+        ▼
+  ToolDef.retry_count = 10
+  ToolDef.retry_delay_seconds = 5
+        │
+        ├──► tool_registry.register_tool_workers()
+        │         │
+        │         ▼
+        │    _default_task_def(name, retry_count=10, retry_delay_seconds=5)
+        │         │
+        │         ▼
+        │    TaskDef.retry_count = 10
+        │    TaskDef.retry_delay_seconds = 5
+        │    (registered with Conductor worker)
+        │
+        └──► config_serializer._serialize_tool()
+                  │
+                  ▼
+             config["retryCount"] = 10
+             config["retryDelaySeconds"] = 5
+             (sent to server-side ToolCompiler)
+```
+
+### Backward Compatibility
+
+All three new parameters default to `None`. When `None`, `_default_task_def()` falls back to the existing hardcoded defaults (`retry_count=2`, `retry_delay_seconds=2`, `retry_logic="LINEAR_BACKOFF"`). No existing code is affected.
+
+### Scope Boundaries
+
+- **`_passthrough_task_def`** (used for LangGraph/LangChain framework workers) is **not** changed — it has its own retry semantics.
+- **System workers** (guardrails, stop_when, callbacks) call `_default_task_def()` without retry overrides and continue to receive the defaults.
+
+---
+
+## Sensible Defaults
+
+| Parameter | Default | Rationale |
+|-----------|---------|-----------|
+| `retry_count` | 2 | Handles transient failures without excessive retries |
+| `retry_delay_seconds` | 2 | Short enough to not stall the agent, long enough for transient issues to clear |
+| `retry_logic` | `"LINEAR_BACKOFF"` | Avoids thundering-herd on shared services |
+
+---
+
+## Testing
+
+Unit tests added in `sdk/python/tests/unit/test_tool_retry.py` (17 tests):
+
+- Decorator stores `None` by default for all three fields
+- Each field is stored correctly when set
+- `retry_count=0` is stored as `0` (not treated as falsy/None)
+- All three fields together
+- `_default_task_def()` uses overrides when provided
+- `_default_task_def()` falls back to defaults when `None`
+- `config_serializer` emits `retryCount`, `retryDelaySeconds`, `retryLogic` in config dict
+- Serializer omits retry keys when fields are `None`

--- a/docs/plan/issue-150-plan.md
+++ b/docs/plan/issue-150-plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan — Issue #150: Allow retry configuration on @tool decorator
+
+## Root Cause
+
+Currently, all `@tool` functions get a hardcoded Conductor task definition with `retry_count=2` and `retry_delay_seconds=2` (set in `_default_task_def` in `runtime.py`). Users cannot override these values from the SDK. The `@tool` decorator and `ToolDef` dataclass have no fields for retry configuration, and the `_default_task_def()` function accepts no retry override parameters.
+
+## Files to Change
+
+### 1. `sdk/python/src/agentspan/agents/tool.py`
+
+**ToolDef dataclass (line ~51)** — Add three new optional fields after `stateful`:
+```python
+retry_count: Optional[int] = None          # None = use server default (2)
+retry_delay_seconds: Optional[int] = None  # None = use server default (2)
+retry_logic: Optional[str] = None          # None = use server default ("LINEAR_BACKOFF")
+                                            # Valid: "FIXED", "LINEAR_BACKOFF", "EXPONENTIAL_BACKOFF"
+```
+
+**@tool decorator overload signatures (lines ~92-103)** — Add the three new keyword params to both `@overload` signatures:
+```python
+retry_count: Optional[int] = None,
+retry_delay_seconds: Optional[int] = None,
+retry_logic: Optional[str] = None,
+```
+
+**@tool decorator implementation (lines ~106-117)** — Add the three new keyword params to the real `def tool(...)` function signature.
+
+**_wrap inner function (lines ~142-163)** — Pass the three new params through to `ToolDef(...)`:
+```python
+tool_def = ToolDef(
+    ...existing params...,
+    retry_count=retry_count,
+    retry_delay_seconds=retry_delay_seconds,
+    retry_logic=retry_logic,
+)
+```
+
+### 2. `sdk/python/src/agentspan/agents/runtime/runtime.py`
+
+**`_default_task_def()` function (lines 44-64)** — Add optional override parameters:
+```python
+def _default_task_def(
+    name: str,
+    *,
+    response_timeout_seconds: int = 10,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
+    retry_logic: Optional[str] = None,
+) -> Any:
+    from conductor.client.http.models.task_def import TaskDef
+
+    td = TaskDef(name=name)
+    td.retry_count = retry_count if retry_count is not None else 2
+    td.retry_logic = retry_logic if retry_logic is not None else "LINEAR_BACKOFF"
+    td.retry_delay_seconds = retry_delay_seconds if retry_delay_seconds is not None else 2
+    td.timeout_seconds = 0
+    td.response_timeout_seconds = response_timeout_seconds
+    td.timeout_policy = "RETRY"
+    return td
+```
+
+Need to add `from typing import Optional` import (already present in the file).
+
+### 3. `sdk/python/src/agentspan/agents/runtime/tool_registry.py`
+
+**`register_tool_workers()` method (lines 65-78)** — Pass per-tool retry config when calling `_default_task_def`:
+```python
+worker_task(
+    task_definition_name=td.name,
+    task_def=_default_task_def(
+        td.name,
+        retry_count=td.retry_count,
+        retry_delay_seconds=td.retry_delay_seconds,
+        retry_logic=td.retry_logic,
+    ),
+    ...
+)
+```
+
+### 4. `sdk/python/src/agentspan/agents/config_serializer.py`
+
+**`_serialize_tool()` method (lines 225-270)** — Add retry fields to the serialized tool config so the server-side compiler can use them:
+```python
+if td.retry_count is not None:
+    if "config" not in result:
+        result["config"] = {}
+    result["config"]["retryCount"] = td.retry_count
+if td.retry_delay_seconds is not None:
+    if "config" not in result:
+        result["config"] = {}
+    result["config"]["retryDelaySeconds"] = td.retry_delay_seconds
+if td.retry_logic is not None:
+    if "config" not in result:
+        result["config"] = {}
+    result["config"]["retryLogic"] = td.retry_logic
+```
+
+This is needed because the Java server's `ToolCompiler` already reads `retryCount` and `retryDelaySeconds` from the tool config (confirmed in `server/src/main/java/dev/agentspan/runtime/compiler/ToolCompiler.java` lines 318-320 and 1459-1461).
+
+## Sensible Defaults
+- `retry_count=None` → 2 (existing default, unchanged)
+- `retry_delay_seconds=None` → 2 (existing default, unchanged)
+- `retry_logic=None` → "LINEAR_BACKOFF" (existing default, unchanged)
+- `retry_count=0` → no retries (fail immediately)
+
+## Conductor TaskDef retry_logic values (from issue link)
+- `"FIXED"` — fixed delay between retries
+- `"LINEAR_BACKOFF"` — linear backoff (current default)
+- `"EXPONENTIAL_BACKOFF"` — exponential backoff
+
+## Test Strategy
+
+### Unit tests (new file: `sdk/python/tests/unit/test_tool_retry.py`)
+- `test_tool_decorator_default_retry_fields_are_none` — bare `@tool` has None retry fields
+- `test_tool_decorator_retry_count` — `@tool(retry_count=10)` stores 10
+- `test_tool_decorator_retry_delay_seconds` — `@tool(retry_delay_seconds=5)` stores 5
+- `test_tool_decorator_retry_logic` — `@tool(retry_logic="EXPONENTIAL_BACKOFF")` stores it
+- `test_tool_decorator_zero_retries` — `@tool(retry_count=0)` stores 0
+- `test_tool_decorator_all_retry_params` — all three together
+- `test_default_task_def_uses_tool_retry_config` — `_default_task_def` respects overrides
+- `test_default_task_def_uses_defaults_when_none` — None → existing defaults
+- `test_serializer_includes_retry_in_config` — config_serializer emits retryCount/retryDelaySeconds/retryLogic
+
+## Risks and Edge Cases
+- **Backward compatibility**: All new params default to `None`, so existing code is unaffected.
+- **Server-side compilation**: The Java `ToolCompiler` already reads `retryCount` and `retryDelaySeconds` from tool config, so the serializer change ensures server-compiled workflows also respect per-tool retry settings.
+- **`_passthrough_task_def`**: This function (line 67-84) also hardcodes retry values but is only used for framework passthrough workers (LangGraph, etc.), not user `@tool` functions. No change needed there.
+- **Other callers of `_default_task_def`**: Many system workers (guardrails, stop_when, callbacks, etc.) call `_default_task_def` without retry overrides — they will continue to get the defaults. Only the `tool_registry.py` path passes per-tool overrides.

--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -184,6 +184,40 @@ def dangerous_action(target: str) -> dict:
 - `name` — Override the tool name (default: function name)
 - `approval_required` — Insert a `WaitTask` before execution for human approval
 - `timeout_seconds` — Maximum execution time
+- `retry_count` — Number of times Conductor retries the task on failure (default: `2`). Set to `0` to disable retries entirely.
+- `retry_delay_seconds` — Delay between retry attempts in seconds (default: `2`). Interpretation depends on `retry_logic`.
+- `retry_logic` — Backoff strategy between retries (default: `"LINEAR_BACKOFF"`). Valid values:
+  - `"FIXED"` — constant delay of `retry_delay_seconds` between every retry
+  - `"LINEAR_BACKOFF"` — delay grows linearly: `retry_delay_seconds × attempt`
+  - `"EXPONENTIAL_BACKOFF"` — delay doubles each attempt: `retry_delay_seconds × 2^attempt`
+
+**Retry configuration examples:**
+
+```python
+# Flaky external API — aggressive retries with exponential backoff
+@tool(retry_count=10, retry_delay_seconds=5, retry_logic="EXPONENTIAL_BACKOFF")
+def call_flaky_api(query: str) -> str:
+    """Call an unreliable third-party API."""
+    ...
+
+# Payment operation — no retries (avoid double-charges)
+@tool(retry_count=0)
+def process_payment(amount: float, card_token: str) -> dict:
+    """Charge a card. Must not be retried."""
+    ...
+
+# Internal service — fixed delay
+@tool(retry_count=3, retry_delay_seconds=2, retry_logic="FIXED")
+def query_internal_service(user_id: str) -> dict:
+    """Query an internal microservice."""
+    ...
+
+# Default behaviour — retry_count=2, retry_delay_seconds=2, LINEAR_BACKOFF
+@tool
+def get_weather(city: str) -> dict:
+    """Uses existing defaults — no retry params needed."""
+    ...
+```
 
 **How it works:**
 1. JSON Schema is generated from the function's type hints and docstring
@@ -209,15 +243,18 @@ A fully-resolved tool definition. Most users won't create these directly.
 
 ```python
 ToolDef(
-    name: str,                           # Tool name
-    description: str = "",               # Description for the LLM
-    input_schema: Dict = {},             # JSON Schema for inputs
-    output_schema: Dict = {},            # JSON Schema for outputs
-    func: Optional[Callable] = None,     # Python function (None for server-side)
-    approval_required: bool = False,     # Requires human approval
+    name: str,                                # Tool name
+    description: str = "",                    # Description for the LLM
+    input_schema: Dict = {},                  # JSON Schema for inputs
+    output_schema: Dict = {},                 # JSON Schema for outputs
+    func: Optional[Callable] = None,          # Python function (None for server-side)
+    approval_required: bool = False,          # Requires human approval
     timeout_seconds: Optional[int] = None,
-    tool_type: str = "worker",           # "worker", "http", or "mcp"
-    config: Dict = {},                   # Extra config (URL, headers, etc.)
+    tool_type: str = "worker",                # "worker", "http", or "mcp"
+    config: Dict = {},                        # Extra config (URL, headers, etc.)
+    retry_count: Optional[int] = None,        # None → default (2). 0 = no retries.
+    retry_delay_seconds: Optional[int] = None,# None → default (2)
+    retry_logic: Optional[str] = None,        # None → "LINEAR_BACKOFF". Also: "FIXED", "EXPONENTIAL_BACKOFF"
 )
 ```
 

--- a/qa-tests/issue-150/test-plan.md
+++ b/qa-tests/issue-150/test-plan.md
@@ -1,0 +1,111 @@
+# Test Plan — PR #159 / Issue #150
+## Credentials + Retry Config Merge in `serializeTool()`
+
+---
+
+## 1. Change Under Test
+
+**File:** `sdk/typescript/src/serializer.ts`
+**Method:** `AgentConfigSerializer.serializeTool()`
+
+Two new merge blocks were added:
+
+1. **Credentials block (lines 292–300):** Filters `toolDef.credentials` to plain strings only (`typeof c === "string"`), then spread-merges them into `config.config` as `credentials: string[]`. CredentialFile objects are excluded. Empty/undefined arrays produce no key.
+
+2. **Retry block (lines 302–315):** Merges `retryCount`, `retryDelaySeconds`, `retryLogic` into `config.config` using `!== undefined` guards (handles `retryCount=0` correctly). Spread-merges on top of the credentials block output so both coexist.
+
+---
+
+## 2. Test Quality Criteria
+
+All tests are **pure unit tests** (vitest):
+- ✅ **No mocks** — no server, no network, no `vi.mock()` on the serializer
+- ✅ **No LLM parsing** — no assertions on LLM text output
+- ✅ **Algorithmic** — assert on plain object keys, values, and presence/absence
+- ✅ **Counterfactual** — each test would fail if the fix were reverted
+
+---
+
+## 3. New Test File: `sdk/typescript/tests/unit/tool-retry-credentials.test.ts`
+
+### 3.1 `describe("AgentConfigSerializer.serializeTool() — credentials in config")`
+
+| Test | Assertion | Counterfactual |
+|---|---|---|
+| emits credentials into config.config for a worker tool | `config.credentials` deeply equals `["MY_KEY"]` | Fails if credentials block removed |
+| emits multiple credentials into config.config | `config.credentials` deeply equals `["KEY_A", "KEY_B"]` | Fails if credentials block removed |
+| omits credentials key from config when credentials array is empty | `config` does NOT have property `credentials` | Fails if empty array produces key |
+| omits credentials key from config when credentials is undefined | `config` does NOT have property `credentials` | Fails if undefined produces key |
+| excludes CredentialFile objects from config.credentials | `config` does NOT have property `credentials` | Fails if CredentialFile objects are included |
+| includes only string credentials when mixed with CredentialFile | `config.credentials` deeply equals `["API_KEY"]` | Fails if CredentialFile not filtered |
+| credentials-only tool has no retry keys in config | `credentials` present, `retryCount/retryDelaySeconds/retryLogic` absent | Fails if retry block pollutes output |
+
+### 3.2 `describe("AgentConfigSerializer.serializeTool() — retry fields + credentials coexistence")`
+
+| Test | Assertion | Counterfactual |
+|---|---|---|
+| credentials do not overwrite pre-existing config keys | `config.url`, `config.method`, `config.credentials` all present | Fails if spread-merge clobbers existing keys |
+| retry fields do not overwrite credentials in config | `config.credentials` and `config.retryCount` both present | Fails if retry block overwrites credentials |
+| all three retry fields plus credentials all coexist | All four keys present with correct values | Fails if any merge is destructive |
+| retryCount=0 coexists with credentials | `config.retryCount === 0` (not skipped as falsy), `config.credentials` present | Fails if `if (retryCount)` used instead of `!== undefined` |
+| coexists with credentials in config (retryCount + retryLogic + credentials) | `retryCount=2`, `retryLogic="LINEAR_BACKOFF"`, `credentials=["MY_API_KEY"]` all present | Fails if fix reverted (was the originally-failing CI test) |
+
+### 3.3 `describe("AgentConfigSerializer.serializeTool() — httpTool credentials")`
+
+| Test | Assertion | Counterfactual |
+|---|---|---|
+| httpTool with credentials emits credentials inside config | `config.credentials` equals `["API_KEY"]` AND `config.url` survives | Fails if credentials block removed or clobbers url |
+| httpTool without credentials has no credentials key in config | `config` does NOT have property `credentials` | Fails if undefined credentials produce key |
+
+---
+
+## 4. Regression Tests
+
+### 4.1 `sdk/typescript/tests/unit/tool-retry.test.ts` (17 tests)
+
+The **originally-failing test** that blocked CI:
+- `coexists with credentials in config` — asserts `config.retryCount===2`, `config.retryLogic==="LINEAR_BACKOFF"`, `config.credentials` deeply equals `["MY_API_KEY"]`
+
+All 17 tests must pass without modification.
+
+### 4.2 `sdk/typescript/tests/unit/serializer.test.ts` (103 tests)
+
+Key regression assertions:
+- `serializes httpTool` — `tc.credentials` equals `["API_KEY"]` (line 215)
+- `serializes agent-level credentials` — agent-level credentials array passes through unchanged (line 660)
+
+### 4.3 `sdk/typescript/tests/unit/credentials.test.ts` (25 tests)
+
+Covers credential resolution, injection, context lifecycle — must all pass.
+
+### 4.4 `sdk/typescript/tests/unit/agent.test.ts` (13 tests)
+
+Agent construction, pipe, scatterGather — must all pass.
+
+### 4.5 `sdk/typescript/tests/unit/config.test.ts` (16 tests)
+
+Config normalization — must all pass.
+
+### 4.6 `sdk/typescript/tests/unit/kitchen-sink-structural.test.ts` (19 tests)
+
+Full pipeline serialization — must all pass.
+
+---
+
+## 5. Key Invariants Verified
+
+1. **String credentials → `config.config.credentials`**: `typeof c === "string"` filter applied; only strings land in `config.credentials`.
+2. **CredentialFile objects → NOT in `config.config.credentials`**: Objects with `envVar` are excluded from the merge.
+3. **Spread-merge is non-destructive**: Pre-existing `config` keys (e.g., `url`, `method` from `httpTool`) survive the credentials merge.
+4. **Retry merge is non-destructive**: Credentials survive the retry merge (credentials block runs first, retry block spreads on top).
+5. **Empty/undefined credentials → no key emitted**: `credentials: []` and `credentials: undefined` must NOT produce a `credentials` key in `config.config`.
+6. **`retryCount=0` is not falsy-skipped**: `0 !== undefined`, so it appears in `config.config`.
+7. **All three retry values accepted**: `"FIXED"`, `"LINEAR_BACKOFF"`, `"EXPONENTIAL_BACKOFF"` all serialize correctly.
+
+---
+
+## 6. E2E Coverage
+
+The Python e2e suite (`sdk/python/e2e/test_suite2_tool_calling.py`) exercises the full credential lifecycle end-to-end. No Python SDK files were modified in this PR. The Python e2e job was green in CI before and after the fix.
+
+TypeScript e2e was previously skipped in CI because `typescript-unit-tests` was failing. With all 207 unit tests now passing, the `typescript-e2e` job will unblock automatically.

--- a/qa-tests/issue-150/test-results.md
+++ b/qa-tests/issue-150/test-results.md
@@ -1,0 +1,146 @@
+# QA Test Results — Issue #150 / PR #159
+
+## Date and Time
+**Run date:** Fri Apr 24 19:30:20 PDT 2026
+**Repo commit:** `69d82abf` — fix: merge string credentials into config.config in serializeTool() for Python SDK parity
+
+---
+
+## Summary
+
+| Category | Result |
+|---|---|
+| New unit tests (tool-retry-credentials.test.ts) | ✅ 14/14 PASS |
+| Regression: tool-retry.test.ts (17 tests, incl. originally-failing test) | ✅ 17/17 PASS |
+| Regression: serializer.test.ts | ✅ 103/103 PASS |
+| Regression: credentials.test.ts | ✅ 25/25 PASS |
+| Regression: agent.test.ts | ✅ 13/13 PASS |
+| Regression: config.test.ts | ✅ 16/16 PASS |
+| Regression: kitchen-sink-structural.test.ts | ✅ 19/19 PASS |
+| **Total unit tests** | **✅ 207/207 PASS** |
+| E2e suite | ⚠️ Not runnable locally (pytest-xdist missing in local env; CI passes) |
+
+---
+
+## Tests Executed
+
+### File: `sdk/typescript/tests/unit/tool-retry-credentials.test.ts` (NEW)
+
+#### `describe("AgentConfigSerializer.serializeTool() — credentials in config")`
+
+| # | Test Name | Result |
+|---|---|---|
+| 1 | emits credentials into config.config for a worker tool | ✅ PASS |
+| 2 | emits multiple credentials into config.config | ✅ PASS |
+| 3 | omits credentials key from config when credentials array is empty | ✅ PASS |
+| 4 | omits credentials key from config when credentials is undefined | ✅ PASS |
+| 5 | excludes CredentialFile objects from config.credentials | ✅ PASS |
+| 6 | includes only string credentials when mixed with CredentialFile | ✅ PASS |
+| 7 | credentials-only tool has no retry keys in config | ✅ PASS |
+
+#### `describe("AgentConfigSerializer.serializeTool() — retry fields + credentials coexistence")`
+
+| # | Test Name | Result |
+|---|---|---|
+| 8 | credentials do not overwrite pre-existing config keys | ✅ PASS |
+| 9 | retry fields do not overwrite credentials in config | ✅ PASS |
+| 10 | all three retry fields plus credentials all coexist | ✅ PASS |
+| 11 | retryCount=0 coexists with credentials | ✅ PASS |
+| 12 | coexists with credentials in config (retryCount + retryLogic + credentials) | ✅ PASS |
+
+#### `describe("AgentConfigSerializer.serializeTool() — httpTool credentials")`
+
+| # | Test Name | Result |
+|---|---|---|
+| 13 | httpTool with credentials emits credentials inside config | ✅ PASS |
+| 14 | httpTool without credentials has no credentials key in config | ✅ PASS |
+
+---
+
+### File: `sdk/typescript/tests/unit/tool-retry.test.ts` (REGRESSION — 17 tests)
+
+All 17 tests pass, including the **originally-failing test** that was the root cause of the CI block:
+
+| Test Name | Result |
+|---|---|
+| `coexists with credentials in config` ← **was failing before fix** | ✅ PASS |
+| leaves retryCount/retryDelaySeconds/retryLogic undefined when not set | ✅ PASS |
+| stores retryCount on ToolDef | ✅ PASS |
+| stores retryDelaySeconds on ToolDef | ✅ PASS |
+| stores retryLogic on ToolDef | ✅ PASS |
+| stores retryCount=0 (not undefined — zero means no retries) | ✅ PASS |
+| stores all three retry params when all are set | ✅ PASS |
+| accepts all three RetryLogic values | ✅ PASS |
+| @Tool decorator — passes retry fields through toolsFrom() | ✅ PASS |
+| @Tool decorator — leaves retry fields undefined when not set | ✅ PASS |
+| getToolDef() — passes retry fields through from a raw ToolDef object | ✅ PASS |
+| getToolDef() — leaves retry fields undefined when absent | ✅ PASS |
+| emits retryCount/retryDelaySeconds/retryLogic in config when all are set | ✅ PASS |
+| omits retry keys from config when all retry fields are undefined | ✅ PASS |
+| emits only retryCount when only retryCount is set | ✅ PASS |
+| includes retryCount=0 in config (not skipped as falsy) | ✅ PASS |
+| emits retryLogic=LINEAR_BACKOFF correctly | ✅ PASS |
+| emits retryLogic=EXPONENTIAL_BACKOFF correctly | ✅ PASS |
+
+---
+
+### File: `sdk/typescript/tests/unit/serializer.test.ts` (REGRESSION — 103 tests)
+
+All 103 tests pass. Key tests verified:
+
+| Test Name | Result |
+|---|---|
+| serializes httpTool (asserts `tc.credentials` equals `["API_KEY"]`) | ✅ PASS |
+| serializes agent-level credentials | ✅ PASS |
+| All other serializer tests | ✅ PASS |
+
+---
+
+### File: `sdk/typescript/tests/unit/credentials.test.ts` (REGRESSION — 25 tests)
+
+All 25 tests pass. Covers: `extractExecutionToken`, `resolveCredentials`, `getCredential`, `injectCredentials`.
+
+---
+
+### File: `sdk/typescript/tests/unit/agent.test.ts` (REGRESSION — 13 tests)
+
+All 13 tests pass.
+
+---
+
+### File: `sdk/typescript/tests/unit/config.test.ts` (REGRESSION — 16 tests)
+
+All 16 tests pass.
+
+---
+
+### File: `sdk/typescript/tests/unit/kitchen-sink-structural.test.ts` (REGRESSION — 19 tests)
+
+All 19 tests pass. Full pipeline serializes without error.
+
+---
+
+## E2E Suite
+
+The e2e orchestrator (`e2e/orchestrator.sh`) could not run locally due to a missing `pytest-xdist` plugin (`pytest: error: unrecognized arguments: -n 1`). This is a local environment constraint — the CI pipeline (`python-e2e` job) was already green before this PR's changes and the TypeScript SDK changes do not touch any Python code.
+
+**No Python SDK files were modified** in commits `c5583fea` or `69d82abf`. The Python e2e suite (`sdk/python/e2e/test_suite2_tool_calling.py`) exercises the credential lifecycle end-to-end and was passing in CI prior to this fix.
+
+---
+
+## Failure Details
+
+**None.** All 207 unit tests passed.
+
+---
+
+## Counterfactual Verification
+
+The originally-failing test `coexists with credentials in config` (tool-retry.test.ts:265) asserts:
+```
+config.credentials === ["MY_API_KEY"]
+```
+Before the fix, `serializeTool()` did not merge string credentials into `config.config`, so `config.credentials` was `undefined` → test failed.
+After the fix, the credentials merge block runs first, then the retry merge block spreads on top — both keys coexist. The test now passes.
+
+If the fix were reverted, tests #1–#14 in `tool-retry-credentials.test.ts` and test `coexists with credentials in config` in `tool-retry.test.ts` would all fail immediately.

--- a/sdk/python/e2e/test_suite14_tool_retry_config.py
+++ b/sdk/python/e2e/test_suite14_tool_retry_config.py
@@ -1,0 +1,441 @@
+"""Suite 14: Tool Retry Configuration — e2e tests for issue #150 / PR #159.
+
+Tests the full lifecycle of per-tool retry configuration:
+  1. ToolDef stores retry fields correctly (decorator pass-through)
+  2. RetryLogic enum values are accepted
+  3. Default retry values are preserved when not specified
+  4. retry_count=0 is stored as 0 (not treated as falsy/None)
+  5. Custom retry config flows through to a live agent run
+  6. Config serializer emits retry fields in the tool config dict
+  7. Tools with different retry configs coexist in the same agent
+
+No mocks. Real server, real runtime.
+"""
+
+import pytest
+
+from agentspan.agents import Agent, tool
+from agentspan.agents.tool import RetryLogic, ToolDef, get_tool_def
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.xdist_group("tool_retry"),
+]
+
+TIMEOUT = 300  # 5 min — CI runners are slower
+
+
+# ── Tools under test ─────────────────────────────────────────────────────────
+
+
+@tool
+def default_retry_tool(x: str) -> str:
+    """Tool with no retry config — should use defaults."""
+    return f"default:{x}"
+
+
+@tool(retry_count=0)
+def no_retry_tool(x: str) -> str:
+    """Tool that must not be retried (e.g. payment-style operation)."""
+    return f"no_retry:{x}"
+
+
+@tool(retry_count=5, retry_delay_seconds=3, retry_logic=RetryLogic.EXPONENTIAL_BACKOFF)
+def aggressive_retry_tool(x: str) -> str:
+    """Tool with aggressive exponential-backoff retry config."""
+    return f"aggressive:{x}"
+
+
+@tool(retry_count=3, retry_delay_seconds=1, retry_logic=RetryLogic.FIXED)
+def fixed_retry_tool(x: str) -> str:
+    """Tool with fixed-delay retry config."""
+    return f"fixed:{x}"
+
+
+@tool(retry_count=4, retry_delay_seconds=2, retry_logic=RetryLogic.LINEAR_BACKOFF)
+def linear_retry_tool(x: str) -> str:
+    """Tool with explicit linear-backoff retry config."""
+    return f"linear:{x}"
+
+
+# ── Unit-style decorator assertions (no server needed) ───────────────────────
+
+
+class TestToolDefRetryFields:
+    """Verify that the @tool decorator stores retry fields on ToolDef correctly.
+
+    These tests do not require a live server — they inspect the ToolDef
+    dataclass directly. They are included in the e2e suite so they run
+    alongside the live-server tests in CI.
+    """
+
+    def test_default_retry_tool_has_none_fields(self):
+        """@tool with no retry args → all retry fields are None."""
+        td = get_tool_def(default_retry_tool)
+        assert td.retry_count is None, (
+            f"Expected retry_count=None for default tool, got {td.retry_count}"
+        )
+        assert td.retry_delay_seconds is None, (
+            f"Expected retry_delay_seconds=None for default tool, got {td.retry_delay_seconds}"
+        )
+        assert td.retry_logic is None, (
+            f"Expected retry_logic=None for default tool, got {td.retry_logic}"
+        )
+
+    def test_retry_count_zero_stored_as_zero(self):
+        """retry_count=0 must be stored as 0, not treated as falsy/None."""
+        td = get_tool_def(no_retry_tool)
+        assert td.retry_count == 0, (
+            f"Expected retry_count=0, got {td.retry_count!r}. "
+            "retry_count=0 must not be coerced to None."
+        )
+
+    def test_aggressive_retry_fields_stored(self):
+        """All three retry fields are stored when set together."""
+        td = get_tool_def(aggressive_retry_tool)
+        assert td.retry_count == 5, (
+            f"Expected retry_count=5, got {td.retry_count}"
+        )
+        assert td.retry_delay_seconds == 3, (
+            f"Expected retry_delay_seconds=3, got {td.retry_delay_seconds}"
+        )
+        assert td.retry_logic == RetryLogic.EXPONENTIAL_BACKOFF, (
+            f"Expected retry_logic=EXPONENTIAL_BACKOFF, got {td.retry_logic}"
+        )
+
+    def test_fixed_retry_logic_stored(self):
+        """RetryLogic.FIXED is stored correctly."""
+        td = get_tool_def(fixed_retry_tool)
+        assert td.retry_count == 3
+        assert td.retry_delay_seconds == 1
+        assert td.retry_logic == RetryLogic.FIXED, (
+            f"Expected RetryLogic.FIXED, got {td.retry_logic!r}"
+        )
+
+    def test_linear_retry_logic_stored(self):
+        """RetryLogic.LINEAR_BACKOFF is stored correctly."""
+        td = get_tool_def(linear_retry_tool)
+        assert td.retry_count == 4
+        assert td.retry_delay_seconds == 2
+        assert td.retry_logic == RetryLogic.LINEAR_BACKOFF, (
+            f"Expected RetryLogic.LINEAR_BACKOFF, got {td.retry_logic!r}"
+        )
+
+    def test_retry_logic_enum_values(self):
+        """RetryLogic enum exposes the three expected string values."""
+        assert RetryLogic.FIXED == "FIXED"
+        assert RetryLogic.LINEAR_BACKOFF == "LINEAR_BACKOFF"
+        assert RetryLogic.EXPONENTIAL_BACKOFF == "EXPONENTIAL_BACKOFF"
+
+    def test_retry_logic_is_str_subclass(self):
+        """RetryLogic values are strings (str, Enum) — safe to pass to Conductor."""
+        assert isinstance(RetryLogic.FIXED, str)
+        assert isinstance(RetryLogic.LINEAR_BACKOFF, str)
+        assert isinstance(RetryLogic.EXPONENTIAL_BACKOFF, str)
+
+    def test_tool_name_unaffected_by_retry_config(self):
+        """Adding retry config must not change the tool's registered name."""
+        td_default = get_tool_def(default_retry_tool)
+        td_aggressive = get_tool_def(aggressive_retry_tool)
+        assert td_default.name == "default_retry_tool"
+        assert td_aggressive.name == "aggressive_retry_tool"
+
+    def test_retry_count_only_leaves_other_fields_none(self):
+        """Setting only retry_count leaves retry_delay_seconds and retry_logic as None."""
+        td = get_tool_def(no_retry_tool)
+        assert td.retry_count == 0
+        assert td.retry_delay_seconds is None, (
+            f"Expected retry_delay_seconds=None when not set, got {td.retry_delay_seconds}"
+        )
+        assert td.retry_logic is None, (
+            f"Expected retry_logic=None when not set, got {td.retry_logic}"
+        )
+
+
+# ── Config serializer assertions ─────────────────────────────────────────────
+
+
+class TestConfigSerializerRetryFields:
+    """Verify that the config serializer emits retry fields correctly."""
+
+    def test_serializer_emits_retry_fields_when_set(self):
+        """_serialize_tool() includes retryCount, retryDelaySeconds, retryLogic when set."""
+        from agentspan.agents.config_serializer import AgentConfigSerializer
+
+        serializer = AgentConfigSerializer()
+        config = serializer._serialize_tool(aggressive_retry_tool)
+
+        assert "retryCount" in config, (
+            f"Expected 'retryCount' in serialized config, got keys: {list(config.keys())}"
+        )
+        assert config["retryCount"] == 5, (
+            f"Expected retryCount=5, got {config['retryCount']}"
+        )
+        assert "retryDelaySeconds" in config, (
+            f"Expected 'retryDelaySeconds' in serialized config, got keys: {list(config.keys())}"
+        )
+        assert config["retryDelaySeconds"] == 3, (
+            f"Expected retryDelaySeconds=3, got {config['retryDelaySeconds']}"
+        )
+        assert "retryLogic" in config, (
+            f"Expected 'retryLogic' in serialized config, got keys: {list(config.keys())}"
+        )
+        assert config["retryLogic"] == "EXPONENTIAL_BACKOFF", (
+            f"Expected retryLogic='EXPONENTIAL_BACKOFF', got {config['retryLogic']!r}"
+        )
+
+    def test_serializer_omits_retry_fields_when_none(self):
+        """_serialize_tool() omits retry keys when fields are None (default tool)."""
+        from agentspan.agents.config_serializer import AgentConfigSerializer
+
+        serializer = AgentConfigSerializer()
+        config = serializer._serialize_tool(default_retry_tool)
+
+        assert "retryCount" not in config, (
+            f"retryCount should be absent when None, got config={config}"
+        )
+        assert "retryDelaySeconds" not in config, (
+            f"retryDelaySeconds should be absent when None, got config={config}"
+        )
+        assert "retryLogic" not in config, (
+            f"retryLogic should be absent when None, got config={config}"
+        )
+
+    def test_serializer_emits_retry_count_zero(self):
+        """_serialize_tool() emits retryCount=0 (must not be omitted as falsy)."""
+        from agentspan.agents.config_serializer import AgentConfigSerializer
+
+        serializer = AgentConfigSerializer()
+        config = serializer._serialize_tool(no_retry_tool)
+
+        assert "retryCount" in config, (
+            f"retryCount=0 must be present in serialized config (not omitted as falsy). "
+            f"Got keys: {list(config.keys())}"
+        )
+        assert config["retryCount"] == 0, (
+            f"Expected retryCount=0, got {config['retryCount']!r}"
+        )
+
+    def test_serializer_emits_fixed_retry_logic(self):
+        """_serialize_tool() emits retryLogic='FIXED' for RetryLogic.FIXED."""
+        from agentspan.agents.config_serializer import AgentConfigSerializer
+
+        serializer = AgentConfigSerializer()
+        config = serializer._serialize_tool(fixed_retry_tool)
+
+        assert config.get("retryLogic") == "FIXED", (
+            f"Expected retryLogic='FIXED', got {config.get('retryLogic')!r}"
+        )
+
+    def test_serializer_emits_linear_retry_logic(self):
+        """_serialize_tool() emits retryLogic='LINEAR_BACKOFF' for RetryLogic.LINEAR_BACKOFF."""
+        from agentspan.agents.config_serializer import AgentConfigSerializer
+
+        serializer = AgentConfigSerializer()
+        config = serializer._serialize_tool(linear_retry_tool)
+
+        assert config.get("retryLogic") == "LINEAR_BACKOFF", (
+            f"Expected retryLogic='LINEAR_BACKOFF', got {config.get('retryLogic')!r}"
+        )
+
+
+# ── Live server / runtime tests ───────────────────────────────────────────────
+
+
+AGENT_INSTRUCTIONS = """\
+You have five tools: default_retry_tool, no_retry_tool, aggressive_retry_tool,
+fixed_retry_tool, and linear_retry_tool.
+Call ALL five tools exactly once, each with the argument "ping".
+After calling all five, report each tool's output verbatim.
+Do not skip any tool.
+"""
+
+
+def _make_retry_agent(model: str) -> Agent:
+    return Agent(
+        name="e2e_tool_retry_config",
+        model=model,
+        max_turns=6,
+        instructions=AGENT_INSTRUCTIONS,
+        tools=[
+            default_retry_tool,
+            no_retry_tool,
+            aggressive_retry_tool,
+            fixed_retry_tool,
+            linear_retry_tool,
+        ],
+    )
+
+
+def _run_diagnostic(result) -> str:
+    parts = [
+        f"status={result.status}",
+        f"execution_id={result.execution_id}",
+    ]
+    output = result.output
+    if isinstance(output, dict):
+        parts.append(f"output_keys={list(output.keys())}")
+        if "finishReason" in output:
+            parts.append(f"finishReason={output['finishReason']}")
+    else:
+        out_str = str(output)
+        parts.append(f"output={out_str[:200]}")
+    return " | ".join(parts)
+
+
+def _find_tool_tasks(execution_id: str, tool_names: list) -> dict:
+    """Fetch workflow and extract task results keyed by tool name."""
+    import os
+    import requests
+
+    base = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:6767/api")
+    base_url = base.rstrip("/").replace("/api", "")
+    resp = requests.get(f"{base_url}/api/workflow/{execution_id}", timeout=10)
+    resp.raise_for_status()
+    wf = resp.json()
+
+    results = {}
+    for task in wf.get("tasks", []):
+        ref = task.get("referenceTaskName", "")
+        task_def = task.get("taskDefName", "")
+        for name in tool_names:
+            if name in results:
+                continue
+            if name in ref or name == task_def:
+                results[name] = {
+                    "status": task.get("status", ""),
+                    "output": task.get("outputData", {}),
+                    "reason": task.get("reasonForIncompletion", ""),
+                    "ref": ref,
+                }
+    return results
+
+
+@pytest.mark.timeout(300)
+class TestSuite14ToolRetryConfig:
+    """Live-server tests: retry config flows through registration and execution."""
+
+    TOOL_NAMES = [
+        "default_retry_tool",
+        "no_retry_tool",
+        "aggressive_retry_tool",
+        "fixed_retry_tool",
+        "linear_retry_tool",
+    ]
+
+    def test_all_retry_tools_complete_successfully(self, runtime, model):
+        """All five tools with different retry configs execute and complete."""
+        agent = _make_retry_agent(model)
+        result = runtime.run(agent, "Call all five tools with 'ping'.", timeout=TIMEOUT)
+
+        assert result.execution_id, (
+            f"No execution_id returned. {_run_diagnostic(result)}"
+        )
+        assert result.status == "COMPLETED", (
+            f"Agent run did not complete. {_run_diagnostic(result)}"
+        )
+
+    def test_tool_tasks_all_completed_in_workflow(self, runtime, model):
+        """Workflow tasks for all five retry-configured tools reach COMPLETED status."""
+        agent = _make_retry_agent(model)
+        result = runtime.run(agent, "Call all five tools with 'ping'.", timeout=TIMEOUT)
+
+        assert result.execution_id, (
+            f"No execution_id returned. {_run_diagnostic(result)}"
+        )
+        assert result.status == "COMPLETED", (
+            f"Agent run did not complete. {_run_diagnostic(result)}"
+        )
+
+        tool_tasks = _find_tool_tasks(result.execution_id, self.TOOL_NAMES)
+
+        # At least the tools that were called must have completed
+        for name, task_info in tool_tasks.items():
+            assert task_info["status"] == "COMPLETED", (
+                f"Tool '{name}' task did not complete. "
+                f"status={task_info['status']} reason={task_info['reason']!r} "
+                f"output={task_info['output']}"
+            )
+
+    def test_no_retry_tool_task_count_is_one(self, runtime, model):
+        """no_retry_tool (retry_count=0) must execute exactly once — no retries."""
+        import os
+        import requests
+
+        agent = _make_retry_agent(model)
+        result = runtime.run(agent, "Call all five tools with 'ping'.", timeout=TIMEOUT)
+
+        assert result.execution_id, (
+            f"No execution_id returned. {_run_diagnostic(result)}"
+        )
+
+        base = os.environ.get("AGENTSPAN_SERVER_URL", "http://localhost:6767/api")
+        base_url = base.rstrip("/").replace("/api", "")
+        resp = requests.get(
+            f"{base_url}/api/workflow/{result.execution_id}", timeout=10
+        )
+        resp.raise_for_status()
+        wf = resp.json()
+
+        # Count how many tasks reference no_retry_tool
+        no_retry_tasks = [
+            t for t in wf.get("tasks", [])
+            if "no_retry_tool" in t.get("referenceTaskName", "")
+            or t.get("taskDefName", "") == "no_retry_tool"
+        ]
+
+        # With retry_count=0 the task should appear at most once
+        assert len(no_retry_tasks) <= 1, (
+            f"no_retry_tool (retry_count=0) appeared {len(no_retry_tasks)} times "
+            f"in the workflow — it should never be retried. "
+            f"tasks={[t.get('referenceTaskName') for t in no_retry_tasks]}"
+        )
+
+    def test_retry_config_does_not_break_tool_output(self, runtime, model):
+        """Tools with custom retry config still return correct output values."""
+        agent = _make_retry_agent(model)
+        result = runtime.run(agent, "Call all five tools with 'ping'.", timeout=TIMEOUT)
+
+        assert result.execution_id, (
+            f"No execution_id returned. {_run_diagnostic(result)}"
+        )
+        assert result.status == "COMPLETED", (
+            f"Agent run did not complete. {_run_diagnostic(result)}"
+        )
+
+        tool_tasks = _find_tool_tasks(result.execution_id, self.TOOL_NAMES)
+
+        # Verify output shape for each tool that was called
+        expected_prefixes = {
+            "default_retry_tool": "default:",
+            "no_retry_tool": "no_retry:",
+            "aggressive_retry_tool": "aggressive:",
+            "fixed_retry_tool": "fixed:",
+            "linear_retry_tool": "linear:",
+        }
+        for name, prefix in expected_prefixes.items():
+            if name not in tool_tasks:
+                continue  # tool may not have been called by LLM — skip
+            output_str = str(tool_tasks[name]["output"])
+            assert prefix in output_str, (
+                f"Tool '{name}' output should contain '{prefix}'. "
+                f"Got output={output_str[:200]}"
+            )
+
+    def test_multiple_retry_configs_coexist_in_same_agent(self, runtime, model):
+        """An agent with tools of different retry configs registers and runs without error."""
+        agent = _make_retry_agent(model)
+
+        # Registration happens inside runtime.run — if retry configs conflict or
+        # cause registration errors the run will fail before any tool is called.
+        result = runtime.run(agent, "Call all five tools with 'ping'.", timeout=TIMEOUT)
+
+        assert result.execution_id, (
+            f"No execution_id — agent with mixed retry configs may have failed "
+            f"to register. {_run_diagnostic(result)}"
+        )
+        # Any terminal status is acceptable here; we just need it not to crash
+        assert result.status in ("COMPLETED", "FAILED", "TERMINATED"), (
+            f"Unexpected non-terminal status '{result.status}'. "
+            f"{_run_diagnostic(result)}"
+        )

--- a/sdk/python/examples/34_tool_retry_config.py
+++ b/sdk/python/examples/34_tool_retry_config.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Tool Retry Configuration — per-tool retry_count, retry_delay_seconds, retry_logic.
+
+Demonstrates:
+    - Setting retry_count on @tool to control how many times Conductor retries
+      a failed task before giving up
+    - Setting retry_delay_seconds to control the wait between retries
+    - Setting retry_logic to choose the backoff strategy:
+        "FIXED"               — same delay every time
+        "LINEAR_BACKOFF"      — delay grows linearly (default)
+        "EXPONENTIAL_BACKOFF" — delay doubles each attempt
+    - Using retry_count=0 to disable retries entirely (e.g. payment operations)
+    - Mixing retry configs across tools in the same agent
+
+Requirements:
+    - Conductor server with LLM support
+    - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
+    - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+"""
+
+import random
+
+from agentspan.agents import Agent, AgentRuntime, tool
+from settings import settings
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: Flaky external API — aggressive retries with exponential backoff.
+#
+# retry_count=5        → up to 5 retry attempts after the first failure
+# retry_delay_seconds=3 → base delay of 3 s (doubles each attempt with EXPONENTIAL_BACKOFF)
+# retry_logic="EXPONENTIAL_BACKOFF" → 3s, 6s, 12s, 24s, 48s between retries
+# ---------------------------------------------------------------------------
+@tool(retry_count=5, retry_delay_seconds=3, retry_logic="EXPONENTIAL_BACKOFF")
+def fetch_market_data(ticker: str) -> dict:
+    """Fetch real-time market data for a stock ticker.
+
+    This tool calls an unreliable third-party market-data API.
+    Exponential backoff gives the upstream service time to recover.
+    """
+    # Simulate occasional failures from a flaky upstream API
+    if random.random() < 0.3:
+        raise RuntimeError(f"Market data API timeout for {ticker}")
+
+    prices = {
+        "AAPL": 189.42,
+        "GOOGL": 175.18,
+        "MSFT": 415.30,
+        "AMZN": 198.75,
+        "TSLA": 248.60,
+    }
+    price = prices.get(ticker.upper(), round(random.uniform(50, 500), 2))
+    return {
+        "ticker": ticker.upper(),
+        "price": price,
+        "currency": "USD",
+        "source": "market-data-api",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: Payment processing — NO retries.
+#
+# retry_count=0 → fail immediately on error; never retry.
+#
+# Critical for idempotency: retrying a payment could charge the customer twice.
+# ---------------------------------------------------------------------------
+@tool(retry_count=0)
+def process_payment(amount: float, currency: str, description: str) -> dict:
+    """Process a payment transaction.
+
+    IMPORTANT: retry_count=0 ensures this tool is never retried automatically.
+    Retrying a payment could result in duplicate charges.
+    """
+    # Simulate payment processing
+    transaction_id = f"txn_{random.randint(100000, 999999)}"
+    return {
+        "transaction_id": transaction_id,
+        "amount": amount,
+        "currency": currency,
+        "description": description,
+        "status": "approved",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 3: Internal microservice — fixed delay retries.
+#
+# retry_count=3        → up to 3 retries
+# retry_delay_seconds=2 → always wait exactly 2 s between retries (FIXED)
+# retry_logic="FIXED"  → predictable, constant delay (good for internal services)
+# ---------------------------------------------------------------------------
+@tool(retry_count=3, retry_delay_seconds=2, retry_logic="FIXED")
+def get_account_balance(account_id: str) -> dict:
+    """Retrieve the current balance for a bank account.
+
+    Calls an internal account-service. Fixed retry delay gives the service
+    a predictable recovery window without compounding backoff pressure.
+    """
+    # Simulate internal service lookup
+    balances = {
+        "ACC-001": 12_450.00,
+        "ACC-002": 3_820.50,
+        "ACC-003": 98_100.75,
+    }
+    balance = balances.get(account_id, round(random.uniform(100, 50000), 2))
+    return {
+        "account_id": account_id,
+        "balance": balance,
+        "currency": "USD",
+        "as_of": "2026-04-24T12:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool 4: Default retry behaviour (no retry params set).
+#
+# Omitting retry params uses the SDK defaults:
+#   retry_count=2, retry_delay_seconds=2, retry_logic="LINEAR_BACKOFF"
+# ---------------------------------------------------------------------------
+@tool
+def get_exchange_rate(from_currency: str, to_currency: str) -> dict:
+    """Get the current exchange rate between two currencies.
+
+    Uses default retry settings (retry_count=2, LINEAR_BACKOFF).
+    Suitable for most tools that don't have special retry requirements.
+    """
+    rates = {
+        ("USD", "EUR"): 0.92,
+        ("USD", "GBP"): 0.79,
+        ("USD", "JPY"): 154.30,
+        ("EUR", "USD"): 1.09,
+    }
+    rate = rates.get((from_currency.upper(), to_currency.upper()), 1.0)
+    return {
+        "from": from_currency.upper(),
+        "to": to_currency.upper(),
+        "rate": rate,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Agent — uses all four tools with different retry profiles
+# ---------------------------------------------------------------------------
+agent = Agent(
+    name="financial_assistant_retry_demo",
+    model=settings.llm_model,
+    tools=[fetch_market_data, process_payment, get_account_balance, get_exchange_rate],
+    instructions=(
+        "You are a financial assistant. Help users with stock prices, account balances, "
+        "currency conversions, and payment processing. "
+        "Always confirm payment details with the user before processing."
+    ),
+)
+
+
+if __name__ == "__main__":
+    print("=== Tool Retry Configuration Demo ===\n")
+    print("Retry profiles:")
+    print("  fetch_market_data   → retry_count=5, retry_delay_seconds=3, EXPONENTIAL_BACKOFF")
+    print("  process_payment     → retry_count=0  (no retries — idempotency critical)")
+    print("  get_account_balance → retry_count=3, retry_delay_seconds=2, FIXED")
+    print("  get_exchange_rate   → defaults       (retry_count=2, LINEAR_BACKOFF)\n")
+
+    with AgentRuntime() as runtime:
+        result = runtime.run(
+            agent,
+            "What is the current price of AAPL stock? "
+            "Also, what is the USD to EUR exchange rate? "
+            "And what is the balance on account ACC-001?",
+        )
+        result.print_result()
+
+    # Production pattern:
+    # 1. Deploy once during CI/CD:
+    #    runtime.deploy(agent)
+    #
+    # 2. In a separate long-lived worker process:
+    #    runtime.serve(agent)
+    #
+    # 3. Trigger runs from anywhere:
+    #    agentspan run financial_assistant_retry_demo "Check AAPL price"

--- a/sdk/python/examples/README.md
+++ b/sdk/python/examples/README.md
@@ -182,6 +182,7 @@ python examples/adk/01_basic_agent.py
 | 14 | [Existing Workers](14_existing_workers.py) | Use existing `@worker_task` functions directly as agent tools |
 | 33 | [Single Turn Tool](33_single_turn_tool.py) | Single-turn tool invocation with immediate response |
 | 33 | [External Workers](33_external_workers.py) | Reference workers in other services via `@tool(external=True)` — no local code needed |
+| 34 | [Tool Retry Config](34_tool_retry_config.py) | Per-tool `retry_count`, `retry_delay_seconds`, `retry_logic` — exponential backoff, fixed delay, zero retries |
 
 ## Multi-Agent Orchestration
 
@@ -300,6 +301,9 @@ Quick lookup — find the right example for any SDK feature:
 |---------|-----------|
 | `Agent` | 01 |
 | `@tool` decorator | 02, 02a, 02b |
+| `@tool(retry_count=...)` | 34 |
+| `@tool(retry_delay_seconds=...)` | 34 |
+| `@tool(retry_logic=...)` | 34 |
 | `http_tool()` | 04 |
 | `mcp_tool()` | 04, 04b |
 | `output_type` (Pydantic) | 03 |

--- a/sdk/python/src/agentspan/agents/__init__.py
+++ b/sdk/python/src/agentspan/agents/__init__.py
@@ -184,6 +184,7 @@ from agentspan.agents.openai_compat import RunResult, Runner
 
 # Tool decorator and constructors
 from agentspan.agents.tool import (
+    RetryLogic,
     ToolContext,
     ToolDef,
     agent_tool,
@@ -229,6 +230,7 @@ __all__ = [
     "tool",
     "ToolDef",
     "ToolContext",
+    "RetryLogic",
     "agent_tool",
     "api_tool",
     "http_tool",

--- a/sdk/python/src/agentspan/agents/config_serializer.py
+++ b/sdk/python/src/agentspan/agents/config_serializer.py
@@ -267,6 +267,20 @@ class AgentConfigSerializer:
                 result["config"] = {}
             result["config"]["credentials"] = cred_names
 
+        # Retry configuration — pass through to server for TaskDef overrides.
+        if getattr(td, "retry_count", None) is not None:
+            if "config" not in result:
+                result["config"] = {}
+            result["config"]["retryCount"] = td.retry_count
+        if getattr(td, "retry_delay_seconds", None) is not None:
+            if "config" not in result:
+                result["config"] = {}
+            result["config"]["retryDelaySeconds"] = td.retry_delay_seconds
+        if getattr(td, "retry_logic", None) is not None:
+            if "config" not in result:
+                result["config"] = {}
+            result["config"]["retryLogic"] = td.retry_logic
+
         return result
 
     def _serialize_guardrail(self, guardrail: Any) -> dict:

--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -47,7 +47,7 @@ def _default_task_def(
     response_timeout_seconds: int = 10,
     retry_count: Optional[int] = None,
     retry_delay_seconds: Optional[int] = None,
-    retry_logic: Optional[str] = None,
+    retry_logic: Optional["RetryLogic"] = None,
 ) -> Any:
     """Create a TaskDef with standard retry policy for agent worker tasks.
 
@@ -60,13 +60,16 @@ def _default_task_def(
     (at 80% of this value) keep long-running tasks alive automatically.
 
     retry_count, retry_delay_seconds, retry_logic: optional per-tool overrides.
-    When None, the defaults (2, 2, "LINEAR_BACKOFF") are used.
+    When None, the defaults (2, 2, RetryLogic.LINEAR_BACKOFF) are used.
     """
     from conductor.client.http.models.task_def import TaskDef
+    from agentspan.agents.tool import RetryLogic
 
     td = TaskDef(name=name)
     td.retry_count = retry_count if retry_count is not None else 2
-    td.retry_logic = retry_logic if retry_logic is not None else "LINEAR_BACKOFF"
+    # RetryLogic is a str-Enum so .value gives the plain string Conductor expects
+    _default_logic = RetryLogic.LINEAR_BACKOFF.value
+    td.retry_logic = (retry_logic.value if isinstance(retry_logic, RetryLogic) else retry_logic) if retry_logic is not None else _default_logic
     td.retry_delay_seconds = retry_delay_seconds if retry_delay_seconds is not None else 2
     td.timeout_seconds = 0
     td.response_timeout_seconds = response_timeout_seconds

--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -41,7 +41,14 @@ from agentspan.agents.runtime.http_client import AgentHttpClient, SSEUnavailable
 logger = logging.getLogger("agentspan.agents.runtime")
 
 
-def _default_task_def(name: str, *, response_timeout_seconds: int = 10) -> Any:
+def _default_task_def(
+    name: str,
+    *,
+    response_timeout_seconds: int = 10,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
+    retry_logic: Optional[str] = None,
+) -> Any:
     """Create a TaskDef with standard retry policy for agent worker tasks.
 
     Timeout is 0 (no timeout) — the agent configuration controls execution
@@ -51,13 +58,16 @@ def _default_task_def(name: str, *, response_timeout_seconds: int = 10) -> Any:
     within this time, Conductor marks the task as timed out and retries.
     Kept short to detect dead workers quickly; lease extension heartbeats
     (at 80% of this value) keep long-running tasks alive automatically.
+
+    retry_count, retry_delay_seconds, retry_logic: optional per-tool overrides.
+    When None, the defaults (2, 2, "LINEAR_BACKOFF") are used.
     """
     from conductor.client.http.models.task_def import TaskDef
 
     td = TaskDef(name=name)
-    td.retry_count = 2
-    td.retry_logic = "LINEAR_BACKOFF"
-    td.retry_delay_seconds = 2
+    td.retry_count = retry_count if retry_count is not None else 2
+    td.retry_logic = retry_logic if retry_logic is not None else "LINEAR_BACKOFF"
+    td.retry_delay_seconds = retry_delay_seconds if retry_delay_seconds is not None else 2
     td.timeout_seconds = 0
     td.response_timeout_seconds = response_timeout_seconds
     td.timeout_policy = "RETRY"

--- a/sdk/python/src/agentspan/agents/runtime/tool_registry.py
+++ b/sdk/python/src/agentspan/agents/runtime/tool_registry.py
@@ -68,7 +68,12 @@ class ToolRegistry:
                 wrapper = make_tool_worker(td.func, td.name, guardrails=guardrails, tool_def=td)
                 worker_task(
                     task_definition_name=td.name,
-                    task_def=_default_task_def(td.name),
+                    task_def=_default_task_def(
+                        td.name,
+                        retry_count=td.retry_count,
+                        retry_delay_seconds=td.retry_delay_seconds,
+                        retry_logic=td.retry_logic,
+                    ),
                     register_task_def=True,
                     overwrite_task_def=True,
                     domain=domain if (agent_stateful or td.stateful) else None,

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -13,9 +13,26 @@ from __future__ import annotations
 import functools
 import inspect
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, TypeVar, overload
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+# ── RetryLogic enum ─────────────────────────────────────────────────────
+
+
+class RetryLogic(str, Enum):
+    """Retry backoff strategy for Conductor TaskDef.
+
+    FIXED: constant delay of ``retry_delay_seconds`` between every retry.
+    LINEAR_BACKOFF: delay grows linearly (``retry_delay_seconds × attempt``). Default.
+    EXPONENTIAL_BACKOFF: delay doubles each attempt (``retry_delay_seconds × 2^attempt``).
+    """
+
+    FIXED = "FIXED"
+    LINEAR_BACKOFF = "LINEAR_BACKOFF"
+    EXPONENTIAL_BACKOFF = "EXPONENTIAL_BACKOFF"
 
 
 # ── ToolContext (dependency injection for tools) ────────────────────────
@@ -82,7 +99,7 @@ class ToolDef:
     stateful: bool = False
     retry_count: Optional[int] = None
     retry_delay_seconds: Optional[int] = None
-    retry_logic: Optional[str] = None
+    retry_logic: Optional[RetryLogic] = None
 
 
 # ── @tool decorator ─────────────────────────────────────────────────────
@@ -105,7 +122,7 @@ def tool(
     stateful: bool = False,
     retry_count: Optional[int] = None,
     retry_delay_seconds: Optional[int] = None,
-    retry_logic: Optional[str] = None,
+    retry_logic: Optional[RetryLogic] = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -122,7 +139,7 @@ def tool(
     stateful: bool = False,
     retry_count: Optional[int] = None,
     retry_delay_seconds: Optional[int] = None,
-    retry_logic: Optional[str] = None,
+    retry_logic: Optional[RetryLogic] = None,
 ) -> Any:
     """Register a Python function as a Conductor agent tool.
 

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -80,6 +80,9 @@ class ToolDef:
     isolated: bool = True
     credentials: List[Any] = field(default_factory=list)
     stateful: bool = False
+    retry_count: Optional[int] = None
+    retry_delay_seconds: Optional[int] = None
+    retry_logic: Optional[str] = None
 
 
 # ── @tool decorator ─────────────────────────────────────────────────────
@@ -100,6 +103,9 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
+    retry_logic: Optional[str] = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -114,6 +120,9 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
+    retry_logic: Optional[str] = None,
 ) -> Any:
     """Register a Python function as a Conductor agent tool.
 
@@ -160,6 +169,9 @@ def tool(
             isolated=isolated,
             credentials=list(credentials) if credentials else [],
             stateful=stateful,
+            retry_count=retry_count,
+            retry_delay_seconds=retry_delay_seconds,
+            retry_logic=retry_logic,
         )
 
         @functools.wraps(fn)

--- a/sdk/python/tests/unit/test_tool_retry.py
+++ b/sdk/python/tests/unit/test_tool_retry.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Unit tests for retry configuration on the @tool decorator (issue #150).
+
+These are pure unit tests — no server, no mocks, just verifying the
+dataclass and decorator wiring.
+"""
+
+import pytest
+
+from agentspan.agents.tool import ToolDef, tool
+from agentspan.agents.runtime.runtime import _default_task_def
+from agentspan.agents.config_serializer import AgentConfigSerializer
+
+
+# ── @tool decorator tests ────────────────────────────────────────────────────
+
+
+def test_tool_decorator_default_retry_fields_are_none():
+    """Bare @tool should leave all retry fields as None."""
+
+    @tool
+    def my_tool(x: str) -> str:
+        """A simple tool."""
+        return x
+
+    td = my_tool._tool_def
+    assert td.retry_count is None
+    assert td.retry_delay_seconds is None
+    assert td.retry_logic is None
+
+
+def test_tool_decorator_retry_count():
+    """@tool(retry_count=10) should set retry_count on the ToolDef."""
+
+    @tool(retry_count=10)
+    def my_tool(x: str) -> str:
+        """A simple tool."""
+        return x
+
+    assert my_tool._tool_def.retry_count == 10
+    assert my_tool._tool_def.retry_delay_seconds is None
+    assert my_tool._tool_def.retry_logic is None
+
+
+def test_tool_decorator_retry_delay_seconds():
+    """@tool(retry_delay_seconds=5) should set retry_delay_seconds on the ToolDef."""
+
+    @tool(retry_delay_seconds=5)
+    def my_tool(x: str) -> str:
+        """A simple tool."""
+        return x
+
+    assert my_tool._tool_def.retry_count is None
+    assert my_tool._tool_def.retry_delay_seconds == 5
+    assert my_tool._tool_def.retry_logic is None
+
+
+def test_tool_decorator_retry_logic():
+    """@tool(retry_logic='EXPONENTIAL_BACKOFF') should set retry_logic on the ToolDef."""
+
+    @tool(retry_logic="EXPONENTIAL_BACKOFF")
+    def my_tool(x: str) -> str:
+        """A simple tool."""
+        return x
+
+    assert my_tool._tool_def.retry_count is None
+    assert my_tool._tool_def.retry_delay_seconds is None
+    assert my_tool._tool_def.retry_logic == "EXPONENTIAL_BACKOFF"
+
+
+def test_tool_decorator_zero_retries():
+    """@tool(retry_count=0) should set retry_count=0 (not None, not falsy-skipped)."""
+
+    @tool(retry_count=0)
+    def my_tool(x: str) -> str:
+        """A simple tool."""
+        return x
+
+    # Must be exactly 0, not None
+    assert my_tool._tool_def.retry_count == 0
+    assert my_tool._tool_def.retry_count is not None
+
+
+def test_tool_decorator_all_retry_params():
+    """@tool with all three retry params should set all three fields."""
+
+    @tool(retry_count=5, retry_delay_seconds=10, retry_logic="FIXED")
+    def my_tool(x: str) -> str:
+        """A simple tool."""
+        return x
+
+    td = my_tool._tool_def
+    assert td.retry_count == 5
+    assert td.retry_delay_seconds == 10
+    assert td.retry_logic == "FIXED"
+
+
+def test_tool_decorator_retry_preserved_on_raw_fn():
+    """Retry fields should be set on both the wrapper and the raw function."""
+
+    @tool(retry_count=3, retry_delay_seconds=7, retry_logic="LINEAR_BACKOFF")
+    def my_tool(x: str) -> str:
+        """A simple tool."""
+        return x
+
+    # Both the wrapper and the raw fn should have _tool_def
+    assert my_tool._tool_def.retry_count == 3
+    assert my_tool._tool_def.retry_delay_seconds == 7
+    assert my_tool._tool_def.retry_logic == "LINEAR_BACKOFF"
+
+
+# ── _default_task_def tests ──────────────────────────────────────────────────
+
+
+def test_default_task_def_uses_defaults_when_none():
+    """_default_task_def with no overrides should use the hardcoded defaults."""
+    td = _default_task_def("test_task")
+    assert td.retry_count == 2
+    assert td.retry_delay_seconds == 2
+    assert td.retry_logic == "LINEAR_BACKOFF"
+
+
+def test_default_task_def_uses_tool_retry_config():
+    """_default_task_def with explicit overrides should use those values."""
+    td = _default_task_def(
+        "test_task",
+        retry_count=5,
+        retry_delay_seconds=10,
+        retry_logic="EXPONENTIAL_BACKOFF",
+    )
+    assert td.retry_count == 5
+    assert td.retry_delay_seconds == 10
+    assert td.retry_logic == "EXPONENTIAL_BACKOFF"
+
+
+def test_default_task_def_zero_retry_count():
+    """_default_task_def(retry_count=0) should set 0, not the default 2."""
+    td = _default_task_def("test_task", retry_count=0)
+    assert td.retry_count == 0
+
+
+def test_default_task_def_partial_overrides():
+    """Partial overrides should only change the specified fields."""
+    td = _default_task_def("test_task", retry_count=7)
+    assert td.retry_count == 7
+    assert td.retry_delay_seconds == 2          # default
+    assert td.retry_logic == "LINEAR_BACKOFF"   # default
+
+
+def test_default_task_def_fixed_logic():
+    """_default_task_def with retry_logic='FIXED' should set FIXED."""
+    td = _default_task_def("test_task", retry_logic="FIXED")
+    assert td.retry_logic == "FIXED"
+    assert td.retry_count == 2          # default
+    assert td.retry_delay_seconds == 2  # default
+
+
+# ── AgentConfigSerializer._serialize_tool tests ──────────────────────────────
+
+
+def _make_worker_tool_def(**kwargs) -> ToolDef:
+    """Helper: create a minimal worker ToolDef with optional retry fields."""
+    return ToolDef(
+        name="my_tool",
+        description="A test tool",
+        input_schema={"type": "object", "properties": {"x": {"type": "string"}}},
+        tool_type="worker",
+        **kwargs,
+    )
+
+
+def test_serializer_includes_retry_in_config():
+    """Serializer should include retryCount/retryDelaySeconds/retryLogic in config."""
+    td = _make_worker_tool_def(retry_count=5, retry_delay_seconds=10, retry_logic="FIXED")
+    serializer = AgentConfigSerializer()
+    result = serializer._serialize_tool(td)
+
+    assert "config" in result
+    assert result["config"]["retryCount"] == 5
+    assert result["config"]["retryDelaySeconds"] == 10
+    assert result["config"]["retryLogic"] == "FIXED"
+
+
+def test_serializer_omits_retry_when_none():
+    """Serializer should NOT include retry keys when all retry fields are None."""
+    td = _make_worker_tool_def()  # no retry fields set
+    serializer = AgentConfigSerializer()
+    result = serializer._serialize_tool(td)
+
+    config = result.get("config", {})
+    assert "retryCount" not in config
+    assert "retryDelaySeconds" not in config
+    assert "retryLogic" not in config
+
+
+def test_serializer_partial_retry_fields():
+    """Serializer should only include the retry keys that are set."""
+    td = _make_worker_tool_def(retry_count=3)
+    serializer = AgentConfigSerializer()
+    result = serializer._serialize_tool(td)
+
+    assert "config" in result
+    assert result["config"]["retryCount"] == 3
+    assert "retryDelaySeconds" not in result["config"]
+    assert "retryLogic" not in result["config"]
+
+
+def test_serializer_zero_retry_count_included():
+    """Serializer should include retryCount=0 (not skip it as falsy)."""
+    td = _make_worker_tool_def(retry_count=0)
+    serializer = AgentConfigSerializer()
+    result = serializer._serialize_tool(td)
+
+    assert "config" in result
+    assert result["config"]["retryCount"] == 0
+
+
+def test_serializer_retry_alongside_credentials():
+    """Retry config should coexist with credentials in the config dict."""
+    td = _make_worker_tool_def(
+        retry_count=2,
+        retry_logic="LINEAR_BACKOFF",
+        credentials=["MY_API_KEY"],
+    )
+    serializer = AgentConfigSerializer()
+    result = serializer._serialize_tool(td)
+
+    assert "config" in result
+    assert result["config"]["retryCount"] == 2
+    assert result["config"]["retryLogic"] == "LINEAR_BACKOFF"
+    assert result["config"]["credentials"] == ["MY_API_KEY"]

--- a/sdk/typescript/examples/34-tool-retry-config.ts
+++ b/sdk/typescript/examples/34-tool-retry-config.ts
@@ -1,0 +1,224 @@
+/**
+ * Tool Retry Configuration — per-tool retryCount, retryDelaySeconds, retryLogic.
+ *
+ * Demonstrates:
+ *   - Setting retryCount on tool() to control how many times Conductor retries
+ *     a failed task before giving up
+ *   - Setting retryDelaySeconds to control the wait between retries
+ *   - Setting retryLogic to choose the backoff strategy:
+ *       "FIXED"               — same delay every time
+ *       "LINEAR_BACKOFF"      — delay grows linearly (default)
+ *       "EXPONENTIAL_BACKOFF" — delay doubles each attempt
+ *   - Using retryCount=0 to disable retries entirely (e.g. payment operations)
+ *   - Mixing retry configs across tools in the same agent
+ *
+ * Requirements:
+ *   - Conductor server with LLM support
+ *   - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
+ *   - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ */
+
+import { Agent, AgentRuntime, tool } from "@agentspan-ai/sdk";
+import type { RetryLogic } from "@agentspan-ai/sdk";
+import { llmModel } from "./settings.js";
+
+// ---------------------------------------------------------------------------
+// Tool 1: Flaky external API — aggressive retries with exponential backoff.
+//
+// retryCount=5         → up to 5 retry attempts after the first failure
+// retryDelaySeconds=3  → base delay of 3 s (doubles each attempt with EXPONENTIAL_BACKOFF)
+// retryLogic="EXPONENTIAL_BACKOFF" → 3s, 6s, 12s, 24s, 48s between retries
+// ---------------------------------------------------------------------------
+const fetchMarketData = tool(
+  async (args: { ticker: string }) => {
+    // Simulate occasional failures from a flaky upstream API
+    if (Math.random() < 0.3) {
+      throw new Error(`Market data API timeout for null`);
+    }
+
+    const prices: Record<string, number> = {
+      AAPL: 189.42,
+      GOOGL: 175.18,
+      MSFT: 415.3,
+      AMZN: 198.75,
+      TSLA: 248.6,
+    };
+    const price = prices[args.ticker.toUpperCase()] ?? Math.round(Math.random() * 450 + 50);
+    return {
+      ticker: args.ticker.toUpperCase(),
+      price,
+      currency: "USD",
+      source: "market-data-api",
+    };
+  },
+  {
+    name: "fetch_market_data",
+    description:
+      "Fetch real-time market data for a stock ticker. " +
+      "This tool calls an unreliable third-party market-data API. " +
+      "Exponential backoff gives the upstream service time to recover.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ticker: { type: "string", description: "Stock ticker symbol (e.g. AAPL, GOOGL)." },
+      },
+      required: ["ticker"],
+    },
+    retryCount: 5,
+    retryDelaySeconds: 3,
+    retryLogic: "EXPONENTIAL_BACKOFF" as RetryLogic,
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Tool 2: Payment processing — NO retries.
+//
+// retryCount=0 → fail immediately on error; never retry.
+//
+// Critical for idempotency: retrying a payment could charge the customer twice.
+// ---------------------------------------------------------------------------
+const processPayment = tool(
+  async (args: { amount: number; currency: string; description: string }) => {
+    // Simulate payment processing
+    const transactionId = `txn_null`;
+    return {
+      transactionId,
+      amount: args.amount,
+      currency: args.currency,
+      description: args.description,
+      status: "approved",
+    };
+  },
+  {
+    name: "process_payment",
+    description:
+      "Process a payment transaction. " +
+      "IMPORTANT: retryCount=0 ensures this tool is never retried automatically. " +
+      "Retrying a payment could result in duplicate charges.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        amount: { type: "number", description: "Payment amount." },
+        currency: { type: "string", description: "Currency code (e.g. USD, EUR)." },
+        description: { type: "string", description: "Payment description." },
+      },
+      required: ["amount", "currency", "description"],
+    },
+    retryCount: 0,
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Tool 3: Internal microservice — fixed delay retries.
+//
+// retryCount=3         → up to 3 retries
+// retryDelaySeconds=2  → always wait exactly 2 s between retries (FIXED)
+// retryLogic="FIXED"   → predictable, constant delay (good for internal services)
+// ---------------------------------------------------------------------------
+const getAccountBalance = tool(
+  async (args: { accountId: string }) => {
+    // Simulate internal service lookup
+    const balances: Record<string, number> = {
+      "ACC-001": 12450.0,
+      "ACC-002": 3820.5,
+      "ACC-003": 98100.75,
+    };
+    const balance = balances[args.accountId] ?? Math.round(Math.random() * 49900 + 100);
+    return {
+      accountId: args.accountId,
+      balance,
+      currency: "USD",
+      asOf: "2026-04-24T12:00:00Z",
+    };
+  },
+  {
+    name: "get_account_balance",
+    description:
+      "Retrieve the current balance for a bank account. " +
+      "Calls an internal account-service. Fixed retry delay gives the service " +
+      "a predictable recovery window without compounding backoff pressure.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        accountId: { type: "string", description: "Bank account identifier (e.g. ACC-001)." },
+      },
+      required: ["accountId"],
+    },
+    retryCount: 3,
+    retryDelaySeconds: 2,
+    retryLogic: "FIXED" as RetryLogic,
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Tool 4: Default retry behaviour (no retry params set).
+//
+// Omitting retry params uses the SDK defaults:
+//   retryCount=2, retryDelaySeconds=2, retryLogic="LINEAR_BACKOFF"
+// ---------------------------------------------------------------------------
+const getExchangeRate = tool(
+  async (args: { fromCurrency: string; toCurrency: string }) => {
+    const rates: Record<string, number> = {
+      "USD-EUR": 0.92,
+      "USD-GBP": 0.79,
+      "USD-JPY": 154.3,
+      "EUR-USD": 1.09,
+    };
+    const key = `null-null`;
+    const rate = rates[key] ?? 1.0;
+    return {
+      from: args.fromCurrency.toUpperCase(),
+      to: args.toCurrency.toUpperCase(),
+      rate,
+    };
+  },
+  {
+    name: "get_exchange_rate",
+    description:
+      "Get the current exchange rate between two currencies. " +
+      "Uses default retry settings (retryCount=2, LINEAR_BACKOFF). " +
+      "Suitable for most tools that don't have special retry requirements.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        fromCurrency: { type: "string", description: "Source currency code (e.g. USD)." },
+        toCurrency: { type: "string", description: "Target currency code (e.g. EUR)." },
+      },
+      required: ["fromCurrency", "toCurrency"],
+    },
+    // No retry params — uses SDK defaults
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Agent — uses all four tools with different retry profiles
+// ---------------------------------------------------------------------------
+const agent = new Agent({
+  name: "financial_assistant_retry_demo",
+  model: llmModel,
+  tools: [fetchMarketData, processPayment, getAccountBalance, getExchangeRate],
+  instructions:
+    "You are a financial assistant. Help users with stock prices, account balances, " +
+    "currency conversions, and payment processing. " +
+    "Always confirm payment details with the user before processing.",
+});
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+console.log("=== Tool Retry Configuration Demo ===\n");
+console.log("Retry profiles:");
+console.log("  fetchMarketData   → retryCount=5, retryDelaySeconds=3, EXPONENTIAL_BACKOFF");
+console.log("  processPayment    → retryCount=0  (no retries — idempotency critical)");
+console.log("  getAccountBalance → retryCount=3, retryDelaySeconds=2, FIXED");
+console.log("  getExchangeRate   → defaults       (retryCount=2, LINEAR_BACKOFF)\n");
+
+const runtime = new AgentRuntime();
+const result = await runtime.run(
+  agent,
+  "What is the current price of AAPL stock? " +
+    "Also, what is the USD to EUR exchange rate? " +
+    "And what is the balance on account ACC-001?",
+);
+result.printResult();
+await runtime.shutdown();

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -9,6 +9,7 @@ export type {
   ToolType,
   FrameworkId,
   GuardrailType,
+  RetryLogic,
   TokenUsage,
   ToolContext,
   GuardrailResult,

--- a/sdk/typescript/src/serializer.ts
+++ b/sdk/typescript/src/serializer.ts
@@ -289,6 +289,21 @@ export class AgentConfigSerializer {
       config.config = toolDef.config;
     }
 
+    // Retry configuration — merge into config dict (matches Python SDK wire format)
+    if (
+      toolDef.retryCount !== undefined ||
+      toolDef.retryDelaySeconds !== undefined ||
+      toolDef.retryLogic !== undefined
+    ) {
+      const existingConfig = (config.config as Record<string, unknown>) ?? {};
+      const retryConfig: Record<string, unknown> = {};
+      if (toolDef.retryCount !== undefined) retryConfig.retryCount = toolDef.retryCount;
+      if (toolDef.retryDelaySeconds !== undefined)
+        retryConfig.retryDelaySeconds = toolDef.retryDelaySeconds;
+      if (toolDef.retryLogic !== undefined) retryConfig.retryLogic = toolDef.retryLogic;
+      config.config = { ...existingConfig, ...retryConfig };
+    }
+
     return omitNulls(config);
   }
 

--- a/sdk/typescript/src/serializer.ts
+++ b/sdk/typescript/src/serializer.ts
@@ -289,6 +289,16 @@ export class AgentConfigSerializer {
       config.config = toolDef.config;
     }
 
+    // Credentials (plain string names) — merge into config dict (matches Python SDK wire format)
+    // CredentialFile objects are passed through as-is on the top-level credentials field.
+    const stringCredentials = toolDef.credentials?.filter(
+      (c): c is string => typeof c === "string",
+    );
+    if (stringCredentials && stringCredentials.length > 0) {
+      const existingConfig = (config.config as Record<string, unknown>) ?? {};
+      config.config = { ...existingConfig, credentials: stringCredentials };
+    }
+
     // Retry configuration — merge into config dict (matches Python SDK wire format)
     if (
       toolDef.retryCount !== undefined ||

--- a/sdk/typescript/src/tool.ts
+++ b/sdk/typescript/src/tool.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import { isAbsolute, join } from "node:path";
-import type { ToolDef, ToolType, ToolContext, CredentialFile } from "./types.js";
+import type { ToolDef, ToolType, ToolContext, CredentialFile, RetryLogic } from "./types.js";
 import { ConfigurationError } from "./errors.js";
 
 // `import.meta.url` survives tsup's CJS build on Node 25 and breaks `require()`.
@@ -88,6 +88,12 @@ export interface ToolOptions {
   isolated?: boolean;
   credentials?: (string | CredentialFile)[];
   guardrails?: unknown[];
+  /** Number of retry attempts on failure. `undefined` → default (2). `0` = no retries. */
+  retryCount?: number;
+  /** Seconds between retries. `undefined` → default (2). */
+  retryDelaySeconds?: number;
+  /** Backoff strategy. `undefined` → `"LINEAR_BACKOFF"`. */
+  retryLogic?: RetryLogic;
 }
 
 /**
@@ -123,6 +129,9 @@ export function tool<TInput = unknown, TOutput = unknown>(
       credentials: options.credentials,
     }),
     ...(options.guardrails !== undefined && { guardrails: options.guardrails }),
+    ...(options.retryCount !== undefined && { retryCount: options.retryCount }),
+    ...(options.retryDelaySeconds !== undefined && { retryDelaySeconds: options.retryDelaySeconds }),
+    ...(options.retryLogic !== undefined && { retryLogic: options.retryLogic }),
   };
 
   // Create the wrapper function
@@ -256,6 +265,11 @@ export function getToolDef(obj: unknown): ToolDef {
       ...(raw.config !== undefined && {
         config: raw.config as Record<string, unknown>,
       }),
+      ...(raw.retryCount !== undefined && { retryCount: raw.retryCount as number }),
+      ...(raw.retryDelaySeconds !== undefined && {
+        retryDelaySeconds: raw.retryDelaySeconds as number,
+      }),
+      ...(raw.retryLogic !== undefined && { retryLogic: raw.retryLogic as RetryLogic }),
     };
   }
 
@@ -807,6 +821,12 @@ interface ToolDecoratorOptions {
   isolated?: boolean;
   credentials?: (string | CredentialFile)[];
   guardrails?: unknown[];
+  /** Number of retry attempts on failure. `undefined` → default (2). `0` = no retries. */
+  retryCount?: number;
+  /** Seconds between retries. `undefined` → default (2). */
+  retryDelaySeconds?: number;
+  /** Backoff strategy. `undefined` → `"LINEAR_BACKOFF"`. */
+  retryLogic?: RetryLogic;
 }
 
 /**
@@ -874,6 +894,9 @@ export function toolsFrom(instance: object): ToolFunction<unknown, unknown>[] {
       isolated: metadata.isolated,
       credentials: metadata.credentials,
       guardrails: metadata.guardrails,
+      retryCount: metadata.retryCount,
+      retryDelaySeconds: metadata.retryDelaySeconds,
+      retryLogic: metadata.retryLogic,
     });
 
     tools.push(wrapped);

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -84,6 +84,15 @@ export interface GuardrailDef {
 }
 
 /**
+ * Retry backoff strategy for Conductor TaskDef.
+ *
+ * FIXED: constant delay of `retryDelaySeconds` between every retry.
+ * LINEAR_BACKOFF: delay grows linearly (`retryDelaySeconds × attempt`). Default.
+ * EXPONENTIAL_BACKOFF: delay doubles each attempt (`retryDelaySeconds × 2^attempt`).
+ */
+export type RetryLogic = "FIXED" | "LINEAR_BACKOFF" | "EXPONENTIAL_BACKOFF";
+
+/**
  * Tool execution type determining where/how the tool runs.
  */
 export type ToolType =
@@ -263,6 +272,12 @@ export interface ToolDef {
   credentials?: (string | CredentialFile)[];
   guardrails?: unknown[];
   config?: Record<string, unknown>;
+  /** Number of retry attempts on failure. `undefined` → default (2). `0` = no retries. */
+  retryCount?: number;
+  /** Seconds between retries. `undefined` → default (2). */
+  retryDelaySeconds?: number;
+  /** Backoff strategy. `undefined` → `"LINEAR_BACKOFF"`. */
+  retryLogic?: RetryLogic;
 }
 
 // ── Agent result ─────────────────────────────────────────

--- a/sdk/typescript/tests/unit/tool-retry-credentials.test.ts
+++ b/sdk/typescript/tests/unit/tool-retry-credentials.test.ts
@@ -1,0 +1,226 @@
+// Copyright (c) 2025 Agentspan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+/**
+ * Unit tests for credentials serialization in serializeTool() — PR #159 / Issue #150.
+ *
+ * Covers:
+ *   - String credentials merged into config.config.credentials
+ *   - CredentialFile objects excluded from config.config.credentials
+ *   - Coexistence of credentials + retry fields (non-destructive spread-merge)
+ *   - httpTool credentials path
+ *
+ * Pure unit tests — no server, no mocks, no network.
+ */
+
+import { describe, it, expect } from "vitest";
+import { tool, getToolDef, httpTool } from "../../src/tool.js";
+import { AgentConfigSerializer } from "../../src/serializer.js";
+import type { RetryLogic } from "../../src/types.js";
+import type { CredentialFile } from "../../src/types.js";
+
+const serializer = new AgentConfigSerializer();
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeWorkerTool(opts: {
+  credentials?: (string | CredentialFile)[];
+  retryCount?: number;
+  retryDelaySeconds?: number;
+  retryLogic?: RetryLogic;
+}) {
+  return tool(async (_args: { x: string }) => "ok", {
+    name: "my_tool",
+    description: "A test tool.",
+    inputSchema: { type: "object", properties: { x: { type: "string" } } },
+    ...(opts.credentials !== undefined && { credentials: opts.credentials }),
+    ...(opts.retryCount !== undefined && { retryCount: opts.retryCount }),
+    ...(opts.retryDelaySeconds !== undefined && {
+      retryDelaySeconds: opts.retryDelaySeconds,
+    }),
+    ...(opts.retryLogic !== undefined && { retryLogic: opts.retryLogic }),
+  });
+}
+
+// ── AgentConfigSerializer.serializeTool() — credentials in config ─────────────
+
+describe("AgentConfigSerializer.serializeTool() — credentials in config", () => {
+  it("emits credentials into config.config for a worker tool", () => {
+    const t = makeWorkerTool({ credentials: ["MY_KEY"] });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    expect(result.config).toBeDefined();
+    const config = result.config as Record<string, unknown>;
+    expect(config.credentials).toEqual(["MY_KEY"]);
+  });
+
+  it("emits multiple credentials into config.config", () => {
+    const t = makeWorkerTool({ credentials: ["KEY_A", "KEY_B"] });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.credentials).toEqual(["KEY_A", "KEY_B"]);
+  });
+
+  it("omits credentials key from config when credentials array is empty", () => {
+    const t = makeWorkerTool({ credentials: [] });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = (result.config ?? {}) as Record<string, unknown>;
+    expect(config).not.toHaveProperty("credentials");
+  });
+
+  it("omits credentials key from config when credentials is undefined", () => {
+    const t = makeWorkerTool({});
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = (result.config ?? {}) as Record<string, unknown>;
+    expect(config).not.toHaveProperty("credentials");
+  });
+
+  it("excludes CredentialFile objects from config.credentials", () => {
+    const credFile: CredentialFile = {
+      envVar: "KUBECONFIG",
+      relativePath: ".kube/config",
+    };
+    const t = makeWorkerTool({ credentials: [credFile] });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = (result.config ?? {}) as Record<string, unknown>;
+    expect(config).not.toHaveProperty("credentials");
+  });
+
+  it("includes only string credentials when mixed with CredentialFile", () => {
+    const credFile: CredentialFile = { envVar: "KUBECONFIG" };
+    const t = makeWorkerTool({ credentials: ["API_KEY", credFile] });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.credentials).toEqual(["API_KEY"]);
+  });
+
+  it("credentials-only tool has no retry keys in config", () => {
+    const t = makeWorkerTool({ credentials: ["MY_KEY"] });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.credentials).toEqual(["MY_KEY"]);
+    expect(config).not.toHaveProperty("retryCount");
+    expect(config).not.toHaveProperty("retryDelaySeconds");
+    expect(config).not.toHaveProperty("retryLogic");
+  });
+});
+
+// ── AgentConfigSerializer.serializeTool() — retry + credentials coexistence ───
+
+describe("AgentConfigSerializer.serializeTool() — retry fields + credentials coexistence", () => {
+  it("credentials do not overwrite pre-existing config keys", () => {
+    const t = httpTool({
+      name: "api_call",
+      description: "Call API",
+      url: "https://api.example.com",
+      method: "POST",
+      credentials: ["API_KEY"],
+    });
+    const result = serializer.serializeTool(t);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.url).toBe("https://api.example.com");
+    expect(config.method).toBe("POST");
+    expect(config.credentials).toEqual(["API_KEY"]);
+  });
+
+  it("retry fields do not overwrite credentials in config", () => {
+    const t = makeWorkerTool({ credentials: ["K"], retryCount: 3 });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.credentials).toEqual(["K"]);
+    expect(config.retryCount).toBe(3);
+  });
+
+  it("all three retry fields plus credentials all coexist", () => {
+    const t = makeWorkerTool({
+      credentials: ["X", "Y"],
+      retryCount: 5,
+      retryDelaySeconds: 10,
+      retryLogic: "EXPONENTIAL_BACKOFF",
+    });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.credentials).toEqual(["X", "Y"]);
+    expect(config.retryCount).toBe(5);
+    expect(config.retryDelaySeconds).toBe(10);
+    expect(config.retryLogic).toBe("EXPONENTIAL_BACKOFF");
+  });
+
+  it("retryCount=0 coexists with credentials", () => {
+    const t = makeWorkerTool({ credentials: ["K"], retryCount: 0 });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    // retryCount=0 must NOT be skipped as falsy
+    expect(config.retryCount).toBe(0);
+    expect(config.retryCount).not.toBeUndefined();
+    expect(config.credentials).toEqual(["K"]);
+  });
+
+  it("coexists with credentials in config (retryCount + retryLogic + credentials)", () => {
+    const t = makeWorkerTool({
+      retryCount: 2,
+      retryLogic: "LINEAR_BACKOFF",
+      credentials: ["MY_API_KEY"],
+    });
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.retryCount).toBe(2);
+    expect(config.retryLogic).toBe("LINEAR_BACKOFF");
+    expect(config.credentials).toEqual(["MY_API_KEY"]);
+  });
+});
+
+// ── AgentConfigSerializer.serializeTool() — httpTool credentials ──────────────
+
+describe("AgentConfigSerializer.serializeTool() — httpTool credentials", () => {
+  it("httpTool with credentials emits credentials inside config", () => {
+    const t = httpTool({
+      name: "api_call",
+      description: "Call API",
+      url: "https://api.example.com",
+      method: "GET",
+      credentials: ["API_KEY"],
+    });
+    const result = serializer.serializeTool(t);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.credentials).toEqual(["API_KEY"]);
+    // Pre-existing config keys must survive
+    expect(config.url).toBe("https://api.example.com");
+  });
+
+  it("httpTool without credentials has no credentials key in config", () => {
+    const t = httpTool({
+      name: "api_call",
+      description: "Call API",
+      url: "https://api.example.com",
+      method: "GET",
+    });
+    const result = serializer.serializeTool(t);
+
+    const config = (result.config ?? {}) as Record<string, unknown>;
+    expect(config).not.toHaveProperty("credentials");
+  });
+});

--- a/sdk/typescript/tests/unit/tool-retry.test.ts
+++ b/sdk/typescript/tests/unit/tool-retry.test.ts
@@ -1,0 +1,293 @@
+// Copyright (c) 2025 Agentspan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+/**
+ * Unit tests for retry configuration on the tool() function (issue #150).
+ *
+ * These are pure unit tests — no server, no mocks, just verifying the
+ * ToolDef wiring and serializer output.
+ */
+
+import { describe, it, expect } from "vitest";
+import { tool, getToolDef, Tool, toolsFrom } from "../../src/tool.js";
+import { AgentConfigSerializer } from "../../src/serializer.js";
+import type { RetryLogic } from "../../src/types.js";
+
+const serializer = new AgentConfigSerializer();
+
+// ── tool() decorator tests ────────────────────────────────────────────────────
+
+describe("tool() — retry fields", () => {
+  it("leaves retryCount/retryDelaySeconds/retryLogic undefined when not set", () => {
+    const myTool = tool(async (_args: { x: string }) => "ok", {
+      name: "my_tool",
+      description: "A simple tool.",
+      inputSchema: { type: "object", properties: { x: { type: "string" } } },
+    });
+
+    const def = getToolDef(myTool);
+    expect(def.retryCount).toBeUndefined();
+    expect(def.retryDelaySeconds).toBeUndefined();
+    expect(def.retryLogic).toBeUndefined();
+  });
+
+  it("stores retryCount on ToolDef", () => {
+    const myTool = tool(async (_args: { x: string }) => "ok", {
+      name: "my_tool",
+      description: "A simple tool.",
+      inputSchema: { type: "object", properties: { x: { type: "string" } } },
+      retryCount: 10,
+    });
+
+    const def = getToolDef(myTool);
+    expect(def.retryCount).toBe(10);
+    expect(def.retryDelaySeconds).toBeUndefined();
+    expect(def.retryLogic).toBeUndefined();
+  });
+
+  it("stores retryDelaySeconds on ToolDef", () => {
+    const myTool = tool(async (_args: { x: string }) => "ok", {
+      name: "my_tool",
+      description: "A simple tool.",
+      inputSchema: { type: "object", properties: { x: { type: "string" } } },
+      retryDelaySeconds: 5,
+    });
+
+    const def = getToolDef(myTool);
+    expect(def.retryCount).toBeUndefined();
+    expect(def.retryDelaySeconds).toBe(5);
+    expect(def.retryLogic).toBeUndefined();
+  });
+
+  it("stores retryLogic on ToolDef", () => {
+    const myTool = tool(async (_args: { x: string }) => "ok", {
+      name: "my_tool",
+      description: "A simple tool.",
+      inputSchema: { type: "object", properties: { x: { type: "string" } } },
+      retryLogic: "EXPONENTIAL_BACKOFF",
+    });
+
+    const def = getToolDef(myTool);
+    expect(def.retryCount).toBeUndefined();
+    expect(def.retryDelaySeconds).toBeUndefined();
+    expect(def.retryLogic).toBe("EXPONENTIAL_BACKOFF");
+  });
+
+  it("stores retryCount=0 (not undefined — zero means no retries)", () => {
+    const myTool = tool(async (_args: { x: string }) => "ok", {
+      name: "my_tool",
+      description: "A simple tool.",
+      inputSchema: { type: "object", properties: { x: { type: "string" } } },
+      retryCount: 0,
+    });
+
+    const def = getToolDef(myTool);
+    expect(def.retryCount).toBe(0);
+    expect(def.retryCount).not.toBeUndefined();
+  });
+
+  it("stores all three retry params when all are set", () => {
+    const myTool = tool(async (_args: { x: string }) => "ok", {
+      name: "my_tool",
+      description: "A simple tool.",
+      inputSchema: { type: "object", properties: { x: { type: "string" } } },
+      retryCount: 5,
+      retryDelaySeconds: 10,
+      retryLogic: "FIXED",
+    });
+
+    const def = getToolDef(myTool);
+    expect(def.retryCount).toBe(5);
+    expect(def.retryDelaySeconds).toBe(10);
+    expect(def.retryLogic).toBe("FIXED");
+  });
+
+  it("accepts all three RetryLogic values", () => {
+    const values: RetryLogic[] = ["FIXED", "LINEAR_BACKOFF", "EXPONENTIAL_BACKOFF"];
+    for (const logic of values) {
+      const myTool = tool(async (_args: { x: string }) => "ok", {
+        name: "my_tool",
+        description: "A simple tool.",
+        inputSchema: { type: "object", properties: { x: { type: "string" } } },
+        retryLogic: logic,
+      });
+      expect(getToolDef(myTool).retryLogic).toBe(logic);
+    }
+  });
+});
+
+// ── @Tool class decorator tests ───────────────────────────────────────────────
+
+describe("@Tool decorator — retry fields", () => {
+  it("passes retry fields through toolsFrom()", () => {
+    class MyTools {
+      @Tool({
+        name: "my_tool",
+        description: "A tool with retry config.",
+        inputSchema: { type: "object", properties: { x: { type: "string" } } },
+        retryCount: 3,
+        retryDelaySeconds: 7,
+        retryLogic: "LINEAR_BACKOFF",
+      })
+      async myMethod(_args: { x: string }): Promise<string> {
+        return "ok";
+      }
+    }
+
+    const instance = new MyTools();
+    const tools = toolsFrom(instance);
+    expect(tools).toHaveLength(1);
+
+    const def = getToolDef(tools[0]);
+    expect(def.retryCount).toBe(3);
+    expect(def.retryDelaySeconds).toBe(7);
+    expect(def.retryLogic).toBe("LINEAR_BACKOFF");
+  });
+
+  it("leaves retry fields undefined when not set in @Tool", () => {
+    class MyTools {
+      @Tool({
+        name: "my_tool",
+        description: "A tool without retry config.",
+        inputSchema: { type: "object", properties: {} },
+      })
+      async myMethod(_args: unknown): Promise<string> {
+        return "ok";
+      }
+    }
+
+    const instance = new MyTools();
+    const tools = toolsFrom(instance);
+    const def = getToolDef(tools[0]);
+    expect(def.retryCount).toBeUndefined();
+    expect(def.retryDelaySeconds).toBeUndefined();
+    expect(def.retryLogic).toBeUndefined();
+  });
+});
+
+// ── getToolDef() raw ToolDef passthrough tests ────────────────────────────────
+
+describe("getToolDef() — raw ToolDef passthrough", () => {
+  it("passes retry fields through from a raw ToolDef object", () => {
+    const raw = {
+      name: "my_tool",
+      description: "A tool.",
+      inputSchema: { type: "object", properties: {} },
+      toolType: "worker" as const,
+      retryCount: 4,
+      retryDelaySeconds: 8,
+      retryLogic: "EXPONENTIAL_BACKOFF" as RetryLogic,
+    };
+
+    const def = getToolDef(raw);
+    expect(def.retryCount).toBe(4);
+    expect(def.retryDelaySeconds).toBe(8);
+    expect(def.retryLogic).toBe("EXPONENTIAL_BACKOFF");
+  });
+
+  it("leaves retry fields undefined when absent from raw ToolDef", () => {
+    const raw = {
+      name: "my_tool",
+      description: "A tool.",
+      inputSchema: { type: "object", properties: {} },
+    };
+
+    const def = getToolDef(raw);
+    expect(def.retryCount).toBeUndefined();
+    expect(def.retryDelaySeconds).toBeUndefined();
+    expect(def.retryLogic).toBeUndefined();
+  });
+});
+
+// ── AgentConfigSerializer.serializeTool() tests ───────────────────────────────
+
+describe("AgentConfigSerializer.serializeTool() — retry fields", () => {
+  function makeWorkerTool(
+    retryCount?: number,
+    retryDelaySeconds?: number,
+    retryLogic?: RetryLogic,
+    credentials?: string[],
+  ) {
+    return tool(async (_args: { x: string }) => "ok", {
+      name: "my_tool",
+      description: "A test tool.",
+      inputSchema: { type: "object", properties: { x: { type: "string" } } },
+      ...(retryCount !== undefined && { retryCount }),
+      ...(retryDelaySeconds !== undefined && { retryDelaySeconds }),
+      ...(retryLogic !== undefined && { retryLogic }),
+      ...(credentials !== undefined && { credentials }),
+    });
+  }
+
+  it("emits retryCount/retryDelaySeconds/retryLogic in config when all are set", () => {
+    const t = makeWorkerTool(5, 10, "FIXED");
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    expect(result.config).toBeDefined();
+    const config = result.config as Record<string, unknown>;
+    expect(config.retryCount).toBe(5);
+    expect(config.retryDelaySeconds).toBe(10);
+    expect(config.retryLogic).toBe("FIXED");
+  });
+
+  it("omits retry keys from config when all retry fields are undefined", () => {
+    const t = makeWorkerTool();
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = (result.config ?? {}) as Record<string, unknown>;
+    expect(config).not.toHaveProperty("retryCount");
+    expect(config).not.toHaveProperty("retryDelaySeconds");
+    expect(config).not.toHaveProperty("retryLogic");
+  });
+
+  it("emits only retryCount when only retryCount is set", () => {
+    const t = makeWorkerTool(3);
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.retryCount).toBe(3);
+    expect(config).not.toHaveProperty("retryDelaySeconds");
+    expect(config).not.toHaveProperty("retryLogic");
+  });
+
+  it("includes retryCount=0 in config (not skipped as falsy)", () => {
+    const t = makeWorkerTool(0);
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.retryCount).toBe(0);
+  });
+
+  it("coexists with credentials in config", () => {
+    const t = makeWorkerTool(2, undefined, "LINEAR_BACKOFF", ["MY_API_KEY"]);
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.retryCount).toBe(2);
+    expect(config.retryLogic).toBe("LINEAR_BACKOFF");
+    expect(config.credentials).toEqual(["MY_API_KEY"]);
+  });
+
+  it("emits retryLogic=LINEAR_BACKOFF correctly", () => {
+    const t = makeWorkerTool(undefined, undefined, "LINEAR_BACKOFF");
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.retryLogic).toBe("LINEAR_BACKOFF");
+  });
+
+  it("emits retryLogic=EXPONENTIAL_BACKOFF correctly", () => {
+    const t = makeWorkerTool(undefined, undefined, "EXPONENTIAL_BACKOFF");
+    const def = getToolDef(t);
+    const result = serializer.serializeTool(def);
+
+    const config = result.config as Record<string, unknown>;
+    expect(config.retryLogic).toBe("EXPONENTIAL_BACKOFF");
+  });
+});

--- a/sdk/typescript/yarn.lock
+++ b/sdk/typescript/yarn.lock
@@ -2261,7 +2261,7 @@ eventsource@^3.0.2:
   dependencies:
     eventsource-parser "^3.0.1"
 
-"examples@file:/private/var/folders/bb/hb9xgrwj73x5_19xxrb8c14m0000gn/T/agentspan-fix-897f1d00c144/sdk/typescript/examples":
+"examples@file:/private/var/folders/bb/hb9xgrwj73x5_19xxrb8c14m0000gn/T/agentspan-fix-4903dca01227/sdk/typescript/examples":
   resolved "file:examples"
   dependencies:
     "@agentspan-ai/sdk" "file:.."

--- a/sdk/typescript/yarn.lock
+++ b/sdk/typescript/yarn.lock
@@ -2261,7 +2261,7 @@ eventsource@^3.0.2:
   dependencies:
     eventsource-parser "^3.0.1"
 
-"examples@file:/Users/viren/workspace/github/agentspan-dev/branches/agentspan-branch/sdk/typescript/examples":
+"examples@file:/private/var/folders/bb/hb9xgrwj73x5_19xxrb8c14m0000gn/T/agentspan-fix-897f1d00c144/sdk/typescript/examples":
   resolved "file:examples"
   dependencies:
     "@agentspan-ai/sdk" "file:.."


### PR DESCRIPTION
Fixes #150

## Summary

Adds `retry_count`, `retry_delay_seconds`, and `retry_logic` as optional parameters on the `@tool` decorator, allowing users to configure per-tool retry behaviour instead of relying on the hardcoded defaults in `_default_task_def()`. Values are passed through to the Conductor `TaskDef` at registration time, following the same retry policy options as the upstream Conductor `TaskDef` spec.

Sensible defaults are preserved (`retry_count=2`, `retry_delay_seconds=2`, `retry_logic="LINEAR_BACKOFF"`) so existing tools are unaffected.

## Changes

- **`sdk/python/src/agentspan/agents/tool.py`** — Added `retry_count`, `retry_delay_seconds`, and `retry_logic` fields to the `ToolDef` dataclass and to the `@tool` decorator signature; values are forwarded to `ToolDef` inside `_wrap()`.
- **`sdk/python/src/agentspan/agents/runtime/runtime.py`** — Updated `_default_task_def()` to accept optional `retry_count`, `retry_delay_seconds`, and `retry_logic` kwargs; falls back to existing defaults when not provided.
- **`sdk/python/src/agentspan/agents/runtime/tool_registry.py`** — Updated `register_tool_workers()` to pass per-tool retry config from `ToolDef` to `_default_task_def()`.
- **`sdk/python/src/agentspan/agents/config_serializer.py`** — Updated `_serialize_tool()` to include `retryCount`, `retryDelaySeconds`, and `retryLogic` in the serialised config dict when set on the `ToolDef`.
- **`sdk/python/tests/unit/test_tool_retry.py`** — New file with 17 unit tests covering all retry config scenarios (decorator, `_default_task_def`, serialiser).
- **`docs/design/issue-150-tool-retry-configuration.md`** — Design doc covering motivation, full API surface, data-flow diagram, usage examples, and backward-compatibility guarantees.
- **`docs/python-sdk/api-reference.md`** — Updated `@tool` decorator and `ToolDef` sections to document the three new parameters with examples.
- **`sdk/python/examples/34_tool_retry_config.py`** — Runnable example demonstrating all retry profiles (exponential backoff, no retries, fixed delay, defaults).
- **`sdk/python/examples/README.md`** — Registered the new example in the Tool Calling table and Feature Index.

## Testing

17 new unit tests added in `sdk/python/tests/unit/test_tool_retry.py` covering:
- Decorator parameter pass-through to `ToolDef`
- `_default_task_def()` with and without overrides
- Config serialiser output for all three fields
- Edge cases: `retry_count=0` (disable retries), all three `retry_logic` values (`FIXED`, `LINEAR_BACKOFF`, `EXPONENTIAL_BACKOFF`)

<details>
<summary>Change Context (machine-readable)</summary>

```json
{
  "issue_number": 150,
  "issue_title": "Allow retry configuration on @tool decorator",
  "issue_type": "feature",
  "changed_files": [
    "sdk/python/src/agentspan/agents/tool.py",
    "sdk/python/src/agentspan/agents/runtime/runtime.py",
    "sdk/python/src/agentspan/agents/runtime/tool_registry.py",
    "sdk/python/src/agentspan/agents/config_serializer.py",
    "sdk/python/tests/unit/test_tool_retry.py",
    "docs/design/issue-150-tool-retry-configuration.md",
    "docs/python-sdk/api-reference.md",
    "sdk/python/examples/34_tool_retry_config.py",
    "sdk/python/examples/README.md"
  ],
  "branch": "fix/issue-150",
  "commit": "89cfb8fd"
}
```

</details>