### PR TITLE
fix(windows): resolve all Windows compatibility issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,24 @@ jobs:
       - name: Run CLI tests
         run: go test ./... -count=1 -race
 
+  # ── Go CLI Tests (Windows) ───────────────────────────────────────
+  cli-tests-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+      - name: Run CLI tests
+        run: go test ./... -count=1
+
   # ── Python SDK Unit Tests ──────────────────────────────────────────
   python-unit-tests:
     runs-on: ubuntu-latest

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -28,7 +28,8 @@ echo "  Built: windows/amd64"
 GOOS=windows GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/agentspan_windows_arm64.exe .
 echo "  Built: windows/arm64"
 
-chmod +x dist/agentspan_*
+# Make Unix binaries executable (Windows .exe files are already executable).
+find dist/ -type f ! -name "*.exe" -exec chmod +x {} +
 
 echo ""
 echo "Build complete! Binaries in dist/"

--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -206,7 +207,11 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// JAVA_HOME check
 	javaHome := os.Getenv("JAVA_HOME")
 	if javaHome != "" {
-		if _, err := os.Stat(filepath.Join(javaHome, "bin", "java")); err != nil {
+		javaBin := "java"
+		if runtime.GOOS == "windows" {
+			javaBin = "java.exe"
+		}
+		if _, err := os.Stat(filepath.Join(javaHome, "bin", javaBin)); err != nil {
 			yellow.Println("  ⚠ JAVA_HOME is set but java binary not found there")
 			fmt.Printf("    JAVA_HOME=%s\n", javaHome)
 			issues++

--- a/cli/cmd/skill.go
+++ b/cli/cmd/skill.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -391,15 +392,17 @@ func executeScript(scriptPath, language, command string) (interface{}, error) {
 	var cmd *exec.Cmd
 	switch language {
 	case "python":
-		cmd = exec.Command("python3", scriptPath, command)
+		cmd = buildPythonCmd(scriptPath, command)
 	case "node":
 		cmd = exec.Command("node", scriptPath, command)
 	case "ruby":
 		cmd = exec.Command("ruby", scriptPath, command)
 	case "go":
 		cmd = exec.Command("go", "run", scriptPath, command)
-	default: // bash
-		cmd = exec.Command("bash", scriptPath, command)
+	case "batch":
+		cmd = exec.Command("cmd", "/c", scriptPath, command)
+	default: // bash/shell
+		cmd = buildShellCmd(scriptPath, command)
 	}
 
 	out, err := cmd.CombinedOutput()
@@ -407,6 +410,28 @@ func executeScript(scriptPath, language, command string) (interface{}, error) {
 		return string(out), fmt.Errorf("script failed: %w\n%s", err, string(out))
 	}
 	return string(out), nil
+}
+
+// buildPythonCmd returns a command to run a Python script.
+// Tries python3 first, falls back to python (Windows ships python, not python3).
+func buildPythonCmd(scriptPath, command string) *exec.Cmd {
+	py := "python3"
+	if _, err := exec.LookPath("python3"); err != nil {
+		py = "python"
+	}
+	return exec.Command(py, scriptPath, command)
+}
+
+// buildShellCmd returns a command to run a shell/bash script.
+// On Windows, tries bash (Git Bash / WSL) and falls back to cmd /c.
+func buildShellCmd(scriptPath, command string) *exec.Cmd {
+	if runtime.GOOS != "windows" {
+		return exec.Command("bash", scriptPath, command)
+	}
+	if _, err := exec.LookPath("bash"); err == nil {
+		return exec.Command("bash", scriptPath, command)
+	}
+	return exec.Command("cmd", "/c", scriptPath, command)
 }
 
 // ── Skill Directory Reading ─────────────────────────────────────────────────
@@ -607,6 +632,8 @@ func detectScriptLanguage(filename string) string {
 		return "python"
 	case ".sh":
 		return "bash"
+	case ".bat", ".cmd":
+		return "batch"
 	case ".js", ".mjs":
 		return "node"
 	case ".ts":

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -39,7 +39,8 @@ func TestIsLocalhost(t *testing.T) {
 
 func TestAPIKeyRoundTrip(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	t.Setenv("HOME", dir)        // Unix
+	t.Setenv("USERPROFILE", dir) // Windows
 	t.Setenv("AGENTSPAN_API_KEY", "")
 
 	cfg := config.DefaultConfig()
@@ -69,7 +70,8 @@ func TestAPIKeyRoundTrip(t *testing.T) {
 
 func TestAPIKeyClearedOnLogout(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	t.Setenv("HOME", dir)        // Unix
+	t.Setenv("USERPROFILE", dir) // Windows
 	t.Setenv("AGENTSPAN_API_KEY", "")
 
 	cfg := config.DefaultConfig()

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -1,15 +1,18 @@
 .PHONY: test test-unit test-integration examples examples-all lint typecheck format all validate validate-slow validate-judge validate-all
 
+# Use python3 when available, fall back to python (Windows).
+PYTHON ?= $(shell python3 --version >/dev/null 2>&1 && echo python3 || echo python)
+
 all: lint typecheck test
 
 test:
-	python3 -m pytest tests/unit/ -v --cov --cov-report=term-missing
+	$(PYTHON) -m pytest tests/unit/ -v --cov --cov-report=term-missing
 
 test-unit:
-	python3 -m pytest tests/unit/ -v
+	$(PYTHON) -m pytest tests/unit/ -v
 
 test-integration:
-	python3 -m pytest tests/integration/ -v
+	$(PYTHON) -m pytest tests/integration/ -v
 
 examples:
 	@./scripts/run_examples.sh
@@ -27,9 +30,9 @@ format:
 	ruff format src/ tests/
 
 validate:
-	python3 -m validation.scripts.run_examples
+	$(PYTHON) -m validation.scripts.run_examples
 
 validate-judge:
-	python3 -m validation.scripts.judge_results
+	$(PYTHON) -m validation.scripts.judge_results
 
 validate-all: validate validate-judge

--- a/sdk/python/scripts/run_examples.sh
+++ b/sdk/python/scripts/run_examples.sh
@@ -18,6 +18,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 EXAMPLES_DIR="$(cd "$SCRIPT_DIR/../examples" && pwd)"
 TIMEOUT="${EXAMPLE_TIMEOUT:-300}"
 
+# Cross-platform python: honour PYTHON env var, then try python3, then python.
+PYTHON="${PYTHON:-$(command -v python3 2>/dev/null || command -v python 2>/dev/null || echo python3)}"
+
+# Cross-platform temp dir: honour TMPDIR (set on macOS/Linux), fall back to /tmp.
+TMP_BASE="${TMPDIR:-${TEMP:-/tmp}}"
+
 # Examples that require external services not typically available in a
 # standard test environment.
 SKIP_BY_DEFAULT=(
@@ -119,7 +125,7 @@ for example in "${EXAMPLES[@]}"; do
     name="$(basename "$example" .py)"
     printf "%-45s " "$name"
 
-    LOG_FILE=$(mktemp "/tmp/example-${name}-XXXXXX")
+    LOG_FILE=$(mktemp "${TMP_BASE}/example-${name}-XXXXXX")
 
     START_TIME=$(date +%s)
 
@@ -135,9 +141,9 @@ for example in "${EXAMPLES[@]}"; do
     if [[ -n "$STDIN_RESPONSE" ]]; then
         # Use `yes` to provide unlimited identical responses — handles
         # cases where the LLM calls an approval tool multiple times.
-        RUN_CMD="yes '$STDIN_RESPONSE' | timeout $TIMEOUT python3 $example"
+        RUN_CMD="yes '$STDIN_RESPONSE' | timeout $TIMEOUT $PYTHON $example"
     else
-        RUN_CMD="timeout $TIMEOUT python3 $example"
+        RUN_CMD="timeout $TIMEOUT $PYTHON $example"
     fi
 
     if eval "$RUN_CMD" > "$LOG_FILE" 2>&1; then
@@ -210,7 +216,7 @@ if [[ ${#FAILED[@]} -gt 0 ]]; then
             if [[ -n "$WF_ID" && -n "${AGENTSPAN_SERVER_URL:-}" ]]; then
                 echo "  Workflow: $WF_ID"
                 # Use the SDK's own client so auth (key/secret → token) is handled
-                WF_INFO=$(python3 -c "
+                WF_INFO=$($PYTHON -c "
 import os, json
 try:
     from agentspan.agents.runtime.config import AgentConfig
@@ -240,11 +246,11 @@ try:
 except Exception as e:
     print(json.dumps({'error': str(e)}))
 " 2>/dev/null || echo '{"error":"query failed"}')
-                WF_STATUS=$(echo "$WF_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
-                WF_REASON=$(echo "$WF_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('reason',''))" 2>/dev/null || true)
-                WF_FAILED_TASKS=$(echo "$WF_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('failed_tasks',''))" 2>/dev/null || true)
-                WF_TASK_REASON=$(echo "$WF_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('task_reason',''))" 2>/dev/null || true)
-                WF_ERROR=$(echo "$WF_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error',''))" 2>/dev/null || true)
+                WF_STATUS=$(echo "$WF_INFO" | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
+                WF_REASON=$(echo "$WF_INFO" | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('reason',''))" 2>/dev/null || true)
+                WF_FAILED_TASKS=$(echo "$WF_INFO" | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('failed_tasks',''))" 2>/dev/null || true)
+                WF_TASK_REASON=$(echo "$WF_INFO" | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('task_reason',''))" 2>/dev/null || true)
+                WF_ERROR=$(echo "$WF_INFO" | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('error',''))" 2>/dev/null || true)
 
                 if [[ -n "$WF_ERROR" ]]; then
                     echo "  (could not query Conductor: $WF_ERROR)"
@@ -261,7 +267,7 @@ except Exception as e:
         fi
     done
     echo ""
-    echo "Logs preserved in /tmp/example-*"
+    echo "Logs preserved in ${TMP_BASE}/example-*"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- **`cli/cmd/doctor.go`**: Fix `JAVA_HOME` validation checking for `java` (Unix) instead of `java.exe` on Windows — caused a false warning even with a valid Java installation
- **`cli/cmd/skill.go`**: `python3` now falls back to `python` (Windows ships `python`, not `python3`); shell scripts try `bash` first (Git Bash) then fall back to `cmd /c`; added `.bat`/`.cmd` support as `batch` language via `cmd /c`
- **`cli/build.sh`**: `chmod +x` now skips `.exe` files using `find ... ! -name *.exe`
- **`sdk/python/Makefile`**: Added `PYTHON ?= python3 || python` variable used throughout
- **`sdk/python/scripts/run_examples.sh`**: Replaced hardcoded `python3` with `$PYTHON`; replaced hardcoded `/tmp` with `$TMP_BASE`
- **`.github/workflows/ci.yml`**: Added `cli-tests-windows` job on `windows-latest` to catch Windows regressions in CI

## Test plan

- [x] `go build ./...` passes (verified locally on Windows)
- [x] All `cli/cmd` unit tests pass on Windows (verified locally)
- [x] `agentspan doctor` shows `✓ Java 21` with no false JAVA_HOME warning on Windows
- [ ] CI `cli-tests-windows` job passes on `windows-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)