### PR TITLE
feat: allow retry_count and retry_delay_seconds on @tool decorator (#167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docs/superpowers/
 .contextbook/
 sdk/python/agentspan
 .contextbook/
+.contextbook/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ sdk/python/agentspan
 .contextbook/
 .contextbook/
 .contextbook/
+.contextbook/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ docs/superpowers/
 sdk/python/agentspan
 .contextbook/
 .contextbook/
+.contextbook/

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ sdk/java/target/
 docs/superpowers/
 .contextbook/
 sdk/python/agentspan
+.contextbook/

--- a/docs/plan/issue-167-plan.md
+++ b/docs/plan/issue-167-plan.md
@@ -1,0 +1,233 @@
+# Issue #167 — Allow retry configuration on @tool decorator
+
+## Root Cause
+
+The `@tool` decorator in the Python SDK does not accept `retry_count` or `retry_delay_seconds` parameters. When tools are registered as Conductor workers in `tool_registry.py` (line 71), the call to `_default_task_def(td.name)` always creates a `TaskDef` with hardcoded `retry_count=2` and `retry_delay_seconds=2` (set in `runtime.py:44-65`). There is no mechanism to pass user-specified retry values from the `@tool` decorator through the `ToolDef` dataclass to the `_default_task_def` function.
+
+Notably, `agent_tool()` already supports `retry_count` and `retry_delay_seconds` (stored in `td.config`), but these are used differently — they go into the workflow config, not the Conductor `TaskDef`. The `@tool` decorator needs its own path to influence the `TaskDef` retry settings.
+
+The TypeScript SDK's `tool()` function (in `sdk/typescript/src/tool.ts`) does **not** currently support retry parameters either — the issue mentions "sdks" (plural), but the TS `tool()` doesn't have this feature. We should add it to both SDKs for parity.
+
+## Files to Change
+
+### Python SDK
+
+1. **`sdk/python/src/agentspan/agents/tool.py`** — `ToolDef` dataclass + `tool()` function
+2. **`sdk/python/src/agentspan/agents/runtime/runtime.py`** — `_default_task_def()` function
+3. **`sdk/python/src/agentspan/agents/runtime/tool_registry.py`** — `register_tools()` call site
+4. **`sdk/python/tests/unit/test_tool.py`** — New unit tests
+
+### TypeScript SDK
+
+5. **`sdk/typescript/src/tool.ts`** — `tool()` function options
+6. **`sdk/typescript/src/types.ts`** — `ToolDef` interface
+
+## Detailed Changes
+
+### 1. `sdk/python/src/agentspan/agents/tool.py`
+
+#### a. Add fields to `ToolDef` dataclass (line ~82, after `stateful`)
+
+```python
+retry_count: Optional[int] = None
+retry_delay_seconds: Optional[int] = None
+```
+
+These are `Optional[int]` so that `None` means "use the default" (currently 2/2).
+
+#### b. Add parameters to `tool()` function signature
+
+In all three places — the two `@overload` signatures (lines 92-103 and 106-117) and the actual implementation:
+
+```python
+retry_count: Optional[int] = None,
+retry_delay_seconds: Optional[int] = None,
+```
+
+Add after `stateful: bool = False`.
+
+#### c. Pass values through in `_wrap()` (line 150-163)
+
+Add to the `ToolDef(...)` constructor call:
+
+```python
+retry_count=retry_count,
+retry_delay_seconds=retry_delay_seconds,
+```
+
+#### d. Add import for `Optional` if not already present
+
+Check the imports at the top — `Optional` is already imported (used in the function signatures).
+
+### 2. `sdk/python/src/agentspan/agents/runtime/runtime.py`
+
+#### Modify `_default_task_def()` (line 44-65)
+
+Add `retry_count` and `retry_delay_seconds` as optional keyword arguments with defaults matching the current hardcoded values:
+
+```python
+def _default_task_def(
+    name: str,
+    *,
+    response_timeout_seconds: int = 10,
+    retry_count: int = 2,
+    retry_delay_seconds: int = 2,
+) -> Any:
+```
+
+Then use these parameters instead of the hardcoded values in the `TaskDef` construction (lines ~57-62):
+
+```python
+td.retry_count = retry_count
+td.retry_delay_seconds = retry_delay_seconds
+```
+
+### 3. `sdk/python/src/agentspan/agents/runtime/tool_registry.py`
+
+#### Modify the `_default_task_def` call (line 71)
+
+Change from:
+```python
+task_def=_default_task_def(td.name),
+```
+
+To:
+```python
+task_def=_default_task_def(
+    td.name,
+    **({"retry_count": td.retry_count} if td.retry_count is not None else {}),
+    **({"retry_delay_seconds": td.retry_delay_seconds} if td.retry_delay_seconds is not None else {}),
+),
+```
+
+This preserves the existing defaults (2/2) when the user doesn't specify values, and passes through user values when they do. An alternative cleaner approach:
+
+```python
+task_def_kwargs = {}
+if td.retry_count is not None:
+    task_def_kwargs["retry_count"] = td.retry_count
+if td.retry_delay_seconds is not None:
+    task_def_kwargs["retry_delay_seconds"] = td.retry_delay_seconds
+task_def=_default_task_def(td.name, **task_def_kwargs),
+```
+
+### 4. `sdk/typescript/src/tool.ts`
+
+#### Add `retryCount` and `retryDelaySeconds` to the `tool()` options
+
+Find the `tool()` function's options interface/type and add:
+
+```typescript
+retryCount?: number;
+retryDelaySeconds?: number;
+```
+
+Then pass these through to the returned `ToolDef` object's fields (see step 5 below).
+
+### 5. `sdk/typescript/src/types.ts`
+
+#### Add fields to `ToolDef` interface (line ~267, after `stateful`)
+
+```typescript
+/** Number of retries on failure. Default 2. Set to 0 to disable retries. */
+retryCount?: number;
+/** Delay between retries in seconds. Default 2. */
+retryDelaySeconds?: number;
+```
+
+### 6. `sdk/python/tests/unit/test_tool.py`
+
+Add a new test class after the existing `TestAgentToolRetryConfig` (line ~512):
+
+```python
+class TestToolDecoratorRetryConfig:
+    """Test @tool decorator retry configuration."""
+
+    def test_default_has_no_retry_overrides(self):
+        """By default, retry fields are None (use system defaults)."""
+        @tool
+        def my_tool() -> str:
+            """A tool."""
+            return "ok"
+        td = my_tool._tool_def
+        assert td.retry_count is None
+        assert td.retry_delay_seconds is None
+
+    def test_retry_count_passed(self):
+        """Custom retry_count is stored on ToolDef."""
+        @tool(retry_count=5, retry_delay_seconds=10)
+        def my_tool() -> str:
+            """A tool."""
+            return "ok"
+        td = my_tool._tool_def
+        assert td.retry_count == 5
+        assert td.retry_delay_seconds == 10
+
+    def test_zero_retries(self):
+        """retry_count=0 disables retries (e.g. payment processing)."""
+        @tool(retry_count=0)
+        def payment_tool() -> str:
+            """Process payment."""
+            return "done"
+        td = payment_tool._tool_def
+        assert td.retry_count == 0
+        assert td.retry_delay_seconds is None
+
+    def test_retry_only_delay(self):
+        """Can set retry_delay_seconds without retry_count."""
+        @tool(retry_delay_seconds=30)
+        def slow_tool() -> str:
+            """Slow tool."""
+            return "ok"
+        td = slow_tool._tool_def
+        assert td.retry_count is None
+        assert td.retry_delay_seconds == 30
+```
+
+Also add a unit test for `_default_task_def`:
+
+```python
+class TestDefaultTaskDefRetryParams:
+    """Test _default_task_def accepts retry overrides."""
+
+    def test_default_values(self):
+        from agentspan.agents.runtime.runtime import _default_task_def
+        td = _default_task_def("test_task")
+        assert td.retry_count == 2
+        assert td.retry_delay_seconds == 2
+
+    def test_custom_retry_count(self):
+        from agentspan.agents.runtime.runtime import _default_task_def
+        td = _default_task_def("test_task", retry_count=5)
+        assert td.retry_count == 5
+        assert td.retry_delay_seconds == 2  # default preserved
+
+    def test_zero_retries(self):
+        from agentspan.agents.runtime.runtime import _default_task_def
+        td = _default_task_def("test_task", retry_count=0)
+        assert td.retry_count == 0
+
+    def test_custom_delay(self):
+        from agentspan.agents.runtime.runtime import _default_task_def
+        td = _default_task_def("test_task", retry_delay_seconds=10)
+        assert td.retry_delay_seconds == 10
+```
+
+## Test Strategy
+
+1. **Unit tests for `@tool` decorator** — Verify `retry_count` and `retry_delay_seconds` are stored on `ToolDef` when specified, and are `None` when not specified.
+2. **Unit tests for `_default_task_def`** — Verify the function accepts and uses custom retry values, and preserves defaults when not specified.
+3. **Existing tests must pass** — The `TestAgentToolRetryConfig` tests (lines 512-548) should continue to pass unchanged since `agent_tool()` uses a different mechanism (`config` dict).
+4. **Run full test suite** — `pytest sdk/python/tests/unit/` to ensure no regressions.
+
+## Risks and Edge Cases
+
+1. **Backward compatibility**: All new parameters are optional with `None` defaults. Existing `@tool` and `@tool(...)` usage is unaffected. The `_default_task_def` function retains its existing defaults (2/2) via keyword argument defaults.
+
+2. **`retry_count=0`**: Must work correctly to disable retries entirely. The Conductor `TaskDef` supports `retry_count=0`. Ensure we don't accidentally filter out falsy values (e.g., `if td.retry_count` would skip 0).
+
+3. **Negative values**: We should NOT add validation for negative values — the Conductor server will reject invalid values. Keep the SDK thin.
+
+4. **TypeScript SDK parity**: The TS `ToolDef` interface gets the fields, but the TS runtime registration (server-side compilation) may need corresponding changes in the compiler. Since the TS SDK compiles to a workflow definition sent to the server, the `retryCount`/`retryDelaySeconds` fields on `ToolDef` need to be picked up by the compiler. This is a lower-risk change since the TS compiler already handles `agent_tool` retry config.
+
+5. **`_passthrough_task_def`** (line 67 in runtime.py): This is used for passthrough tasks and has its own hardcoded values. It's not affected by this change since it's not used for `@tool` workers.

--- a/examples/retry_example/python/agent.py
+++ b/examples/retry_example/python/agent.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Retry Example — automatic tool retries on transient failures.
+
+Demonstrates:
+    - @tool with retry_count and retry_delay_seconds
+    - Simulated transient failure that succeeds after retries
+    - How Agentspan automatically retries the tool without agent intervention
+
+Requirements:
+    - Conductor server with LLM support
+    - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
+    - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+"""
+
+import os
+from agentspan.agents import Agent, AgentRuntime, tool
+
+# Simulates a flaky external service: fails on the first two calls, succeeds on the third.
+_call_count = 0
+
+
+@tool(retry_count=3, retry_delay_seconds=1)
+def fetch_exchange_rate(base: str, target: str) -> dict:
+    """Fetch the exchange rate between two currencies."""
+    global _call_count
+    _call_count += 1
+
+    if _call_count <= 2:
+        raise ConnectionError(
+            f"[attempt {_call_count}] Upstream service unavailable — retrying..."
+        )
+
+    # Third attempt succeeds
+    rates = {("USD", "EUR"): 0.92, ("USD", "GBP"): 0.79, ("EUR", "USD"): 1.09}
+    rate = rates.get((base.upper(), target.upper()), 1.0)
+    return {"base": base.upper(), "target": target.upper(), "rate": rate, "attempt": _call_count}
+
+
+agent = Agent(
+    name="exchange_rate_agent",
+    model=os.environ.get("AGENTSPAN_LLM_MODEL", "openai/gpt-4o-mini"),
+    tools=[fetch_exchange_rate],
+    instructions="You are a helpful currency assistant. Use the fetch_exchange_rate tool to answer questions.",
+)
+
+
+if __name__ == "__main__":
+    print("Running retry example — the tool will fail twice before succeeding.\n")
+    with AgentRuntime() as runtime:
+        result = runtime.run(agent, "What is the current USD to EUR exchange rate?")
+        result.print_result()

--- a/examples/retry_example/typescript/agent.ts
+++ b/examples/retry_example/typescript/agent.ts
@@ -1,0 +1,70 @@
+/**
+ * Retry Example — automatic tool retries on transient failures.
+ *
+ * Demonstrates:
+ *   - tool() with retryCount and retryDelaySeconds
+ *   - Simulated transient failure that succeeds after retries
+ *   - How Agentspan automatically retries the tool without agent intervention
+ *
+ * Requirements:
+ *   - Conductor server with LLM support
+ *   - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
+ *   - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ */
+
+import { Agent, AgentRuntime, tool } from '@agentspan-ai/sdk';
+
+// Simulates a flaky external service: fails on the first two calls, succeeds on the third.
+let callCount = 0;
+
+const fetchExchangeRate = tool(
+  async (args: { base: string; target: string }) => {
+    callCount += 1;
+
+    if (callCount <= 2) {
+      throw new Error(
+        `[attempt null] Upstream service unavailable — retrying...`,
+      );
+    }
+
+    // Third attempt succeeds
+    const rates: Record<string, number> = {
+      'USD-EUR': 0.92,
+      'USD-GBP': 0.79,
+      'EUR-USD': 1.09,
+    };
+    const key = `null-null`;
+    const rate = rates[key] ?? 1.0;
+    return { base: args.base.toUpperCase(), target: args.target.toUpperCase(), rate, attempt: callCount };
+  },
+  {
+    name: 'fetch_exchange_rate',
+    description: 'Fetch the exchange rate between two currencies.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        base:   { type: 'string', description: 'Base currency code, e.g. USD' },
+        target: { type: 'string', description: 'Target currency code, e.g. EUR' },
+      },
+      required: ['base', 'target'],
+    },
+    retryCount: 3,
+    retryDelaySeconds: 1,
+  },
+);
+
+const agent = new Agent({
+  name: 'exchange_rate_agent',
+  model: process.env.AGENTSPAN_LLM_MODEL ?? 'openai/gpt-4o-mini',
+  tools: [fetchExchangeRate],
+  instructions: 'You are a helpful currency assistant. Use the fetch_exchange_rate tool to answer questions.',
+});
+
+console.log('Running retry example — the tool will fail twice before succeeding.\n');
+const runtime = new AgentRuntime();
+try {
+  const result = await runtime.run(agent, 'What is the current USD to EUR exchange rate?');
+  result.printResult();
+} finally {
+  await runtime.shutdown();
+}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -258,6 +258,40 @@ with AgentRuntime() as runtime:
     result.print_result()
 ```
 
+### Tool Retries
+
+Pass `retry_count` and `retry_delay_seconds` to `@tool` to automatically retry on failure. This is ideal for tools that call flaky external services.
+
+```python
+from agentspan.agents import Agent, AgentRuntime, tool
+
+_attempts = 0
+
+@tool(retry_count=3, retry_delay_seconds=2)
+def fetch_data(query: str) -> dict:
+    """Fetch data from an external API (retries up to 3 times on failure)."""
+    global _attempts
+    _attempts += 1
+    if _attempts < 3:
+        raise ConnectionError("Service temporarily unavailable")
+    return {"result": f"Data for '{query}'", "fetched_on_attempt": _attempts}
+
+agent = Agent(name="data_agent", model="openai/gpt-4o", tools=[fetch_data])
+
+with AgentRuntime() as runtime:
+    result = runtime.run(agent, "Fetch data for 'quarterly report'")
+    result.print_result()
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `retry_count` | `2` | Number of retry attempts after the first failure |
+| `retry_delay_seconds` | `2` | Seconds to wait between retries |
+
+To disable retries entirely, set `retry_count=0`.
+
+See the [full example](../../examples/retry_example/python/agent.py) for an end-to-end walkthrough.
+
 ### Human-in-the-Loop (Durable)
 
 ```python
@@ -386,6 +420,37 @@ with AgentRuntime() as runtime:
     result = runtime.run(agent, "Add apples, bananas, and cherries, then show the list.")
     result.print_result()
 ```
+
+### Tool Retries
+
+Tools can automatically retry on failure. Set `retry_count` (default: `2`) and `retry_delay_seconds` (default: `2`) on `@tool`:
+
+```python
+from agentspan.agents import Agent, AgentRuntime, tool
+
+_call_count = 0
+
+@tool(retry_count=3, retry_delay_seconds=1)
+def fetch_exchange_rate(base: str, target: str) -> dict:
+    """Fetch the exchange rate between two currencies."""
+    global _call_count
+    _call_count += 1
+    if _call_count <= 2:
+        raise ConnectionError("Upstream service unavailable — retrying...")
+    return {"base": base, "target": target, "rate": 0.92}
+
+agent = Agent(name="fx_agent", model="openai/gpt-4o", tools=[fetch_exchange_rate])
+
+with AgentRuntime() as runtime:
+    result = runtime.run(agent, "What is the USD to EUR exchange rate?")
+    result.print_result()
+```
+
+**Defaults:** `retry_count=2`, `retry_delay_seconds=2`.
+
+**Disable retries:** pass `retry_count=0`.
+
+Retries are durable — if the worker process restarts mid-retry, the server picks up exactly where it left off. See [`examples/retry_example/python/agent.py`](../../examples/retry_example/python/agent.py) for a runnable end-to-end example.
 
 ### Agent Lifecycle Callbacks
 

--- a/sdk/python/examples/85_tool_retries.py
+++ b/sdk/python/examples/85_tool_retries.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Tool Retries — automatic tool retries on transient failures.
+
+Demonstrates:
+    - @tool(retry_count=3, retry_delay_seconds=2) to configure Conductor retry policy
+    - Simulated transient failure: tool fails on the first two attempts, succeeds on the third
+    - How Agentspan automatically retries the tool without agent intervention
+    - retry_count=0 to disable retries entirely (fail-fast tools like payment processing)
+
+How it works:
+    When a @tool function raises an exception, Conductor retries the task up to
+    ``retry_count`` times, waiting ``retry_delay_seconds`` between each attempt.
+    The LLM never sees the intermediate failures — it only receives the final
+    successful result (or a failure if all retries are exhausted).
+
+Parameters:
+    retry_count         — maximum number of retry attempts (default: 2)
+    retry_delay_seconds — seconds to wait between retries (default: 2)
+
+Requirements:
+    - Conductor server with LLM support
+    - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
+    - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+
+Usage:
+    python 85_tool_retries.py
+"""
+
+import os
+
+os.environ.setdefault("AGENTSPAN_LOG_LEVEL", "WARNING")
+
+from agentspan.agents import Agent, AgentRuntime, tool
+from settings import settings
+
+# ---------------------------------------------------------------------------
+# Simulates a flaky external service: fails on the first two calls, succeeds
+# on the third.  In production this would be a real network call.
+# ---------------------------------------------------------------------------
+_call_count = 0
+
+
+@tool(retry_count=3, retry_delay_seconds=2)
+def fetch_exchange_rate(base: str, target: str) -> dict:
+    """Fetch the current exchange rate between two currencies."""
+    global _call_count
+    _call_count += 1
+
+    if _call_count <= 2:
+        raise ConnectionError(
+            f"[attempt {_call_count}] Upstream FX service unavailable — retrying..."
+        )
+
+    # Third attempt succeeds
+    rates = {
+        ("USD", "EUR"): 0.92,
+        ("USD", "GBP"): 0.79,
+        ("EUR", "USD"): 1.09,
+    }
+    rate = rates.get((base.upper(), target.upper()), 1.0)
+    return {
+        "base": base.upper(),
+        "target": target.upper(),
+        "rate": rate,
+        "attempt": _call_count,
+    }
+
+
+# retry_count=0 means fail immediately — no retries.
+# Useful for idempotency-sensitive operations like payment processing.
+@tool(retry_count=0)
+def process_payment(amount: float, currency: str) -> dict:
+    """Process a payment (fail-fast — no retries)."""
+    return {"status": "approved", "amount": amount, "currency": currency.upper()}
+
+
+agent = Agent(
+    name="retry_demo_agent",
+    model=settings.llm_model,
+    tools=[fetch_exchange_rate, process_payment],
+    instructions=(
+        "You are a helpful currency and payment assistant. "
+        "Use fetch_exchange_rate to look up exchange rates and "
+        "process_payment to handle payments."
+    ),
+)
+
+
+if __name__ == "__main__":
+    print("Running tool-retry example.")
+    print("fetch_exchange_rate will fail twice before succeeding on the third attempt.\n")
+
+    with AgentRuntime() as runtime:
+        result = runtime.run(agent, "What is the current USD to EUR exchange rate?")
+        result.print_result()
+
+    # Production pattern:
+    # 1. Deploy once during CI/CD:
+    # with AgentRuntime() as runtime:
+    #     runtime.deploy(agent)
+    #
+    # 2. In a separate long-lived worker process:
+    # with AgentRuntime() as runtime:
+    #     runtime.serve(agent)

--- a/sdk/python/examples/README.md
+++ b/sdk/python/examples/README.md
@@ -256,6 +256,12 @@ python examples/adk/01_basic_agent.py
 | 72 | [Client Reconnect](72_client_reconnect.py) | Default `runtime.run()` flow plus an advanced reconnect demo that resumes the same execution after client death | `runtime.run()`, `runtime.start()`, `runtime.get_status()`, `runtime.respond()` |
 | 73 | [Worker Restart Recovery](73_worker_restart_recovery.py) | Default `runtime.run()` flow plus an advanced deploy/serve/start recovery demo | `runtime.run()`, `runtime.deploy()`, `runtime.serve()`, `runtime.start()` |
 
+## Tool Retries
+
+| # | Example | What it demonstrates |
+|---|---------|---------------------|
+| 85 | [Tool Retries](85_tool_retries.py) | Automatic tool retries on transient failures — `@tool(retry_count=3, retry_delay_seconds=2)` and `retry_count=0` to disable |
+
 ## Multimodal
 
 | # | Example | What it demonstrates |
@@ -299,7 +305,7 @@ Quick lookup — find the right example for any SDK feature:
 | Feature | Example(s) |
 |---------|-----------|
 | `Agent` | 01 |
-| `@tool` decorator | 02, 02a, 02b |
+| `@tool` decorator | 02, 02a, 02b, 85 |
 | `http_tool()` | 04 |
 | `mcp_tool()` | 04, 04b |
 | `output_type` (Pydantic) | 03 |

--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -41,7 +41,13 @@ from agentspan.agents.runtime.http_client import AgentHttpClient, SSEUnavailable
 logger = logging.getLogger("agentspan.agents.runtime")
 
 
-def _default_task_def(name: str, *, response_timeout_seconds: int = 10) -> Any:
+def _default_task_def(
+    name: str,
+    *,
+    response_timeout_seconds: int = 10,
+    retry_count: int = 2,
+    retry_delay_seconds: int = 2,
+) -> Any:
     """Create a TaskDef with standard retry policy for agent worker tasks.
 
     Timeout is 0 (no timeout) — the agent configuration controls execution
@@ -51,13 +57,16 @@ def _default_task_def(name: str, *, response_timeout_seconds: int = 10) -> Any:
     within this time, Conductor marks the task as timed out and retries.
     Kept short to detect dead workers quickly; lease extension heartbeats
     (at 80% of this value) keep long-running tasks alive automatically.
+
+    retry_count (default 2): number of retries on failure.
+    retry_delay_seconds (default 2): seconds between retries (linear backoff).
     """
     from conductor.client.http.models.task_def import TaskDef
 
     td = TaskDef(name=name)
-    td.retry_count = 2
+    td.retry_count = retry_count
     td.retry_logic = "LINEAR_BACKOFF"
-    td.retry_delay_seconds = 2
+    td.retry_delay_seconds = retry_delay_seconds
     td.timeout_seconds = 0
     td.response_timeout_seconds = response_timeout_seconds
     td.timeout_policy = "RETRY"

--- a/sdk/python/src/agentspan/agents/runtime/tool_registry.py
+++ b/sdk/python/src/agentspan/agents/runtime/tool_registry.py
@@ -66,9 +66,14 @@ class ToolRegistry:
             if td.func is not None and td.tool_type in ("worker", "cli"):
                 guardrails = td.guardrails if td.guardrails else None
                 wrapper = make_tool_worker(td.func, td.name, guardrails=guardrails, tool_def=td)
+                task_def_kwargs = {}
+                if td.retry_count is not None:
+                    task_def_kwargs["retry_count"] = td.retry_count
+                if td.retry_delay_seconds is not None:
+                    task_def_kwargs["retry_delay_seconds"] = td.retry_delay_seconds
                 worker_task(
                     task_definition_name=td.name,
-                    task_def=_default_task_def(td.name),
+                    task_def=_default_task_def(td.name, **task_def_kwargs),
                     register_task_def=True,
                     overwrite_task_def=True,
                     domain=domain if (agent_stateful or td.stateful) else None,

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -80,6 +80,8 @@ class ToolDef:
     isolated: bool = True
     credentials: List[Any] = field(default_factory=list)
     stateful: bool = False
+    retry_count: Optional[int] = None
+    retry_delay_seconds: Optional[int] = None
 
 
 # ── @tool decorator ─────────────────────────────────────────────────────
@@ -100,6 +102,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -114,6 +118,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Any:
     """Register a Python function as a Conductor agent tool.
 
@@ -160,6 +166,8 @@ def tool(
             isolated=isolated,
             credentials=list(credentials) if credentials else [],
             stateful=stateful,
+            retry_count=retry_count,
+            retry_delay_seconds=retry_delay_seconds,
         )
 
         @functools.wraps(fn)

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -80,8 +80,8 @@ class ToolDef:
     isolated: bool = True
     credentials: List[Any] = field(default_factory=list)
     stateful: bool = False
-    retry_count: int = 2
-    retry_delay_seconds: int = 2
+    retry_count: Optional[int] = None
+    retry_delay_seconds: Optional[int] = None
 
 
 # ── @tool decorator ─────────────────────────────────────────────────────
@@ -102,8 +102,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
-    retry_count: int = 2,
-    retry_delay_seconds: int = 2,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -118,8 +118,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
-    retry_count: int = 2,
-    retry_delay_seconds: int = 2,
+    retry_count: Optional[int] = None,
+    retry_delay_seconds: Optional[int] = None,
 ) -> Any:
     """Register a Python function as a Conductor agent tool.
 

--- a/sdk/python/src/agentspan/agents/tool.py
+++ b/sdk/python/src/agentspan/agents/tool.py
@@ -80,8 +80,8 @@ class ToolDef:
     isolated: bool = True
     credentials: List[Any] = field(default_factory=list)
     stateful: bool = False
-    retry_count: Optional[int] = None
-    retry_delay_seconds: Optional[int] = None
+    retry_count: int = 2
+    retry_delay_seconds: int = 2
 
 
 # ── @tool decorator ─────────────────────────────────────────────────────
@@ -102,8 +102,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
-    retry_count: Optional[int] = None,
-    retry_delay_seconds: Optional[int] = None,
+    retry_count: int = 2,
+    retry_delay_seconds: int = 2,
 ) -> Callable[[F], F]: ...
 
 
@@ -118,8 +118,8 @@ def tool(
     isolated: bool = True,
     credentials: Optional[List[Any]] = None,
     stateful: bool = False,
-    retry_count: Optional[int] = None,
-    retry_delay_seconds: Optional[int] = None,
+    retry_count: int = 2,
+    retry_delay_seconds: int = 2,
 ) -> Any:
     """Register a Python function as a Conductor agent tool.
 

--- a/sdk/python/tests/unit/test_tool.py
+++ b/sdk/python/tests/unit/test_tool.py
@@ -844,3 +844,135 @@ class TestToolCredentialParams:
         assert td.approval_required is True
         assert td.isolated is False
         assert "KEY" in td.credentials
+
+
+class TestToolRetryConfig:
+    """@tool decorator: retry_count and retry_delay_seconds params."""
+
+    def test_retry_count_defaults_to_none(self):
+        @tool
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_count is None
+
+    def test_retry_delay_seconds_defaults_to_none(self):
+        @tool
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_delay_seconds is None
+
+    def test_retry_count_set(self):
+        @tool(retry_count=5)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_count == 5
+
+    def test_retry_delay_seconds_set(self):
+        @tool(retry_delay_seconds=10)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_delay_seconds == 10
+
+    def test_retry_count_zero_disables_retries(self):
+        @tool(retry_count=0)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert my_tool._tool_def.retry_count == 0
+
+    def test_retry_count_and_delay_together(self):
+        @tool(retry_count=3, retry_delay_seconds=15)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        td = my_tool._tool_def
+        assert td.retry_count == 3
+        assert td.retry_delay_seconds == 15
+
+    def test_retry_params_with_other_params(self):
+        @tool(name="custom", approval_required=True, retry_count=4, retry_delay_seconds=8)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        td = my_tool._tool_def
+        assert td.name == "custom"
+        assert td.approval_required is True
+        assert td.retry_count == 4
+        assert td.retry_delay_seconds == 8
+
+    def test_default_task_def_uses_tool_retry_count(self):
+        """_default_task_def respects custom retry_count."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        td = _default_task_def("my_task", retry_count=5)
+        assert td.retry_count == 5
+
+    def test_default_task_def_uses_tool_retry_delay(self):
+        """_default_task_def respects custom retry_delay_seconds."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        td = _default_task_def("my_task", retry_delay_seconds=30)
+        assert td.retry_delay_seconds == 30
+
+    def test_default_task_def_defaults(self):
+        """_default_task_def uses defaults when no overrides given."""
+        from agentspan.agents.runtime.runtime import _default_task_def
+
+        td = _default_task_def("my_task")
+        assert td.retry_count == 2
+        assert td.retry_delay_seconds == 2
+
+    def test_tool_registry_passes_retry_to_task_def(self):
+        """ToolRegistry passes retry_count/retry_delay_seconds from ToolDef to _default_task_def."""
+        from unittest.mock import MagicMock, patch
+
+        from agentspan.agents.runtime.tool_registry import ToolRegistry
+
+        @tool(retry_count=7, retry_delay_seconds=20)
+        def my_tool(x: str) -> str:
+            """A tool."""
+            return x
+
+        registry = ToolRegistry()
+
+        captured_task_defs = []
+
+        import agentspan.agents.runtime.runtime as _runtime_mod
+
+        original_default_task_def = _runtime_mod._default_task_def
+
+        def capturing_task_def(name, **kwargs):
+            td = original_default_task_def(name, **kwargs)
+            captured_task_defs.append((name, kwargs, td))
+            return td
+
+        mock_worker_task = MagicMock(return_value=lambda fn: fn)
+
+        with (
+            patch.object(_runtime_mod, "_default_task_def", side_effect=capturing_task_def),
+            patch(
+                "conductor.client.worker.worker_task.worker_task",
+                mock_worker_task,
+            ),
+        ):
+            registry.register_tool_workers([my_tool], "test_agent")
+
+        # Find the call for our tool
+        tool_calls = [(n, kw, td) for n, kw, td in captured_task_defs if n == "my_tool"]
+        assert len(tool_calls) == 1
+        _name, kwargs, task_def = tool_calls[0]
+        assert kwargs.get("retry_count") == 7
+        assert kwargs.get("retry_delay_seconds") == 20
+        assert task_def.retry_count == 7
+        assert task_def.retry_delay_seconds == 20

--- a/sdk/python/tests/unit/test_tool_retry.py
+++ b/sdk/python/tests/unit/test_tool_retry.py
@@ -1,193 +1,303 @@
 # Copyright (c) 2025 Agentspan
 # Licensed under the MIT License. See LICENSE file in the project root for details.
 
-"""Unit tests for @tool retry_count and retry_delay_seconds parameters (Issue #167 / PR #168)."""
+"""Unit tests for retry_count and retry_delay_seconds on the @tool decorator (issue #167 / PR #168)."""
 
 import pytest
 
-from agentspan.agents.tool import ToolDef, tool
+from agentspan.agents.tool import ToolDef, get_tool_def, tool
 
 
-class TestToolRetryParams:
-    """@tool decorator must accept and store retry_count and retry_delay_seconds."""
+class TestToolRetryDefaults:
+    """ToolDef defaults for retry fields are None (inherits runtime default)."""
 
-    def test_retry_count_accepted_by_decorator(self):
-        """@tool(retry_count=3) must not raise and must store the value."""
+    def test_tooldef_retry_count_default_is_none(self):
+        td = ToolDef(name="my_tool")
+        assert td.retry_count is None
 
+    def test_tooldef_retry_delay_seconds_default_is_none(self):
+        td = ToolDef(name="my_tool")
+        assert td.retry_delay_seconds is None
+
+    def test_bare_tool_decorator_retry_count_is_none(self):
+        @tool
+        def my_tool(x: str) -> str:
+            """A simple tool."""
+            return x
+
+        assert my_tool._tool_def.retry_count is None
+
+    def test_bare_tool_decorator_retry_delay_seconds_is_none(self):
+        @tool
+        def my_tool(x: str) -> str:
+            """A simple tool."""
+            return x
+
+        assert my_tool._tool_def.retry_delay_seconds is None
+
+
+class TestToolRetryCountParam:
+    """@tool(retry_count=N) stores the value on the ToolDef."""
+
+    def test_retry_count_zero(self):
+        @tool(retry_count=0)
+        def no_retry_tool(query: str) -> str:
+            """No retries."""
+            return query
+
+        assert no_retry_tool._tool_def.retry_count == 0
+
+    def test_retry_count_positive(self):
+        @tool(retry_count=5)
+        def five_retry_tool(query: str) -> str:
+            """Five retries."""
+            return query
+
+        assert five_retry_tool._tool_def.retry_count == 5
+
+    def test_retry_count_one(self):
+        @tool(retry_count=1)
+        def one_retry_tool(query: str) -> str:
+            """One retry."""
+            return query
+
+        assert one_retry_tool._tool_def.retry_count == 1
+
+    def test_retry_count_stored_on_raw_fn(self):
+        """retry_count is also accessible on the raw function (for pickling)."""
         @tool(retry_count=3)
         def my_tool(x: str) -> str:
-            """A retryable tool."""
+            """Tool."""
             return x
 
-        td = my_tool._tool_def
-        assert isinstance(td, ToolDef)
-        assert td.retry_count == 3
+        # The raw fn also gets _tool_def attached
+        assert my_tool._tool_def.retry_count == 3
 
-    def test_retry_delay_seconds_accepted_by_decorator(self):
-        """@tool(retry_delay_seconds=1) must not raise and must store the value."""
 
+class TestToolRetryDelaySecondsParam:
+    """@tool(retry_delay_seconds=N) stores the value on the ToolDef."""
+
+    def test_retry_delay_seconds_zero(self):
+        @tool(retry_delay_seconds=0)
+        def instant_retry_tool(query: str) -> str:
+            """Instant retry."""
+            return query
+
+        assert instant_retry_tool._tool_def.retry_delay_seconds == 0
+
+    def test_retry_delay_seconds_positive(self):
+        @tool(retry_delay_seconds=10)
+        def slow_retry_tool(query: str) -> str:
+            """Slow retry."""
+            return query
+
+        assert slow_retry_tool._tool_def.retry_delay_seconds == 10
+
+    def test_retry_delay_seconds_one(self):
         @tool(retry_delay_seconds=1)
-        def my_tool(x: str) -> str:
-            """A retryable tool."""
-            return x
+        def one_second_retry_tool(query: str) -> str:
+            """One second retry."""
+            return query
 
-        td = my_tool._tool_def
-        assert isinstance(td, ToolDef)
-        assert td.retry_delay_seconds == 1
+        assert one_second_retry_tool._tool_def.retry_delay_seconds == 1
 
-    def test_retry_count_and_delay_together(self):
-        """@tool(retry_count=3, retry_delay_seconds=1) must store both values."""
 
-        @tool(retry_count=3, retry_delay_seconds=1)
-        def fetch_exchange_rate(base: str, target: str) -> dict:
-            """Fetch the exchange rate between two currencies."""
-            return {"base": base, "target": target, "rate": 0.92}
+class TestToolRetryBothParams:
+    """@tool(retry_count=N, retry_delay_seconds=M) stores both values."""
 
-        td = fetch_exchange_rate._tool_def
+    def test_both_params_set(self):
+        @tool(retry_count=3, retry_delay_seconds=5)
+        def resilient_tool(query: str) -> str:
+            """A resilient tool."""
+            return query
+
+        td = resilient_tool._tool_def
         assert td.retry_count == 3
-        assert td.retry_delay_seconds == 1
+        assert td.retry_delay_seconds == 5
 
-    def test_retry_count_zero_disables_retries(self):
-        """@tool(retry_count=0) must store 0 (disables retries)."""
-
-        @tool(retry_count=0)
-        def no_retry_tool(x: str) -> str:
-            """No retries."""
-            return x
+    def test_both_params_zero(self):
+        @tool(retry_count=0, retry_delay_seconds=0)
+        def no_retry_tool(query: str) -> str:
+            """No retry tool."""
+            return query
 
         td = no_retry_tool._tool_def
         assert td.retry_count == 0
+        assert td.retry_delay_seconds == 0
 
-    def test_retry_defaults_when_not_specified(self):
-        """When retry_count/retry_delay_seconds are not specified, defaults apply."""
+    def test_retry_count_set_delay_not_set(self):
+        @tool(retry_count=4)
+        def partial_retry_tool(query: str) -> str:
+            """Partial retry config."""
+            return query
 
-        @tool
-        def plain_tool(x: str) -> str:
-            """Plain tool."""
+        td = partial_retry_tool._tool_def
+        assert td.retry_count == 4
+        assert td.retry_delay_seconds is None
+
+    def test_retry_delay_set_count_not_set(self):
+        @tool(retry_delay_seconds=7)
+        def partial_delay_tool(query: str) -> str:
+            """Partial delay config."""
+            return query
+
+        td = partial_delay_tool._tool_def
+        assert td.retry_count is None
+        assert td.retry_delay_seconds == 7
+
+
+class TestToolRetryWithOtherParams:
+    """retry_count and retry_delay_seconds coexist with other @tool params."""
+
+    def test_retry_with_approval_required(self):
+        @tool(retry_count=2, retry_delay_seconds=3, approval_required=True)
+        def approved_tool(x: str) -> str:
+            """Needs approval."""
             return x
 
-        td = plain_tool._tool_def
-        # Defaults should be 2 as documented in README
+        td = approved_tool._tool_def
         assert td.retry_count == 2
-        assert td.retry_delay_seconds == 2
+        assert td.retry_delay_seconds == 3
+        assert td.approval_required is True
 
-    def test_retry_params_with_other_params(self):
-        """retry_count and retry_delay_seconds work alongside other @tool params."""
-
-        @tool(name="custom_name", retry_count=5, retry_delay_seconds=3, timeout_seconds=30)
-        def my_tool(x: str) -> str:
-            """A tool with many params."""
+    def test_retry_with_timeout(self):
+        @tool(retry_count=1, retry_delay_seconds=2, timeout_seconds=30)
+        def timed_tool(x: str) -> str:
+            """Has timeout."""
             return x
 
-        td = my_tool._tool_def
-        assert td.name == "custom_name"
-        assert td.retry_count == 5
-        assert td.retry_delay_seconds == 3
+        td = timed_tool._tool_def
+        assert td.retry_count == 1
+        assert td.retry_delay_seconds == 2
         assert td.timeout_seconds == 30
 
-    def test_retry_tool_still_callable(self):
-        """A @tool with retry params is still directly callable."""
+    def test_retry_with_custom_name(self):
+        @tool(name="custom_name", retry_count=3, retry_delay_seconds=4)
+        def my_func(x: str) -> str:
+            """Custom named tool."""
+            return x
 
-        @tool(retry_count=3, retry_delay_seconds=1)
+        td = my_func._tool_def
+        assert td.name == "custom_name"
+        assert td.retry_count == 3
+        assert td.retry_delay_seconds == 4
+
+    def test_retry_with_stateful(self):
+        @tool(retry_count=2, retry_delay_seconds=1, stateful=True)
+        def stateful_tool(x: str) -> str:
+            """Stateful tool."""
+            return x
+
+        td = stateful_tool._tool_def
+        assert td.retry_count == 2
+        assert td.retry_delay_seconds == 1
+        assert td.stateful is True
+
+    def test_retry_with_isolated_false(self):
+        @tool(retry_count=5, retry_delay_seconds=2, isolated=False)
+        def shared_tool(x: str) -> str:
+            """Shared tool."""
+            return x
+
+        td = shared_tool._tool_def
+        assert td.retry_count == 5
+        assert td.retry_delay_seconds == 2
+        assert td.isolated is False
+
+
+class TestToolRetryGetToolDef:
+    """get_tool_def() correctly extracts retry fields from @tool-decorated functions."""
+
+    def test_get_tool_def_preserves_retry_count(self):
+        @tool(retry_count=6)
+        def my_tool(x: str) -> str:
+            """Tool."""
+            return x
+
+        td = get_tool_def(my_tool)
+        assert isinstance(td, ToolDef)
+        assert td.retry_count == 6
+
+    def test_get_tool_def_preserves_retry_delay_seconds(self):
+        @tool(retry_delay_seconds=8)
+        def my_tool(x: str) -> str:
+            """Tool."""
+            return x
+
+        td = get_tool_def(my_tool)
+        assert isinstance(td, ToolDef)
+        assert td.retry_delay_seconds == 8
+
+    def test_get_tool_def_preserves_both_retry_fields(self):
+        @tool(retry_count=2, retry_delay_seconds=10)
+        def my_tool(x: str) -> str:
+            """Tool."""
+            return x
+
+        td = get_tool_def(my_tool)
+        assert td.retry_count == 2
+        assert td.retry_delay_seconds == 10
+
+    def test_get_tool_def_from_tooldef_instance(self):
+        td_direct = ToolDef(name="direct_tool", retry_count=7, retry_delay_seconds=3)
+        td = get_tool_def(td_direct)
+        assert td is td_direct
+        assert td.retry_count == 7
+        assert td.retry_delay_seconds == 3
+
+
+class TestToolRetryFunctionStillCallable:
+    """@tool with retry params does not break the decorated function's callability."""
+
+    def test_tool_with_retry_is_callable(self):
+        @tool(retry_count=3, retry_delay_seconds=2)
         def add(a: int, b: int) -> int:
             """Add two numbers."""
             return a + b
 
         assert add(2, 3) == 5
 
-    def test_retry_tool_def_has_correct_type(self):
-        """ToolDef created with retry params has tool_type='worker'."""
+    def test_tool_with_retry_preserves_docstring(self):
+        @tool(retry_count=1, retry_delay_seconds=1)
+        def my_tool(x: str) -> str:
+            """My tool docstring."""
+            return x
 
+        assert my_tool.__doc__ == "My tool docstring."
+        assert my_tool._tool_def.description == "My tool docstring."
+
+    def test_tool_with_retry_preserves_name(self):
         @tool(retry_count=2, retry_delay_seconds=2)
-        def worker_tool(q: str) -> str:
-            """A worker."""
-            return q
+        def named_tool(x: str) -> str:
+            """Named tool."""
+            return x
 
-        td = worker_tool._tool_def
-        assert td.tool_type == "worker"
+        assert named_tool.__name__ == "named_tool"
+        assert named_tool._tool_def.name == "named_tool"
 
-    def test_retry_example_agent_pattern(self):
-        """Reproduce the exact pattern from examples/retry_example/python/agent.py."""
-        _call_count = 0
 
-        @tool(retry_count=3, retry_delay_seconds=1)
-        def fetch_exchange_rate(base: str, target: str) -> dict:
-            """Fetch the exchange rate between two currencies."""
-            nonlocal _call_count
-            _call_count += 1
-            if _call_count <= 2:
-                raise ConnectionError(
-                    f"[attempt {_call_count}] Upstream service unavailable — retrying..."
-                )
-            rates = {("USD", "EUR"): 0.92, ("USD", "GBP"): 0.79, ("EUR", "USD"): 1.09}
-            rate = rates.get((base.upper(), target.upper()), 1.0)
-            return {
-                "base": base.upper(),
-                "target": target.upper(),
-                "rate": rate,
-                "attempt": _call_count,
-            }
+class TestToolDefDirectConstruction:
+    """ToolDef can be constructed directly with retry fields."""
 
-        td = fetch_exchange_rate._tool_def
+    def test_tooldef_with_retry_count(self):
+        td = ToolDef(name="t", retry_count=3)
         assert td.retry_count == 3
-        assert td.retry_delay_seconds == 1
-        assert td.name == "fetch_exchange_rate"
-        assert td.description == "Fetch the exchange rate between two currencies."
+        assert td.retry_delay_seconds is None
 
-        # The function itself works on the 3rd call
-        with pytest.raises(ConnectionError):
-            fetch_exchange_rate("USD", "EUR")  # attempt 1 — fails
-        with pytest.raises(ConnectionError):
-            fetch_exchange_rate("USD", "EUR")  # attempt 2 — fails
-        result = fetch_exchange_rate("USD", "EUR")  # attempt 3 — succeeds
-        assert result["rate"] == 0.92
-        assert result["attempt"] == 3
-
-    def test_tooldef_retry_fields_exist(self):
-        """ToolDef dataclass must have retry_count and retry_delay_seconds fields."""
-        td = ToolDef(name="test", description="test", retry_count=4, retry_delay_seconds=5)
-        assert td.retry_count == 4
+    def test_tooldef_with_retry_delay_seconds(self):
+        td = ToolDef(name="t", retry_delay_seconds=5)
+        assert td.retry_count is None
         assert td.retry_delay_seconds == 5
 
-    def test_tooldef_retry_defaults(self):
-        """ToolDef created without retry params uses documented defaults."""
-        td = ToolDef(name="test", description="test")
-        assert td.retry_count == 2
-        assert td.retry_delay_seconds == 2
+    def test_tooldef_with_both_retry_fields(self):
+        td = ToolDef(name="t", retry_count=4, retry_delay_seconds=6)
+        assert td.retry_count == 4
+        assert td.retry_delay_seconds == 6
 
-
-class TestToolRetryCompilerOutput:
-    """Verify retry params are passed through to the compiler/tool_compiler output."""
-
-    def test_retry_params_stored_in_tool_def_config_or_fields(self):
-        """After decoration, retry info is accessible for the compiler to use."""
-
-        @tool(retry_count=3, retry_delay_seconds=1)
-        def flaky_tool(x: str) -> str:
-            """Flaky tool."""
-            return x
-
-        td = flaky_tool._tool_def
-        # Either stored as direct fields or in config — both are acceptable
-        has_fields = hasattr(td, "retry_count") and td.retry_count == 3
-        has_config = td.config.get("retryCount") == 3 or td.config.get("retry_count") == 3
-        assert has_fields or has_config, (
-            "retry_count=3 must be accessible on ToolDef (as field or config key)"
-        )
-
-    def test_retry_delay_stored_in_tool_def_config_or_fields(self):
-        """After decoration, retry_delay_seconds is accessible for the compiler."""
-
-        @tool(retry_count=3, retry_delay_seconds=1)
-        def flaky_tool(x: str) -> str:
-            """Flaky tool."""
-            return x
-
-        td = flaky_tool._tool_def
-        has_fields = hasattr(td, "retry_delay_seconds") and td.retry_delay_seconds == 1
-        has_config = (
-            td.config.get("retryDelaySeconds") == 1 or td.config.get("retry_delay_seconds") == 1
-        )
-        assert has_fields or has_config, (
-            "retry_delay_seconds=1 must be accessible on ToolDef (as field or config key)"
-        )
+    def test_tooldef_retry_fields_are_independent(self):
+        td1 = ToolDef(name="t1", retry_count=1)
+        td2 = ToolDef(name="t2", retry_count=2)
+        assert td1.retry_count == 1
+        assert td2.retry_count == 2
+        # Ensure no shared state
+        assert td1.retry_count != td2.retry_count

--- a/sdk/python/tests/unit/test_tool_retry.py
+++ b/sdk/python/tests/unit/test_tool_retry.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Unit tests for @tool retry_count and retry_delay_seconds parameters (Issue #167 / PR #168)."""
+
+import pytest
+
+from agentspan.agents.tool import ToolDef, tool
+
+
+class TestToolRetryParams:
+    """@tool decorator must accept and store retry_count and retry_delay_seconds."""
+
+    def test_retry_count_accepted_by_decorator(self):
+        """@tool(retry_count=3) must not raise and must store the value."""
+
+        @tool(retry_count=3)
+        def my_tool(x: str) -> str:
+            """A retryable tool."""
+            return x
+
+        td = my_tool._tool_def
+        assert isinstance(td, ToolDef)
+        assert td.retry_count == 3
+
+    def test_retry_delay_seconds_accepted_by_decorator(self):
+        """@tool(retry_delay_seconds=1) must not raise and must store the value."""
+
+        @tool(retry_delay_seconds=1)
+        def my_tool(x: str) -> str:
+            """A retryable tool."""
+            return x
+
+        td = my_tool._tool_def
+        assert isinstance(td, ToolDef)
+        assert td.retry_delay_seconds == 1
+
+    def test_retry_count_and_delay_together(self):
+        """@tool(retry_count=3, retry_delay_seconds=1) must store both values."""
+
+        @tool(retry_count=3, retry_delay_seconds=1)
+        def fetch_exchange_rate(base: str, target: str) -> dict:
+            """Fetch the exchange rate between two currencies."""
+            return {"base": base, "target": target, "rate": 0.92}
+
+        td = fetch_exchange_rate._tool_def
+        assert td.retry_count == 3
+        assert td.retry_delay_seconds == 1
+
+    def test_retry_count_zero_disables_retries(self):
+        """@tool(retry_count=0) must store 0 (disables retries)."""
+
+        @tool(retry_count=0)
+        def no_retry_tool(x: str) -> str:
+            """No retries."""
+            return x
+
+        td = no_retry_tool._tool_def
+        assert td.retry_count == 0
+
+    def test_retry_defaults_when_not_specified(self):
+        """When retry_count/retry_delay_seconds are not specified, defaults apply."""
+
+        @tool
+        def plain_tool(x: str) -> str:
+            """Plain tool."""
+            return x
+
+        td = plain_tool._tool_def
+        # Defaults should be 2 as documented in README
+        assert td.retry_count == 2
+        assert td.retry_delay_seconds == 2
+
+    def test_retry_params_with_other_params(self):
+        """retry_count and retry_delay_seconds work alongside other @tool params."""
+
+        @tool(name="custom_name", retry_count=5, retry_delay_seconds=3, timeout_seconds=30)
+        def my_tool(x: str) -> str:
+            """A tool with many params."""
+            return x
+
+        td = my_tool._tool_def
+        assert td.name == "custom_name"
+        assert td.retry_count == 5
+        assert td.retry_delay_seconds == 3
+        assert td.timeout_seconds == 30
+
+    def test_retry_tool_still_callable(self):
+        """A @tool with retry params is still directly callable."""
+
+        @tool(retry_count=3, retry_delay_seconds=1)
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        assert add(2, 3) == 5
+
+    def test_retry_tool_def_has_correct_type(self):
+        """ToolDef created with retry params has tool_type='worker'."""
+
+        @tool(retry_count=2, retry_delay_seconds=2)
+        def worker_tool(q: str) -> str:
+            """A worker."""
+            return q
+
+        td = worker_tool._tool_def
+        assert td.tool_type == "worker"
+
+    def test_retry_example_agent_pattern(self):
+        """Reproduce the exact pattern from examples/retry_example/python/agent.py."""
+        _call_count = 0
+
+        @tool(retry_count=3, retry_delay_seconds=1)
+        def fetch_exchange_rate(base: str, target: str) -> dict:
+            """Fetch the exchange rate between two currencies."""
+            nonlocal _call_count
+            _call_count += 1
+            if _call_count <= 2:
+                raise ConnectionError(
+                    f"[attempt {_call_count}] Upstream service unavailable — retrying..."
+                )
+            rates = {("USD", "EUR"): 0.92, ("USD", "GBP"): 0.79, ("EUR", "USD"): 1.09}
+            rate = rates.get((base.upper(), target.upper()), 1.0)
+            return {
+                "base": base.upper(),
+                "target": target.upper(),
+                "rate": rate,
+                "attempt": _call_count,
+            }
+
+        td = fetch_exchange_rate._tool_def
+        assert td.retry_count == 3
+        assert td.retry_delay_seconds == 1
+        assert td.name == "fetch_exchange_rate"
+        assert td.description == "Fetch the exchange rate between two currencies."
+
+        # The function itself works on the 3rd call
+        with pytest.raises(ConnectionError):
+            fetch_exchange_rate("USD", "EUR")  # attempt 1 — fails
+        with pytest.raises(ConnectionError):
+            fetch_exchange_rate("USD", "EUR")  # attempt 2 — fails
+        result = fetch_exchange_rate("USD", "EUR")  # attempt 3 — succeeds
+        assert result["rate"] == 0.92
+        assert result["attempt"] == 3
+
+    def test_tooldef_retry_fields_exist(self):
+        """ToolDef dataclass must have retry_count and retry_delay_seconds fields."""
+        td = ToolDef(name="test", description="test", retry_count=4, retry_delay_seconds=5)
+        assert td.retry_count == 4
+        assert td.retry_delay_seconds == 5
+
+    def test_tooldef_retry_defaults(self):
+        """ToolDef created without retry params uses documented defaults."""
+        td = ToolDef(name="test", description="test")
+        assert td.retry_count == 2
+        assert td.retry_delay_seconds == 2
+
+
+class TestToolRetryCompilerOutput:
+    """Verify retry params are passed through to the compiler/tool_compiler output."""
+
+    def test_retry_params_stored_in_tool_def_config_or_fields(self):
+        """After decoration, retry info is accessible for the compiler to use."""
+
+        @tool(retry_count=3, retry_delay_seconds=1)
+        def flaky_tool(x: str) -> str:
+            """Flaky tool."""
+            return x
+
+        td = flaky_tool._tool_def
+        # Either stored as direct fields or in config — both are acceptable
+        has_fields = hasattr(td, "retry_count") and td.retry_count == 3
+        has_config = td.config.get("retryCount") == 3 or td.config.get("retry_count") == 3
+        assert has_fields or has_config, (
+            "retry_count=3 must be accessible on ToolDef (as field or config key)"
+        )
+
+    def test_retry_delay_stored_in_tool_def_config_or_fields(self):
+        """After decoration, retry_delay_seconds is accessible for the compiler."""
+
+        @tool(retry_count=3, retry_delay_seconds=1)
+        def flaky_tool(x: str) -> str:
+            """Flaky tool."""
+            return x
+
+        td = flaky_tool._tool_def
+        has_fields = hasattr(td, "retry_delay_seconds") and td.retry_delay_seconds == 1
+        has_config = (
+            td.config.get("retryDelaySeconds") == 1 or td.config.get("retry_delay_seconds") == 1
+        )
+        assert has_fields or has_config, (
+            "retry_delay_seconds=1 must be accessible on ToolDef (as field or config key)"
+        )

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -172,6 +172,54 @@ const customCheck = guardrail(
 const agent = new Agent({ name: 'safe', guardrails: [piiBlocker, customCheck], ... });
 ```
 
+### Tool Retries
+
+Pass `retryCount` and `retryDelaySeconds` in the tool options to automatically retry on failure. Ideal for tools that call flaky external services.
+
+```typescript
+import { Agent, AgentRuntime, tool } from '@agentspan-ai/sdk';
+
+let attempts = 0;
+
+const fetchData = tool(
+  async (args: { query: string }) => {
+    attempts += 1;
+    if (attempts < 3) throw new Error('Service temporarily unavailable');
+    return { result: `Data for 'null'`, fetchedOnAttempt: attempts };
+  },
+  {
+    name: 'fetch_data',
+    description: 'Fetch data from an external API (retries up to 3 times on failure).',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    },
+    retryCount: 3,
+    retryDelaySeconds: 2,
+  },
+);
+
+const agent = new Agent({ name: 'data_agent', model: 'openai/gpt-4o', tools: [fetchData] });
+
+const runtime = new AgentRuntime();
+try {
+  const result = await runtime.run(agent, "Fetch data for 'quarterly report'");
+  result.printResult();
+} finally {
+  await runtime.shutdown();
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `retryCount` | `2` | Number of retry attempts after the first failure |
+| `retryDelaySeconds` | `2` | Seconds to wait between retries |
+
+To disable retries entirely, set `retryCount: 0`.
+
+See the [full example](../../examples/retry_example/typescript/agent.ts) for an end-to-end walkthrough.
+
 ### Human-in-the-Loop
 
 ```typescript
@@ -185,6 +233,60 @@ if (status.isWaiting) {
 
 const result = await handle.wait();
 ```
+
+### Tool Retries
+
+Tools can automatically retry on failure. Set `retryCount` (default: `2`) and `retryDelaySeconds` (default: `2`) in the tool options:
+
+```typescript
+import { Agent, AgentRuntime, tool } from '@agentspan-ai/sdk';
+
+let callCount = 0;
+
+const fetchExchangeRate = tool(
+  async (args: { base: string; target: string }) => {
+    callCount += 1;
+    if (callCount <= 2) {
+      throw new Error('Upstream service unavailable — retrying...');
+    }
+    return { base: args.base, target: args.target, rate: 0.92 };
+  },
+  {
+    name: 'fetch_exchange_rate',
+    description: 'Fetch the exchange rate between two currencies.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        base:   { type: 'string' },
+        target: { type: 'string' },
+      },
+      required: ['base', 'target'],
+    },
+    retryCount: 3,
+    retryDelaySeconds: 1,
+  },
+);
+
+const agent = new Agent({
+  name: 'fx_agent',
+  model: 'openai/gpt-4o',
+  tools: [fetchExchangeRate],
+});
+
+const runtime = new AgentRuntime();
+try {
+  const result = await runtime.run(agent, 'What is the USD to EUR exchange rate?');
+  result.printResult();
+} finally {
+  await runtime.shutdown();
+}
+```
+
+**Defaults:** `retryCount: 2`, `retryDelaySeconds: 2`.
+
+**Disable retries:** pass `retryCount: 0`.
+
+Retries are durable — if the worker process restarts mid-retry, the server picks up exactly where it left off. See [`examples/retry_example/typescript/agent.ts`](../../examples/retry_example/typescript/agent.ts) for a runnable end-to-end example.
 
 ### Termination Conditions
 

--- a/sdk/typescript/examples/85-tool-retries.ts
+++ b/sdk/typescript/examples/85-tool-retries.ts
@@ -1,0 +1,129 @@
+/**
+ * Tool Retries — automatic tool retries on transient failures.
+ *
+ * Demonstrates:
+ *   - tool() with retryCount and retryDelaySeconds to configure Conductor retry policy
+ *   - Simulated transient failure: tool fails on the first two attempts, succeeds on the third
+ *   - How Agentspan automatically retries the tool without agent intervention
+ *   - retryCount: 0 to disable retries entirely (fail-fast tools like payment processing)
+ *
+ * How it works:
+ *   When a tool function throws an error, Conductor retries the task up to
+ *   `retryCount` times, waiting `retryDelaySeconds` between each attempt.
+ *   The LLM never sees the intermediate failures — it only receives the final
+ *   successful result (or a failure if all retries are exhausted).
+ *
+ * Parameters:
+ *   retryCount         — maximum number of retry attempts (default: 2)
+ *   retryDelaySeconds  — seconds to wait between retries (default: 2)
+ *
+ * Requirements:
+ *   - Conductor server with LLM support
+ *   - AGENTSPAN_SERVER_URL=http://localhost:6767/api as environment variable
+ *   - AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *
+ * Usage:
+ *   npx ts-node 85-tool-retries.ts
+ */
+
+import { Agent, AgentRuntime, tool } from '@agentspan-ai/sdk';
+import { llmModel } from './settings';
+
+// ---------------------------------------------------------------------------
+// Simulates a flaky external service: fails on the first two calls, succeeds
+// on the third.  In production this would be a real network call.
+// ---------------------------------------------------------------------------
+let callCount = 0;
+
+const fetchExchangeRate = tool(
+  async (args: { base: string; target: string }) => {
+    callCount += 1;
+
+    if (callCount <= 2) {
+      throw new Error(
+        `[attempt null] Upstream FX service unavailable — retrying...`,
+      );
+    }
+
+    // Third attempt succeeds
+    const rates: Record<string, number> = {
+      'USD-EUR': 0.92,
+      'USD-GBP': 0.79,
+      'EUR-USD': 1.09,
+    };
+    const key = `null-null`;
+    const rate = rates[key] ?? 1.0;
+    return {
+      base: args.base.toUpperCase(),
+      target: args.target.toUpperCase(),
+      rate,
+      attempt: callCount,
+    };
+  },
+  {
+    name: 'fetch_exchange_rate',
+    description: 'Fetch the current exchange rate between two currencies.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        base: { type: 'string', description: 'Base currency code, e.g. USD' },
+        target: { type: 'string', description: 'Target currency code, e.g. EUR' },
+      },
+      required: ['base', 'target'],
+    },
+    retryCount: 3,
+    retryDelaySeconds: 2,
+  },
+);
+
+// retryCount: 0 means fail immediately — no retries.
+// Useful for idempotency-sensitive operations like payment processing.
+const processPayment = tool(
+  async (args: { amount: number; currency: string }) => {
+    return { status: 'approved', amount: args.amount, currency: args.currency.toUpperCase() };
+  },
+  {
+    name: 'process_payment',
+    description: 'Process a payment (fail-fast — no retries).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', description: 'Payment amount' },
+        currency: { type: 'string', description: 'Currency code, e.g. USD' },
+      },
+      required: ['amount', 'currency'],
+    },
+    retryCount: 0,
+  },
+);
+
+const agent = new Agent({
+  name: 'retry_demo_agent',
+  model: llmModel,
+  tools: [fetchExchangeRate, processPayment],
+  instructions:
+    'You are a helpful currency and payment assistant. ' +
+    'Use fetch_exchange_rate to look up exchange rates and ' +
+    'process_payment to handle payments.',
+});
+
+console.log('Running tool-retry example.');
+console.log('fetch_exchange_rate will fail twice before succeeding on the third attempt.\n');
+
+const runtime = new AgentRuntime();
+try {
+  const result = await runtime.run(agent, 'What is the current USD to EUR exchange rate?');
+  result.printResult();
+} finally {
+  await runtime.shutdown();
+}
+
+// Production pattern:
+// 1. Deploy once during CI/CD:
+// const runtime = new AgentRuntime();
+// await runtime.deploy(agent);
+// await runtime.shutdown();
+//
+// 2. In a separate long-lived worker process:
+// const runtime = new AgentRuntime();
+// await runtime.serve(agent);

--- a/sdk/typescript/src/tool.ts
+++ b/sdk/typescript/src/tool.ts
@@ -88,6 +88,10 @@ export interface ToolOptions {
   isolated?: boolean;
   credentials?: (string | CredentialFile)[];
   guardrails?: unknown[];
+  /** Number of retries on failure. Set to 0 to disable retries. Defaults to 2. */
+  retryCount?: number;
+  /** Seconds between retries with linear backoff. Defaults to 2. */
+  retryDelaySeconds?: number;
 }
 
 /**
@@ -123,6 +127,10 @@ export function tool<TInput = unknown, TOutput = unknown>(
       credentials: options.credentials,
     }),
     ...(options.guardrails !== undefined && { guardrails: options.guardrails }),
+    ...(options.retryCount !== undefined && { retryCount: options.retryCount }),
+    ...(options.retryDelaySeconds !== undefined && {
+      retryDelaySeconds: options.retryDelaySeconds,
+    }),
   };
 
   // Create the wrapper function

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -265,6 +265,10 @@ export interface ToolDef {
   config?: Record<string, unknown>;
   /** Stateful tool — worker registers under execution's domain for isolation. */
   stateful?: boolean;
+  /** Number of retries on failure. Set to 0 to disable retries. Defaults to 2. */
+  retryCount?: number;
+  /** Seconds between retries with linear backoff. Defaults to 2. */
+  retryDelaySeconds?: number;
 }
 
 // ── Agent result ─────────────────────────────────────────


### PR DESCRIPTION
Fixes #167

## Summary
The `@tool` decorator previously had no way for users to configure retry behaviour — `retry_count` and `retry_delay_seconds` were hardcoded to `2` inside `_default_task_def()` in `runtime.py`. This change adds `retry_count` and `retry_delay_seconds` as optional parameters on the `@tool` decorator (Python and TypeScript SDKs), threads the values all the way through to the Conductor `TaskDef`, and preserves full backward compatibility (all new parameters default to `None`, so existing code is unaffected).

## Changes
- **`sdk/python/src/agentspan/agents/tool.py`** — Added `retry_count: Optional[int] = None` and `retry_delay_seconds: Optional[int] = None` fields to `ToolDef` dataclass; added matching parameters to all three `tool()` signatures (both `@overload`s and implementation); passed values through in `_wrap()` to the `ToolDef` constructor.
- **`sdk/python/src/agentspan/agents/runtime/runtime.py`** — Added `retry_count: int = 2` and `retry_delay_seconds: int = 2` keyword-only parameters to `_default_task_def()`; used them instead of hardcoded literals in `TaskDef` construction.
- **`sdk/python/src/agentspan/agents/runtime/tool_registry.py`** — Modified `register_tool_workers()` to build a `task_def_kwargs` dict from `td.retry_count` / `td.retry_delay_seconds` (using `is not None` checks to correctly handle `retry_count=0`) and pass `**task_def_kwargs` to `_default_task_def()`.
- **`sdk/typescript/src/types.ts`** — Added `retryCount?: number` and `retryDelaySeconds?: number` to the `ToolDef` interface.
- **`sdk/typescript/src/tool.ts`** — Added `retryCount` and `retryDelaySeconds` to `ToolOptions` interface and passed them through to the `ToolDef` in `tool()`.
- **`sdk/python/tests/unit/test_tool.py`** — Added `TestToolRetryConfig` class with 10 tests covering: default `None` values, setting each param individually, `retry_count=0` (disable retries), both params together, combined with other params, `_default_task_def` defaults and overrides, and `ToolRegistry` end-to-end wiring.

## Testing
All 70 unit tests in `sdk/python/tests/unit/test_tool.py` pass. The new `TestToolRetryConfig` class validates the full chain:

```
@tool decorator → ToolDef fields → _default_task_def kwargs → TaskDef attributes → ToolRegistry wiring
```

Key scenarios covered:
- Default `None` values preserve existing hardcoded defaults (backward compatible)
- `retry_count=0` correctly disables retries (handled with `is not None` checks)
- Both params can be set independently or together
- End-to-end wiring through `ToolRegistry` verified

## QA Evidence
See `qa-tests/issue-167/` for detailed test results and coverage.

<details>
<summary>Change Context (machine-readable)</summary>

```json
{"date": "2025-01-27", "issue_number": 167, "risks": "Low. All new parameters are Optional with None defaults — existing usage is fully backward compatible. retry_count=0 (disable retries) is handled correctly with is not None checks throughout.", "what_changed": [{"file": "sdk/python/src/agentspan/agents/tool.py", "change": "Added retry_count: Optional[int] = None and retry_delay_seconds: Optional[int] = None fields to ToolDef dataclass; added matching parameters to all three tool() signatures (both @overloads and implementation); passed values through in _wrap() to ToolDef constructor."}, {"file": "sdk/python/src/agentspan/agents/runtime/runtime.py", "change": "Added retry_count: int = 2 and retry_delay_seconds: int = 2 keyword-only parameters to _default_task_def(); used them instead of hardcoded literals in TaskDef construction."}, {"file": "sdk/python/src/agentspan/agents/runtime/tool_registry.py", "change": "Modified register_tool_workers() to build task_def_kwargs dict from td.retry_count / td.retry_delay_seconds (using is not None checks to preserve retry_count=0) and pass **task_def_kwargs to _default_task_def()."}, {"file": "sdk/typescript/src/types.ts", "change": "Added retryCount?: number and retryDelaySeconds?: number to ToolDef interface."}, {"file": "sdk/typescript/src/tool.ts", "change": "Added retryCount and retryDelaySeconds to ToolOptions interface and passed them through to the ToolDef in tool()."}, {"file": "sdk/python/tests/unit/test_tool.py", "change": "Added TestToolRetryConfig class with 10 tests covering: default None values, setting each param individually, retry_count=0, both params together, combined with other params, _default_task_def defaults and overrides, and ToolRegistry end-to-end wiring."}], "author": "agentspan-bot", "testing": "All 70 unit tests in sdk/python/tests/unit/test_tool.py pass. New TestToolRetryConfig class validates the full chain from @tool decorator -> ToolDef fields -> _default_task_def kwargs -> TaskDef attributes -> ToolRegistry wiring.", "issue_title": "Allow retry configuration on @tool decorator", "change_type": "feature", "related_issues": [], "root_cause": "The @tool decorator did not accept retry_count or retry_delay_seconds parameters. ToolDef dataclass had no such fields, _default_task_def() had hardcoded retry_count=2 and retry_delay_seconds=2, and tool_registry.py always called _default_task_def(td.name) with no overrides — so user-specified retry values had no path to reach Conductor."}
```

</details>