### PR TITLE
fix(ts-sdk): replace module-level credential singleton with AsyncLocalStorage

### DIFF
--- a/sdk/typescript/src/credentials.ts
+++ b/sdk/typescript/src/credentials.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   CredentialNotFoundError,
   CredentialAuthError,
@@ -5,7 +6,7 @@ import {
   CredentialServiceError,
 } from "./errors.js";
 
-// ── Module-level credential context ──────────────────────
+// ── Credential context ────────────────────────────────────
 
 interface CredentialContext {
   serverUrl: string;
@@ -13,11 +14,30 @@ interface CredentialContext {
   executionToken: string;
 }
 
+// AsyncLocalStorage provides per-execution isolation — concurrent workers in the
+// same Node.js process each see their own context without overwriting each other.
+const _credentialStorage = new AsyncLocalStorage<CredentialContext>();
+
+// Module-level singleton kept for backward compatibility with setCredentialContext()
+// callers (e.g. unit tests). Worker execution should use runWithCredentialContext().
 let _credentialContext: CredentialContext | null = null;
 
 /**
+ * Run fn in an isolated async context with its own credential context.
+ * Preferred over setCredentialContext() for concurrent worker execution.
+ */
+export function runWithCredentialContext<T>(
+  serverUrl: string,
+  headers: Record<string, string>,
+  executionToken: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return _credentialStorage.run({ serverUrl, headers, executionToken }, fn);
+}
+
+/**
  * Set the module-level credential context for getCredential().
- * Called by the worker before tool execution.
+ * @deprecated Prefer runWithCredentialContext() for concurrent-safe execution.
  */
 export function setCredentialContext(
   serverUrl: string,
@@ -29,7 +49,7 @@ export function setCredentialContext(
 
 /**
  * Clear the module-level credential context.
- * Called after tool execution completes.
+ * @deprecated Paired with the deprecated setCredentialContext().
  */
 export function clearCredentialContext(): void {
   _credentialContext = null;
@@ -166,13 +186,16 @@ export async function resolveCredentials(
  * Throws if no context is set (i.e., not called during worker execution).
  */
 export async function getCredential(name: string): Promise<string> {
-  if (!_credentialContext) {
+  // AsyncLocalStorage context takes priority (set via runWithCredentialContext).
+  // Falls back to module-level singleton for backward-compatible callers.
+  const ctx = _credentialStorage.getStore() ?? _credentialContext;
+  if (!ctx) {
     throw new CredentialAuthError(
       "No credential context available. getCredential() must be called during worker execution.",
     );
   }
 
-  const { serverUrl, headers, executionToken } = _credentialContext;
+  const { serverUrl, headers, executionToken } = ctx;
   const resolved = await resolveCredentials(serverUrl, headers, executionToken, [name]);
 
   const value = resolved[name];

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -146,6 +146,7 @@ export {
   extractExecutionToken,
   resolveCredentials,
   getCredential,
+  runWithCredentialContext,
   setCredentialContext,
   clearCredentialContext,
   injectCredentials,

--- a/sdk/typescript/src/worker.ts
+++ b/sdk/typescript/src/worker.ts
@@ -4,8 +4,7 @@ import type { ToolContext } from "./types.js";
 import { TerminalToolError } from "./errors.js";
 import {
   extractExecutionToken,
-  setCredentialContext,
-  clearCredentialContext,
+  runWithCredentialContext,
   resolveCredentials,
   injectCredentials,
 } from "./credentials.js";
@@ -343,60 +342,65 @@ export class WorkerManager {
         cleaned["__workflowInstanceId__"] = task.workflowInstanceId;
         if (toolContext) cleaned["__toolContext__"] = toolContext;
 
-        // Credential setup
         const execToken = extractExecutionToken(inputData);
-        if (execToken) setCredentialContext(mgr.serverUrl, mgr.headers, execToken);
 
-        let cleanupCreds: (() => void) | null = null;
-        if (pw.credentials?.length) {
-          if (!execToken) {
-            throw new NonRetryableException(
-              `Required credentials not found: ${pw.credentials.join(", ")}. ` +
-                `No execution token available.`,
-            );
+        const executeHandler = async (): Promise<Omit<TaskResult, "workflowInstanceId" | "taskId">> => {
+          let cleanupCreds: (() => void) | null = null;
+          if (pw.credentials?.length) {
+            if (!execToken) {
+              throw new NonRetryableException(
+                `Required credentials not found: ${pw.credentials.join(", ")}. ` +
+                  `No execution token available.`,
+              );
+            }
+            try {
+              const resolved = await resolveCredentials(
+                mgr.serverUrl,
+                mgr.headers,
+                execToken,
+                pw.credentials,
+              );
+              cleanupCreds = injectCredentials(mgr.serverUrl, mgr.headers, execToken, resolved);
+            } catch (err) {
+              throw new NonRetryableException(
+                `Credential resolution failed for ${pw.taskName}: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
           }
+
           try {
-            const resolved = await resolveCredentials(
-              mgr.serverUrl,
-              mgr.headers,
-              execToken,
-              pw.credentials,
-            );
-            cleanupCreds = injectCredentials(mgr.serverUrl, mgr.headers, execToken, resolved);
-          } catch (err) {
-            throw new NonRetryableException(
-              `Credential resolution failed for ${pw.taskName}: ${err instanceof Error ? err.message : String(err)}`,
-            );
+            let result = await pw.handler(cleaned);
+
+            // State mutation capture
+            if (toolContext) {
+              const updates = captureStateMutations(stateSnapshot, toolContext.state);
+              if (updates) result = appendStateUpdates(result, updates);
+            }
+
+            // Wrap primitives — conductor expects outputData as an object
+            const outputData =
+              result != null && typeof result === "object" && !Array.isArray(result)
+                ? (result as Record<string, unknown>)
+                : { result };
+
+            recordSuccess(pw.taskName);
+            return { status: "COMPLETED", outputData };
+          } catch (error) {
+            recordFailure(pw.taskName);
+            if (error instanceof TerminalToolError) {
+              throw new NonRetryableException(error.message);
+            }
+            throw error;
+          } finally {
+            cleanupCreds?.();
           }
-        }
+        };
 
-        try {
-          let result = await pw.handler(cleaned);
-
-          // State mutation capture
-          if (toolContext) {
-            const updates = captureStateMutations(stateSnapshot, toolContext.state);
-            if (updates) result = appendStateUpdates(result, updates);
-          }
-
-          // Wrap primitives — conductor expects outputData as an object
-          const outputData =
-            result != null && typeof result === "object" && !Array.isArray(result)
-              ? (result as Record<string, unknown>)
-              : { result };
-
-          recordSuccess(pw.taskName);
-          return { status: "COMPLETED", outputData };
-        } catch (error) {
-          recordFailure(pw.taskName);
-          if (error instanceof TerminalToolError) {
-            throw new NonRetryableException(error.message);
-          }
-          throw error;
-        } finally {
-          cleanupCreds?.();
-          if (execToken) clearCredentialContext();
-        }
+        // Each tool execution runs in its own async context so concurrent workers
+        // cannot overwrite each other's credential context (fixes module-singleton race).
+        return execToken
+          ? runWithCredentialContext(mgr.serverUrl, mgr.headers, execToken, executeHandler)
+          : executeHandler();
       },
     };
   }


### PR DESCRIPTION
## Root cause

`sdk/typescript/src/worker.ts` used a module-level `_credentialContext` singleton written by `setCredentialContext()`. Vitest runs all e2e test files concurrently in the same Node.js process. When Suite 8/15/18 tool workers called `setCredentialContext` with their execution tokens, they overwrote Suite 2's context window. When Suite 2's `getCredential()` then executed, it held the wrong execution token → server returned 404 → `paid_tool_a` / `paid_tool_b` tasks failed with FAILED_WITH_TERMINAL_ERROR → `[With creds] paid_tool_a should be COMPLETED` assertion failed.

This is the root cause of the long-standing flakiness in `test_suite2_tool_calling`.

## Fix

Replace the module-level singleton with `AsyncLocalStorage.run()`. Each tool execution now runs inside its own async context — concurrent workers cannot clobber each other's credential state regardless of how vitest parallelises them.

`setCredentialContext` / `clearCredentialContext` are kept as backward-compatible shims (still used by unit tests); `getCredential()` prefers the `AsyncLocalStorage` store and falls back to the singleton for callers that haven't migrated.

## Test plan

- [ ] CI: `test_suite2_tool_calling` passes reliably (no more singleton race)
- [ ] Existing unit tests for `getCredential` continue to pass (backward-compat shims preserved)
- [ ] No other e2e suites regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)