### PR TITLE
docs(readme): add star callout and mark Windows support as coming soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 
 ---
 
+> ⭐ If you find Agentspan useful, [give us a star](https://github.com/agentspan-ai/agentspan) — it helps others find the project!
+
+---
+
 **Agentspan** is a distributed, durable runtime for AI agents that survive crashes, scale across machines, and pause for human approval for days — not minutes.
 
 ## Quickstart (60 seconds)
@@ -34,10 +38,9 @@
 ```bash
 # macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/agentspan-ai/agentspan/main/cli/install.sh | sh
-
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/agentspan-ai/agentspan/main/cli/install.ps1 | iex
 ```
+
+> **Windows support — coming soon.**
 ## Install SDKs
 ```bash
 # Python
@@ -74,9 +77,6 @@ Open `http://localhost:6767` to see the visual execution UI.
 ```bash
 # npm
 npm install -g @agentspan-ai/agentspan
-
-# Windows — CMD / double-click
-curl -fsSL https://raw.githubusercontent.com/agentspan-ai/agentspan/main/cli/install.bat -o install.bat && install.bat
 
 # From source
 cd cli && go build -o agentspan .

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@
 ```bash
 # macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/agentspan-ai/agentspan/main/cli/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/agentspan-ai/agentspan/main/cli/install.ps1 | iex
 ```
 
-> **Windows support — coming soon.**
 ## Install SDKs
 ```bash
 # Python
@@ -77,6 +79,9 @@ Open `http://localhost:6767` to see the visual execution UI.
 ```bash
 # npm
 npm install -g @agentspan-ai/agentspan
+
+# Windows — CMD / double-click
+curl -fsSL https://raw.githubusercontent.com/agentspan-ai/agentspan/main/cli/install.bat -o install.bat && install.bat
 
 # From source
 cd cli && go build -o agentspan .

--- a/cli/README.md
+++ b/cli/README.md
@@ -243,7 +243,7 @@ See [examples/](examples/) for more samples.
 |----|-------------|
 | macOS | x86_64, ARM64 (Apple Silicon) |
 | Linux | x86_64, ARM64 |
-| Windows | coming soon |
+| Windows | x86_64, ARM64 |
 
 ## Development
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -243,7 +243,7 @@ See [examples/](examples/) for more samples.
 |----|-------------|
 | macOS | x86_64, ARM64 (Apple Silicon) |
 | Linux | x86_64, ARM64 |
-| Windows | x86_64, ARM64 |
+| Windows | coming soon |
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Adds a star callout after the badges section to encourage community engagement
- Removes Windows install instructions and replaces with "coming soon" note

## Changes
- Star callout: `⭐ If you find Agentspan useful, give us a star`
- Removed PowerShell and CMD Windows install lines
- Added `> **Windows support — coming soon.**`