### PR TITLE
fix(ts-sdk): Credential context race condition under concurrent tool workers

### DIFF
--- a/sdk/typescript/src/credentials.ts
+++ b/sdk/typescript/src/credentials.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import {
   CredentialNotFoundError,
   CredentialAuthError,
@@ -5,7 +7,7 @@ import {
   CredentialServiceError,
 } from "./errors.js";
 
-// ── Module-level credential context ──────────────────────
+// ── Per-async-call credential context ────────────────────
 
 interface CredentialContext {
   serverUrl: string;
@@ -13,26 +15,52 @@ interface CredentialContext {
   executionToken: string;
 }
 
-let _credentialContext: CredentialContext | null = null;
+// AsyncLocalStorage scopes context per async-call chain so concurrent worker
+// handlers each see their own credentials instead of clobbering a shared global.
+const _credentialStore = new AsyncLocalStorage<CredentialContext>();
+
+// Fallback used by setCredentialContext() — kept for callers that can't run
+// inside runWithCredentialContext(). Reads always prefer the ALS store.
+let _fallbackContext: CredentialContext | null = null;
+
+function activeContext(): CredentialContext | null {
+  return _credentialStore.getStore() ?? _fallbackContext;
+}
 
 /**
- * Set the module-level credential context for getCredential().
- * Called by the worker before tool execution.
+ * Run `fn` with the given credential context active in AsyncLocalStorage.
+ * Concurrent calls each see their own context — sibling cleanups can't clobber it.
+ */
+export function runWithCredentialContext<T>(
+  serverUrl: string,
+  headers: Record<string, string>,
+  executionToken: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return _credentialStore.run({ serverUrl, headers, executionToken }, fn);
+}
+
+/**
+ * Set a fallback credential context for getCredential().
+ *
+ * Prefer {@link runWithCredentialContext} — it scopes context per async call
+ * and is safe under concurrent workers. setCredentialContext writes to a
+ * shared module-level slot and is only consulted when no ALS context is
+ * active; sibling clears can race with concurrent reads.
  */
 export function setCredentialContext(
   serverUrl: string,
   headers: Record<string, string>,
   executionToken: string,
 ): void {
-  _credentialContext = { serverUrl, headers, executionToken };
+  _fallbackContext = { serverUrl, headers, executionToken };
 }
 
 /**
- * Clear the module-level credential context.
- * Called after tool execution completes.
+ * Clear the fallback credential context. Does not affect ALS-scoped contexts.
  */
 export function clearCredentialContext(): void {
-  _credentialContext = null;
+  _fallbackContext = null;
 }
 
 // ── Execution token extraction ───────────────────────────
@@ -162,17 +190,19 @@ export async function resolveCredentials(
 /**
  * Resolve a single credential by name.
  *
- * Uses the module-level credential context set by setCredentialContext().
+ * Uses the active credential context (per-async via {@link runWithCredentialContext},
+ * falling back to {@link setCredentialContext} for legacy callers).
  * Throws if no context is set (i.e., not called during worker execution).
  */
 export async function getCredential(name: string): Promise<string> {
-  if (!_credentialContext) {
+  const ctx = activeContext();
+  if (!ctx) {
     throw new CredentialAuthError(
       "No credential context available. getCredential() must be called during worker execution.",
     );
   }
 
-  const { serverUrl, headers, executionToken } = _credentialContext;
+  const { serverUrl, headers, executionToken } = ctx;
   const resolved = await resolveCredentials(serverUrl, headers, executionToken, [name]);
 
   const value = resolved[name];

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -147,6 +147,7 @@ export {
   resolveCredentials,
   getCredential,
   setCredentialContext,
+  runWithCredentialContext,
   clearCredentialContext,
   injectCredentials,
 } from "./credentials.js";

--- a/sdk/typescript/src/worker.ts
+++ b/sdk/typescript/src/worker.ts
@@ -4,10 +4,9 @@ import type { ToolContext } from "./types.js";
 import { TerminalToolError } from "./errors.js";
 import {
   extractExecutionToken,
-  setCredentialContext,
-  clearCredentialContext,
   resolveCredentials,
   injectCredentials,
+  runWithCredentialContext,
 } from "./credentials.js";
 
 // ── Type coercion (base spec §14.1) ─────────────────────
@@ -345,7 +344,6 @@ export class WorkerManager {
 
         // Credential setup
         const execToken = extractExecutionToken(inputData);
-        if (execToken) setCredentialContext(mgr.serverUrl, mgr.headers, execToken);
 
         let cleanupCreds: (() => void) | null = null;
         if (pw.credentials?.length) {
@@ -370,33 +368,44 @@ export class WorkerManager {
           }
         }
 
-        try {
-          let result = await pw.handler(cleaned);
+        const runHandler = async (): Promise<
+          Omit<TaskResult, "workflowInstanceId" | "taskId">
+        > => {
+          try {
+            let result = await pw.handler(cleaned);
 
-          // State mutation capture
-          if (toolContext) {
-            const updates = captureStateMutations(stateSnapshot, toolContext.state);
-            if (updates) result = appendStateUpdates(result, updates);
+            // State mutation capture
+            if (toolContext) {
+              const updates = captureStateMutations(stateSnapshot, toolContext.state);
+              if (updates) result = appendStateUpdates(result, updates);
+            }
+
+            // Wrap primitives — conductor expects outputData as an object
+            const outputData =
+              result != null && typeof result === "object" && !Array.isArray(result)
+                ? (result as Record<string, unknown>)
+                : { result };
+
+            recordSuccess(pw.taskName);
+            return { status: "COMPLETED", outputData };
+          } catch (error) {
+            recordFailure(pw.taskName);
+            if (error instanceof TerminalToolError) {
+              throw new NonRetryableException(error.message);
+            }
+            throw error;
+          } finally {
+            cleanupCreds?.();
           }
+        };
 
-          // Wrap primitives — conductor expects outputData as an object
-          const outputData =
-            result != null && typeof result === "object" && !Array.isArray(result)
-              ? (result as Record<string, unknown>)
-              : { result };
-
-          recordSuccess(pw.taskName);
-          return { status: "COMPLETED", outputData };
-        } catch (error) {
-          recordFailure(pw.taskName);
-          if (error instanceof TerminalToolError) {
-            throw new NonRetryableException(error.message);
-          }
-          throw error;
-        } finally {
-          cleanupCreds?.();
-          if (execToken) clearCredentialContext();
+        // Scope credential context per-async-call so concurrent workers do not
+        // share (and clobber) module-level state. Runs even without an exec
+        // token so handlers see a consistent context shape.
+        if (execToken) {
+          return runWithCredentialContext(mgr.serverUrl, mgr.headers, execToken, runHandler);
         }
+        return runHandler();
       },
     };
   }

--- a/sdk/typescript/tests/unit/credentials.test.ts
+++ b/sdk/typescript/tests/unit/credentials.test.ts
@@ -5,6 +5,7 @@ import {
   getCredential,
   setCredentialContext,
   clearCredentialContext,
+  runWithCredentialContext,
   injectCredentials,
 } from "../../src/credentials.js";
 import {
@@ -367,6 +368,55 @@ describe("injectCredentials", () => {
 
     vi.restoreAllMocks();
   });
+
+  it.each([1, 2, 3])(
+    "runWithCredentialContext isolates concurrent executions (run %i)",
+    async () => {
+      // Reproduce the worker race that breaks test_suite2_tool_calling:
+      //   1. Worker A enters context, starts handler.
+      //   2. Worker B enters context, finishes, exits.
+      //   3. Worker A's handler later calls getCredential — without per-async
+      //      isolation, B's exit nulled A's context and getCredential throws.
+      // Test re-runs (1-3) to surface scheduling-dependent regressions.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(async (_url, init: RequestInit) => {
+          const body = JSON.parse(String(init.body));
+          // Echo the token back in the resolved value so we can verify isolation.
+          const result: Record<string, string> = {};
+          for (const n of body.names) result[n] = `${body.token}:${n}`;
+          return { ok: true, json: async () => result };
+        }),
+      );
+
+      async function workerHandler(execToken: string, delayMs: number) {
+        return runWithCredentialContext(serverUrl, headers, execToken, async () => {
+          await new Promise((r) => setTimeout(r, delayMs));
+          return getCredential("MY_KEY");
+        });
+      }
+
+      // 5 overlapping workers — each must resolve with its own token even though
+      // siblings enter/exit their contexts during this one's handler.
+      const results = await Promise.all([
+        workerHandler("tok-A", 30),
+        workerHandler("tok-B", 5),
+        workerHandler("tok-C", 20),
+        workerHandler("tok-D", 10),
+        workerHandler("tok-E", 15),
+      ]);
+
+      expect(results).toEqual([
+        "tok-A:MY_KEY",
+        "tok-B:MY_KEY",
+        "tok-C:MY_KEY",
+        "tok-D:MY_KEY",
+        "tok-E:MY_KEY",
+      ]);
+
+      vi.restoreAllMocks();
+    },
+  );
 
   it("isolated mode explicitly set to true works same as default", () => {
     const creds = { TEST_CRED_A: "val-a" };

--- a/sdk/typescript/tests/unit/worker.test.ts
+++ b/sdk/typescript/tests/unit/worker.test.ts
@@ -599,6 +599,82 @@ describe("WorkerManager", () => {
       await expect(getCredential("ANY")).rejects.toThrow("No credential context available");
     });
 
+    it("isolates credential context across concurrent worker executions (regression: race in test_suite2)", async () => {
+      // Reproduces the test_suite2_tool_calling flake deterministically:
+      // The LLM emits parallel tool calls, so multiple worker.execute()
+      // run concurrently. Pre-fix, all share a single module-level
+      // credential context. Worker B's `finally`-block clear races with
+      // worker A's getCredential() call, throwing
+      // "No credential context available".
+      //
+      // We force the race by gating each handler on a barrier so all
+      // handlers are mid-flight at the same time, then have each call
+      // getCredential() and verify each got *its own* execution token's
+      // resolved value back.
+      const serverUrl = "http://cred-race";
+      const manager = new WorkerManager(serverUrl, {}, 100);
+
+      const NUM = 5;
+      const barrier = new Promise<void>((resolve) => {
+        let arrived = 0;
+        manager.addWorker(
+          "race_task",
+          async () => {
+            arrived++;
+            // Wait until all handlers are running concurrently.
+            if (arrived === NUM) resolve();
+            await barrierGate;
+            const { getCredential } = await import("../../src/credentials.js");
+            return { value: await getCredential("MY_CRED") };
+          },
+          undefined,
+        );
+        // Build the gate via a sentinel resolved after all arrive.
+        // The actual barrier the handlers await:
+      });
+      // Bridge: when `barrier` (all-arrived) resolves, open the gate.
+      let openGate!: () => void;
+      const barrierGate = new Promise<void>((res) => {
+        openGate = res;
+      });
+      void barrier.then(() => openGate());
+
+      // Echo the token back as the resolved value so we can detect crosstalk.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+          if (typeof url === "string" && url.includes("/credentials/resolve")) {
+            const body = JSON.parse(String(init?.body));
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({ MY_CRED: `${body.token}:resolved` }),
+            };
+          }
+          return { ok: true, status: 200, text: async () => "" };
+        }),
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wrapped = (manager as any)._wrapWorker((manager as any).pendingWorkers[0]);
+
+      const tasks = Array.from({ length: NUM }, (_, i) => ({
+        taskId: `task-${i}`,
+        workflowInstanceId: "wf-1",
+        inputData: {
+          __agentspan_ctx__: { executionToken: `tok-${i}` },
+        },
+      }));
+
+      const results = await Promise.all(tasks.map((t) => wrapped.execute(t)));
+
+      // Each handler must see its own execution token, end to end —
+      // no nulls, no crosstalk between concurrent calls.
+      for (let i = 0; i < NUM; i++) {
+        expect(results[i].outputData).toEqual({ value: `tok-${i}:resolved` });
+      }
+    });
+
     it("does not set credential context when no execution token", async () => {
       const manager = new WorkerManager("http://test", {}, 100);
 


### PR DESCRIPTION
# Summary

Concurrent tool workers clobber a shared `_credentialContext` singleton, causing `getCredential()` to see a null context and silently fail, resulting in `FAILED` tasks even when credentials are correctly set.

- `_credentialContext` is a module-level global — shared across all async worker executions
- A sibling worker's `clearCredentialContext()` in its `finally` block races with another worker's `getCredential()` call
- `getCredential()` throws `CredentialAuthError`, tool catches it silently, re-throws plain `Error` → Conductor marks task `FAILED`

```
time ──────────────────────────────────────────────────────────────►

paid_tool_a:  setCtx(A) ──── resolveCredentials ──── getCredential()❌
                                                           ▲
free_tool:                        setCtx(F) ── clearCtx() ┘
                                                (nulls shared global)
```

# How to Reproduce

Run e2e suite 2 (`test_suite2_tool_calling.test.ts`) with a live server. The agent uses 3 tools concurrently: `free_tool`, `paid_tool_a`, `paid_tool_b`. In Step 4 (credentials set via CLI), `paid_tool_a` or `paid_tool_b` intermittently returns `FAILED` instead of `COMPLETED`. Failure rate increases with faster Conductor poll intervals or more concurrent agents.

Race sequence:
1. `paid_tool_a` worker: `setCredentialContext(execToken_A)`
2. `free_tool` worker: `clearCredentialContext()` in `finally` (nulls shared global)
3. `paid_tool_a` tool handler: `getCredential(CRED_A)` → `_credentialContext` is `null` → throws
4. Tool silently catches → `cred` undefined → throws plain `Error` → task `FAILED`

# Changes

**`src/credentials.ts`**
- Replace `let _credentialContext` singleton with `AsyncLocalStorage<CredentialContext>`
- Add `runWithCredentialContext(serverUrl, headers, token, fn)` — runs `fn` inside an ALS-scoped context; concurrent callers each see their own store
- Keep `setCredentialContext`/`clearCredentialContext` as a legacy fallback; `activeContext()` prefers ALS over the fallback slot

**`src/worker.ts`**
- Remove `setCredentialContext`/`clearCredentialContext` calls from `_wrapWorker`
- Wrap the handler invocation in `runWithCredentialContext()` so each worker's async call chain has an isolated credential context
- Move `cleanupCreds?.()` into the inner `runHandler` closure's `finally`

# Test Plan

- [ ] Run `tests/e2e/test_suite2_tool_calling.test.ts` — full credential lifecycle test passes consistently (was flaky before)
- [ ] Run `npm test` — all unit tests pass, no regressions
- [ ] Manually verify: `getCredential()` resolves correctly when 3 tools execute concurrently against a live server
- [ ] Verify legacy path: `setCredentialContext`/`clearCredentialContext` still work for callers outside `runWithCredentialContext` (no ALS context active)
