### PR TITLE
feat: allow retry_count and retry_delay_seconds on @tool decorator (#150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ sdk/java/target/
 docs/superpowers/
 .contextbook/
 sdk/python/agentspan
+.contextbook/

--- a/docs/plan/issue-150-plan.md
+++ b/docs/plan/issue-150-plan.md
@@ -1,0 +1,129 @@
+# Issue #150 — Allow retry configuration on @tool decorator
+
+## Root Cause
+
+The `@tool` decorator in `sdk/python/src/agentspan/agents/tool.py` does not accept `retry_count` or `retry_delay_seconds` parameters. When tools are registered as Conductor workers in `sdk/python/src/agentspan/agents/runtime/tool_registry.py` (line 71), the call `_default_task_def(td.name)` always produces a `TaskDef` with hardcoded `retry_count=2` and `retry_delay_seconds=2` (defined in `runtime.py` lines 44–65). There is no mechanism to pass user-specified retry values from the `ToolDef` through to `_default_task_def`.
+
+Note: `agent_tool()` already supports `retry_count` and `retry_delay_seconds` by storing them in `ToolDef.config` — but those are forwarded to the *server-side compiler*, not to the Conductor `TaskDef`. For `@tool` (worker-type tools), the retry config must be applied to the `TaskDef` at worker-registration time.
+
+## Files to Change
+
+### 1. `sdk/python/src/agentspan/agents/tool.py`
+
+**What:** Add `retry_count` and `retry_delay_seconds` parameters to the `@tool` decorator and store them on the `ToolDef`.
+
+- **`ToolDef` dataclass (line 52–82):** Add two new optional fields:
+  ```python
+  retry_count: Optional[int] = None
+  retry_delay_seconds: Optional[int] = None
+  ```
+  Using `None` means "use the default" (currently 2 and 2). This preserves backward compatibility.
+
+- **`@overload` signatures (lines 92–103):** Add `retry_count: Optional[int] = None` and `retry_delay_seconds: Optional[int] = None` to both overload signatures.
+
+- **`tool()` function signature (lines 106–117):** Add `retry_count: Optional[int] = None` and `retry_delay_seconds: Optional[int] = None` as keyword-only parameters.
+
+- **`tool()` docstring (lines 118–140):** Add documentation for the new parameters:
+  ```
+  retry_count: Number of retries on failure. Defaults to 2 if not specified.
+      Set to 0 to disable retries entirely.
+  retry_delay_seconds: Seconds between retries (linear backoff). Defaults to 2
+      if not specified.
+  ```
+
+- **`_wrap()` inner function (lines 150–163):** Pass the new parameters to the `ToolDef` constructor:
+  ```python
+  tool_def = ToolDef(
+      ...
+      retry_count=retry_count,
+      retry_delay_seconds=retry_delay_seconds,
+  )
+  ```
+
+### 2. `sdk/python/src/agentspan/agents/runtime/runtime.py`
+
+**What:** Update `_default_task_def` to accept optional `retry_count` and `retry_delay_seconds` parameters.
+
+- **`_default_task_def()` function (lines 44–65):** Change signature to:
+  ```python
+  def _default_task_def(
+      name: str,
+      *,
+      response_timeout_seconds: int = 10,
+      retry_count: Optional[int] = None,
+      retry_delay_seconds: Optional[int] = None,
+  ) -> Any:
+  ```
+  Inside the function body, use the provided values or fall back to the existing defaults:
+  ```python
+  effective_retry_count = retry_count if retry_count is not None else 2
+  effective_retry_delay = retry_delay_seconds if retry_delay_seconds is not None else 2
+  ```
+  Then use `effective_retry_count` and `effective_retry_delay` when constructing the `TaskDef` (replacing the current hardcoded `2` values).
+
+### 3. `sdk/python/src/agentspan/agents/runtime/tool_registry.py`
+
+**What:** Forward `ToolDef.retry_count` and `ToolDef.retry_delay_seconds` to `_default_task_def` when registering worker tools.
+
+- **`register_tools()` function, line 71:** Change:
+  ```python
+  task_def=_default_task_def(td.name),
+  ```
+  to:
+  ```python
+  task_def=_default_task_def(
+      td.name,
+      retry_count=td.retry_count,
+      retry_delay_seconds=td.retry_delay_seconds,
+  ),
+  ```
+
+### 4. (No change needed) Other call sites of `_default_task_def`
+
+The other call sites in `runtime.py` (lines 767, 2998, 3113) are for framework workers, graph workers, and skill workers — not user `@tool` functions. These should continue using the defaults (passing no retry overrides), which is exactly what happens since the new parameters default to `None`.
+
+## Changes Summary
+
+| File | Function/Class | Change |
+|------|---------------|--------|
+| `tool.py` | `ToolDef` | Add `retry_count: Optional[int] = None`, `retry_delay_seconds: Optional[int] = None` fields |
+| `tool.py` | `tool()` + overloads | Add `retry_count`, `retry_delay_seconds` keyword params; pass to `ToolDef` |
+| `runtime.py` | `_default_task_def()` | Accept optional `retry_count`, `retry_delay_seconds`; use them or fall back to 2 |
+| `tool_registry.py` | `register_tools()` | Forward `td.retry_count`, `td.retry_delay_seconds` to `_default_task_def()` |
+
+## Test Strategy
+
+### File: `sdk/python/tests/unit/test_tool.py`
+
+Add a new test class or extend existing tests with the following cases:
+
+1. **`test_tool_retry_count_stored_on_tool_def`** — Decorate a function with `@tool(retry_count=5)` and assert `func._tool_def.retry_count == 5`.
+
+2. **`test_tool_retry_delay_stored_on_tool_def`** — Decorate with `@tool(retry_delay_seconds=10)` and assert `func._tool_def.retry_delay_seconds == 10`.
+
+3. **`test_tool_retry_both_params`** — Decorate with `@tool(retry_count=0, retry_delay_seconds=0)` and assert both are stored correctly.
+
+4. **`test_tool_retry_defaults_to_none`** — Bare `@tool` should have `retry_count=None` and `retry_delay_seconds=None` on the `ToolDef`.
+
+5. **`test_default_task_def_uses_defaults`** — Call `_default_task_def("test")` with no retry args and assert the TaskDef has `retry_count=2` and `retry_delay_seconds=2`.
+
+6. **`test_default_task_def_custom_retry`** — Call `_default_task_def("test", retry_count=5, retry_delay_seconds=10)` and assert the TaskDef reflects those values.
+
+7. **`test_default_task_def_zero_retry`** — Call `_default_task_def("test", retry_count=0)` and assert `retry_count=0` (retries disabled).
+
+8. **`test_register_tools_forwards_retry_config`** — Mock `worker_task` and `_default_task_def`, create a `ToolDef` with `retry_count=3, retry_delay_seconds=5`, call `register_tools`, and verify `_default_task_def` was called with those values.
+
+### Validation approach (per CLAUDE.md):
+- Write each test first, then verify it fails before the implementation is applied, confirming the test is actually testing the right thing.
+
+## Risks and Edge Cases
+
+1. **Negative values:** Users could pass `retry_count=-1`. We should either validate (raise `ValueError` for negative values) or let Conductor handle it. **Recommendation:** Add a simple validation in `_default_task_def` — raise `ValueError` if `retry_count < 0` or `retry_delay_seconds < 0`.
+
+2. **Type safety:** Users could pass floats or strings. The type hints (`Optional[int]`) provide IDE guidance but no runtime enforcement. The Conductor SDK will likely reject non-int values at registration time, which is acceptable.
+
+3. **Backward compatibility:** Fully preserved — all new parameters default to `None`, and `None` maps to the existing defaults (2, 2). No existing code changes behavior.
+
+4. **`retry_logic` field:** The issue mentions `retry_logic` as a potential future addition. This plan does NOT include it to keep scope minimal. It can be added in a follow-up using the same pattern (add to `ToolDef`, forward through `_default_task_def`).
+
+5. **`agent_tool()` already has retry params:** The `agent_tool()` function (line 1059) already accepts `retry_count` and `retry_delay_seconds` but stores them in `config` dict for server-side use. The `@tool` decorator stores them as first-class `ToolDef` fields instead, because they need to be forwarded to the Conductor `TaskDef` at worker-registration time. These are two different mechanisms for two different tool types — no conflict.

--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -41,7 +41,13 @@ from agentspan.agents.runtime.http_client import AgentHttpClient, SSEUnavailable
 logger = logging.getLogger("agentspan.agents.runtime")
 
 
-def _default_task_def(name: str, *, response_timeout_seconds: int = 10) -> Any:
+def _default_task_def(
+    name: str,
+    *,
+    response_timeout_seconds: int = 10,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
+) -> Any:
     """Create a TaskDef with standard retry policy for agent worker tasks.
 
     Timeout is 0 (no timeout) — the agent configuration controls execution
@@ -51,13 +57,26 @@ def _default_task_def(name: str, *, response_timeout_seconds: int = 10) -> Any:
     within this time, Conductor marks the task as timed out and retries.
     Kept short to detect dead workers quickly; lease extension heartbeats
     (at 80% of this value) keep long-running tasks alive automatically.
+
+    retry_count: Number of retries on failure. Defaults to 2 if not specified.
+        Set to 0 to disable retries entirely. Must be >= 0.
+    retry_delay_seconds: Seconds between retries (linear backoff). Defaults
+        to 2 if not specified. Must be >= 0.
     """
+    if retry_count is not None and retry_count < 0:
+        raise ValueError(f"retry_count must be >= 0, got {retry_count}")
+    if retry_delay_seconds is not None and retry_delay_seconds < 0:
+        raise ValueError(f"retry_delay_seconds must be >= 0, got {retry_delay_seconds}")
+
     from conductor.client.http.models.task_def import TaskDef
 
+    effective_retry_count = retry_count if retry_count is not None else 2
+    effective_retry_delay = retry_delay_seconds if retry_delay_seconds is not None else 2
+
     td = TaskDef(name=name)
-    td.retry_count = 2
+    td.retry_count = effective_retry_count
     td.retry_logic = "LINEAR_BACKOFF"
-    td.retry_delay_seconds = 2
+    td.retry_delay_seconds = effective_retry_delay
     td.timeout_seconds = 0
     td.response_timeout_seconds = response_timeout_seconds
     td.timeout_policy = "RETRY"

--- a/sdk/python/src/agentspan/agents/runtime/tool_registry.py
+++ b/sdk/python/src/agentspan/agents/runtime/tool_registry.py
@@ -68,7 +68,11 @@ class ToolRegistry:
                 wrapper = make_tool_worker(td.func, td.name, guardrails=guardrails, tool_def=td)
                 worker_task(
                     task_definition_name=td.name,
-                    task_def=_default_task_def(td.name),
+                    task_def=_default_task_def(
+                        td.name,
+                        retry_count=td.retry_count,
+                        retry_delay_seconds=td.retry_delay_seconds,
+                    ),
                     register_task_def=True,
                     overwrite_task_def=True,
                     domain=domain if (agent_stateful or td.stateful) else None,

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -80,6 +80,8 @@ class ToolDef:
     isolated: bool = True
     credentials: List[Any] = field(default_factory=list)
     stateful: bool = False
+    retry_count: Optional[int] = None
+    retry_delay_seconds: Optional[int] = None
 
 
 # ── @tool decorator ─────────────────────────────────────────────────────
@@ -100,6 +102,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -114,6 +118,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Any:
     """Register a Python function as a Conductor agent tool.
 
@@ -137,6 +143,12 @@ def tool(
         hints) and description (via docstring), but **no local worker is
         started** — Conductor dispatches the task to whatever worker is polling
         for that task definition name.
+
+    Args:
+        retry_count: Number of retries on failure. Defaults to 2 if not
+            specified. Set to ``0`` to disable retries entirely.
+        retry_delay_seconds: Seconds between retries (linear backoff).
+            Defaults to 2 if not specified.
     """
 
     def _wrap(fn: F) -> F:
@@ -160,6 +172,8 @@ def tool(
             isolated=isolated,
             credentials=list(credentials) if credentials else [],
             stateful=stateful,
+            retry_count=retry_count,
+            retry_delay_seconds=retry_delay_seconds,
         )
 
         @functools.wraps(fn)

--- a/sdk/python/tests/unit/test_tool.py
+++ b/sdk/python/tests/unit/test_tool.py
@@ -844,3 +844,140 @@ class TestToolCredentialParams:
         assert td.approval_required is True
         assert td.isolated is False
         assert "KEY" in td.credentials
+
+
+class TestToolRetryConfig:
+    """Test @tool decorator retry_count and retry_delay_seconds parameters."""
+
+    def test_tool_retry_count_stored_on_tool_def(self):
+        """@tool(retry_count=5) stores retry_count on the ToolDef."""
+
+        @tool(retry_count=5)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_count == 5
+
+    def test_tool_retry_delay_stored_on_tool_def(self):
+        """@tool(retry_delay_seconds=10) stores retry_delay_seconds on the ToolDef."""
+
+        @tool(retry_delay_seconds=10)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_delay_seconds == 10
+
+    def test_tool_retry_both_params(self):
+        """@tool(retry_count=0, retry_delay_seconds=0) stores both correctly."""
+
+        @tool(retry_count=0, retry_delay_seconds=0)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_count == 0
+        assert my_tool._tool_def.retry_delay_seconds == 0
+
+    def test_tool_retry_defaults_to_none(self):
+        """Bare @tool should have retry_count=None and retry_delay_seconds=None."""
+
+        @tool
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_count is None
+        assert my_tool._tool_def.retry_delay_seconds is None
+
+    def test_default_task_def_uses_defaults(self):
+        """_default_task_def with no retry args produces retry_count=2, retry_delay_seconds=2."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        td = _default_task_def("test_task")
+        assert td.retry_count == 2
+        assert td.retry_delay_seconds == 2
+
+    def test_default_task_def_custom_retry(self):
+        """_default_task_def with custom retry args reflects those values."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        td = _default_task_def("test_task", retry_count=5, retry_delay_seconds=10)
+        assert td.retry_count == 5
+        assert td.retry_delay_seconds == 10
+
+    def test_default_task_def_zero_retry(self):
+        """_default_task_def with retry_count=0 disables retries."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        td = _default_task_def("test_task", retry_count=0)
+        assert td.retry_count == 0
+
+    def test_default_task_def_negative_retry_count_raises(self):
+        """_default_task_def raises ValueError for negative retry_count."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        with pytest.raises(ValueError, match="retry_count must be >= 0"):
+            _default_task_def("test_task", retry_count=-1)
+
+    def test_default_task_def_negative_retry_delay_raises(self):
+        """_default_task_def raises ValueError for negative retry_delay_seconds."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        with pytest.raises(ValueError, match="retry_delay_seconds must be >= 0"):
+            _default_task_def("test_task", retry_delay_seconds=-1)
+
+    def test_register_tools_forwards_retry_config(self):
+        """register_tool_workers forwards retry_count and retry_delay_seconds to _default_task_def."""
+        from unittest.mock import MagicMock, call, patch
+
+        from agentspan.agents.runtime.tool_registry import ToolRegistry
+        from agentspan.agents.tool import ToolDef
+
+        def my_func(x: str) -> str:
+            """A tool."""
+            return x
+
+        td = ToolDef(
+            name="retry_tool",
+            description="A tool with retry config",
+            func=my_func,
+            tool_type="worker",
+            retry_count=3,
+            retry_delay_seconds=5,
+        )
+
+        captured_calls = []
+
+        def fake_default_task_def(name, *, response_timeout_seconds=10, retry_count=None, retry_delay_seconds=None):
+            captured_calls.append({
+                "name": name,
+                "retry_count": retry_count,
+                "retry_delay_seconds": retry_delay_seconds,
+            })
+            # Return a minimal mock TaskDef
+            mock_td = MagicMock()
+            mock_td.retry_count = retry_count if retry_count is not None else 2
+            mock_td.retry_delay_seconds = retry_delay_seconds if retry_delay_seconds is not None else 2
+            return mock_td
+
+        mock_worker_task_decorator = MagicMock(return_value=lambda fn: fn)
+        mock_worker_task = MagicMock(return_value=mock_worker_task_decorator)
+
+        # _default_task_def and worker_task are imported inside register_tool_workers,
+        # so we patch them at their source modules.
+        # get_tool_defs is also imported inside the method body, so patch at its source.
+        with (
+            patch("agentspan.agents.runtime.runtime._default_task_def", side_effect=fake_default_task_def),
+            patch("conductor.client.worker.worker_task.worker_task", mock_worker_task),
+            patch("agentspan.agents.tool.get_tool_defs", return_value=[td]),
+            patch("agentspan.agents.runtime.tool_registry.make_tool_worker", return_value=lambda task: None),
+        ):
+            registry = ToolRegistry()
+            registry.register_tool_workers([td], "test_agent")
+
+        assert len(captured_calls) == 1
+        assert captured_calls[0]["name"] == "retry_tool"
+        assert captured_calls[0]["retry_count"] == 3
+        assert captured_calls[0]["retry_delay_seconds"] == 5


### PR DESCRIPTION
Fixes #150

## Summary
The `@tool` decorator previously used hardcoded retry settings (`retry_count=2`, `retry_delay_seconds=2`) in `_default_task_def()` with no way for users to override them per-tool. This change adds `retry_count` and `retry_delay_seconds` as optional parameters to the `@tool` decorator and `ToolDef` dataclass, wires them through the runtime, and validates inputs.

## Changes
- **`sdk/python/src/agentspan/agents/tool.py`** — Added `retry_count` and `retry_delay_seconds` fields to `ToolDef` dataclass; added both params to `@tool` decorator (overloads + implementation); passes values through to `ToolDef` constructor.
- **`sdk/python/src/agentspan/agents/runtime/runtime.py`** — Updated `_default_task_def()` to accept `retry_count` and `retry_delay_seconds` keyword args with input validation (`ValueError` for negatives) and fallback to original defaults (2/2) when `None`.
- **`sdk/python/src/agentspan/agents/runtime/tool_registry.py`** — Forward `td.retry_count` and `td.retry_delay_seconds` to `_default_task_def()` when registering Conductor workers.
- **`sdk/python/tests/unit/test_tool.py`** — Added `TestToolRetryConfig` class with 10 new tests covering all new behaviour including defaults, custom values, zero retries, and `ValueError` on negative inputs.

## Testing
All 69 unit tests pass (59 pre-existing + 10 new in `TestToolRetryConfig`).

- `retry_count` stored on `ToolDef`
- `retry_delay_seconds` stored on `ToolDef`
- Both params together (including zero)
- Defaults to `None` on bare `@tool`
- `_default_task_def` uses defaults (2/2) when not specified
- `_default_task_def` applies custom values
- `_default_task_def` with `retry_count=0` disables retries
- `ValueError` raised for negative `retry_count`
- `ValueError` raised for negative `retry_delay_seconds`
- `register_tool_workers` forwards retry config to `_default_task_def`

## QA Evidence
See `qa-tests/issue-150/` for detailed test results and coverage.

<details>
<summary>Change Context (machine-readable)</summary>

```json
{"date": "2025-01-31", "issue_number": 150, "risks": "Low — purely additive change; existing behaviour preserved via None defaults falling back to original hardcoded values (2/2)", "what_changed": [{"file": "sdk/python/src/agentspan/agents/tool.py", "change": "Added retry_count and retry_delay_seconds fields to ToolDef dataclass; added both params to @tool decorator (overloads + implementation); passes values through to ToolDef constructor"}, {"file": "sdk/python/src/agentspan/agents/runtime/runtime.py", "change": "Updated _default_task_def() to accept retry_count and retry_delay_seconds keyword args with input validation (ValueError for negatives) and fallback to original defaults (2/2) when None"}, {"file": "sdk/python/src/agentspan/agents/runtime/tool_registry.py", "change": "Forward td.retry_count and td.retry_delay_seconds to _default_task_def() when registering Conductor workers"}, {"file": "sdk/python/tests/unit/test_tool.py", "change": "Added TestToolRetryConfig class with 10 new tests covering all new behaviour including defaults, custom values, zero retries, and ValueError on negative inputs"}], "author": "agentspan-bot", "testing": "69 unit tests pass (59 pre-existing + 10 new in TestToolRetryConfig). Commit: 27b68852", "issue_title": "Allow retry configuration on @tool decorator", "change_type": "feature", "related_issues": [150], "root_cause": "The @tool decorator and ToolDef dataclass had no retry_count or retry_delay_seconds parameters. The _default_task_def() helper in runtime.py always used hardcoded values (retry_count=2, retry_delay_seconds=2), with no way for users to override them per-tool."}
```

</details>