### PR TITLE
feat(java): synthesize flag + e2e parity

### DIFF
--- a/e2e/mutation_test_java.sh
+++ b/e2e/mutation_test_java.sh
@@ -255,6 +255,39 @@ run_mutation \
     "E2eSuite9CodeExecution#test_local_bash_execution" \
     "test"
 
+# ── Suite 10 — Synthesize flag mutations ──────────────────────────
+
+# Mutation 17: Suite10 SDK — synthesize field never sent to server (AgentConfigSerializer)
+# Commenting out agentMap.put("synthesize", false) means the server never receives the flag
+# → server defaults to doSynthesize=true → adds _final task → finalCount == 1 AND
+# agentDef.synthesize == null (not false) → assertEquals(Boolean.FALSE, null) fails → KILLED.
+run_mutation \
+    "Suite10 SDK: agentMap.put('synthesize', false) removed (AgentConfigSerializer)" \
+    "$JAVA_SDK/src/main/java/dev/agentspan/internal/AgentConfigSerializer.java" \
+    "sed -i '' 's/agentMap.put(\"synthesize\", false);/\/\/ MUTANT: synthesize not sent/' '$JAVA_SDK/src/main/java/dev/agentspan/internal/AgentConfigSerializer.java'" \
+    "E2eSuite10Synthesize#test_handoff_no_synthesize_omits_final_task" \
+    "source"
+
+# Mutation 18: Suite10 Test — finalCount assertion wrong (0→2)
+# The test expects 0 final tasks when synthesize=false.
+# Changing 0→2 makes the assertion fail because the real count is 0.
+run_mutation \
+    "Suite10 Test: finalCount assertion 0→2 (handoff)" \
+    "$JAVA_SDK/src/test/java/dev/agentspan/e2e/E2eSuite10Synthesize.java" \
+    "sed -i '' 's/assertEquals(0, finalCount,/assertEquals(2, finalCount,/' '$JAVA_SDK/src/test/java/dev/agentspan/e2e/E2eSuite10Synthesize.java'" \
+    "E2eSuite10Synthesize#test_handoff_no_synthesize_omits_final_task" \
+    "test"
+
+# Mutation 19: Suite10 Test — synthesize assertion flipped (false→true)
+# The test asserts agentDef.synthesize == false.
+# Changing to assertEquals(true, ...) means a correctly-serialized false will fail.
+run_mutation \
+    "Suite10 Test: synthesize assertion false→true (agentDef check)" \
+    "$JAVA_SDK/src/test/java/dev/agentspan/e2e/E2eSuite10Synthesize.java" \
+    "sed -i '' 's/assertEquals(Boolean.FALSE, agentDef.get(\"synthesize\")/assertEquals(Boolean.TRUE, agentDef.get(\"synthesize\")/' '$JAVA_SDK/src/test/java/dev/agentspan/e2e/E2eSuite10Synthesize.java'" \
+    "E2eSuite10Synthesize#test_handoff_no_synthesize_omits_final_task" \
+    "test"
+
 # ── Summary ──────────────────────────────────────────────────────
 
 echo ""

--- a/sdk/java/src/main/java/dev/agentspan/Agent.java
+++ b/sdk/java/src/main/java/dev/agentspan/Agent.java
@@ -71,6 +71,7 @@ public class Agent {
     private final Map<String, Object> metadata;
     private final List<String> allowedCommands;
     private final String stopWhenTaskName;
+    private final boolean synthesize;
 
     private Agent(Builder builder) {
         this.name = builder.name;
@@ -106,6 +107,7 @@ public class Agent {
         this.metadata = builder.metadata;
         this.allowedCommands = builder.allowedCommands != null ? new ArrayList<>(builder.allowedCommands) : new ArrayList<>();
         this.stopWhenTaskName = builder.stopWhenTaskName;
+        this.synthesize = builder.synthesize;
     }
 
     /**
@@ -179,6 +181,7 @@ public class Agent {
     public Map<String, Object> getMetadata() { return metadata; }
     public List<String> getAllowedCommands() { return allowedCommands; }
     public String getStopWhenTaskName() { return stopWhenTaskName; }
+    public boolean isSynthesize() { return synthesize; }
 
     public static Builder builder() {
         return new Builder();
@@ -234,6 +237,7 @@ public class Agent {
         private Map<String, Object> metadata;
         private List<String> allowedCommands;
         private String stopWhenTaskName;
+        private boolean synthesize = true;
 
         /** Set the agent name (required). Must match {@code ^[a-zA-Z_][a-zA-Z0-9_-]*$}. */
         public Builder name(String name) {
@@ -524,6 +528,15 @@ public class Agent {
          */
         public Builder stopWhen(String taskName) {
             this.stopWhenTaskName = taskName;
+            return this;
+        }
+
+        /**
+         * Whether a final LLM synthesis step is added after handoff/router/swarm strategies.
+         * Default true (backward compatible). Set to false to pass the last specialist's output through directly.
+         */
+        public Builder synthesize(boolean synthesize) {
+            this.synthesize = synthesize;
             return this;
         }
 

--- a/sdk/java/src/main/java/dev/agentspan/internal/AgentConfigSerializer.java
+++ b/sdk/java/src/main/java/dev/agentspan/internal/AgentConfigSerializer.java
@@ -148,6 +148,11 @@ public class AgentConfigSerializer {
             agentMap.put("planner", true);
         }
 
+        // Synthesize — only emit when explicitly disabled (true is the server default)
+        if (!agent.isSynthesize()) {
+            agentMap.put("synthesize", false);
+        }
+
         // Code execution
         if (agent.isLocalCodeExecution()) {
             List<String> langs = agent.getAllowedLanguages();

--- a/sdk/java/src/test/java/dev/agentspan/e2e/E2eSuite10Synthesize.java
+++ b/sdk/java/src/test/java/dev/agentspan/e2e/E2eSuite10Synthesize.java
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 Agentspan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package dev.agentspan.e2e;
+
+import dev.agentspan.Agent;
+import dev.agentspan.AgentRuntime;
+import dev.agentspan.annotations.Tool;
+import dev.agentspan.enums.Strategy;
+import dev.agentspan.internal.ToolRegistry;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Suite 10: synthesize flag — structural plan() assertions.
+ *
+ * <p>All tests use plan() — no agent execution, no LLM calls.
+ *
+ * <p>COUNTERFACTUAL: each test must fail if the synthesize flag has no effect.
+ */
+@Tag("e2e")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class E2eSuite10Synthesize extends E2eBaseTest {
+
+    private static AgentRuntime runtime;
+
+    @BeforeAll
+    static void setup() {
+        runtime = new AgentRuntime(new dev.agentspan.AgentConfig(BASE_URL, null, null, 100, 1));
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (runtime != null) runtime.close();
+    }
+
+    // ── Dummy sub-agents ──────────────────────────────────────────────────
+
+    static class DummyTools {
+        @Tool(name = "e2e_synth_tool", description = "Dummy tool for synthesize tests")
+        public String run(String input) {
+            return input;
+        }
+    }
+
+    private static Agent makeSubAgent(String name) {
+        return Agent.builder()
+                .name(name)
+                .model(MODEL)
+                .instructions("You are " + name)
+                .tools(ToolRegistry.fromInstance(new DummyTools()))
+                .build();
+    }
+
+    // ── Helper: count _final tasks in flat task list ──────────────────────
+
+    private long countFinalTasks(Map<String, Object> workflowDef, String agentName) {
+        List<Map<String, Object>> tasks = allTasksFlat(workflowDef);
+        String expectedRef = agentName.replace("-", "_") + "_final";
+        return tasks.stream()
+                .filter(t -> expectedRef.equals(t.get("taskReferenceName")))
+                .count();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────
+
+    /**
+     * Default (synthesize not set) handoff agent: workflow MUST have a _final task.
+     *
+     * COUNTERFACTUAL: if the final synthesis task is removed, finalTaskCount == 0 → fails.
+     */
+    @Test
+    @Order(1)
+    void test_handoff_default_has_final_task() {
+        Agent agent = Agent.builder()
+                .name("e2e_synth_default_handoff")
+                .model(MODEL)
+                .strategy(Strategy.HANDOFF)
+                .agents(List.of(makeSubAgent("e2e_sub_alpha"), makeSubAgent("e2e_sub_beta")))
+                .build();
+
+        Map<String, Object> plan = runtime.plan(agent);
+        Map<String, Object> agentDef = getAgentDef(plan);
+
+        // synthesize defaults to true — must NOT appear in serialized config (we only emit when false)
+        assertFalse(agentDef.containsKey("synthesize"),
+                "[default handoff] agentDef should NOT contain 'synthesize' when default. Got: " + agentDef.keySet());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wfDef = (Map<String, Object>) plan.get("workflowDef");
+        long finalCount = countFinalTasks(wfDef, "e2e_synth_default_handoff");
+        assertEquals(1, finalCount,
+                "[default handoff] expected exactly 1 _final task, got " + finalCount);
+    }
+
+    /**
+     * synthesize=false handoff: agentDef must contain synthesize=false,
+     * and the workflow must NOT have a _final task.
+     *
+     * COUNTERFACTUAL: if synthesize flag is ignored, the _final task remains → finalCount > 0 → fails.
+     */
+    @Test
+    @Order(2)
+    void test_handoff_no_synthesize_omits_final_task() {
+        Agent agent = Agent.builder()
+                .name("e2e_synth_false_handoff")
+                .model(MODEL)
+                .strategy(Strategy.HANDOFF)
+                .agents(List.of(makeSubAgent("e2e_sub_gamma"), makeSubAgent("e2e_sub_delta")))
+                .synthesize(false)
+                .build();
+
+        Map<String, Object> plan = runtime.plan(agent);
+        Map<String, Object> agentDef = getAgentDef(plan);
+
+        assertEquals(Boolean.FALSE, agentDef.get("synthesize"),
+                "[synthesize=false handoff] agentDef.synthesize must be false. Got: " + agentDef.get("synthesize"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wfDef = (Map<String, Object>) plan.get("workflowDef");
+        long finalCount = countFinalTasks(wfDef, "e2e_synth_false_handoff");
+        assertEquals(0, finalCount,
+                "[synthesize=false handoff] workflow must NOT have a _final task, got " + finalCount);
+    }
+
+    /**
+     * synthesize=false router: agentDef must contain synthesize=false,
+     * and the workflow must NOT have a _final task.
+     *
+     * COUNTERFACTUAL: if synthesize flag is ignored for router, the _final task remains → fails.
+     */
+    @Test
+    @Order(3)
+    void test_router_no_synthesize_omits_final_task() {
+        Agent agent = Agent.builder()
+                .name("e2e_synth_false_router")
+                .model(MODEL)
+                .strategy(Strategy.ROUTER)
+                .agents(List.of(makeSubAgent("e2e_sub_epsilon"), makeSubAgent("e2e_sub_zeta")))
+                .synthesize(false)
+                .build();
+
+        Map<String, Object> plan = runtime.plan(agent);
+        Map<String, Object> agentDef = getAgentDef(plan);
+
+        assertEquals(Boolean.FALSE, agentDef.get("synthesize"),
+                "[synthesize=false router] agentDef.synthesize must be false. Got: " + agentDef.get("synthesize"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wfDef = (Map<String, Object>) plan.get("workflowDef");
+        long finalCount = countFinalTasks(wfDef, "e2e_synth_false_router");
+        assertEquals(0, finalCount,
+                "[synthesize=false router] workflow must NOT have a _final task, got " + finalCount);
+    }
+
+    /**
+     * synthesize=false swarm: agentDef must contain synthesize=false,
+     * and the workflow must NOT have a _final task.
+     *
+     * COUNTERFACTUAL: if synthesize flag is ignored for swarm, the _final task remains → fails.
+     */
+    @Test
+    @Order(4)
+    void test_swarm_no_synthesize_omits_final_task() {
+        Agent agent = Agent.builder()
+                .name("e2e_synth_false_swarm")
+                .model(MODEL)
+                .strategy(Strategy.SWARM)
+                .agents(List.of(makeSubAgent("e2e_sub_eta"), makeSubAgent("e2e_sub_theta")))
+                .synthesize(false)
+                .build();
+
+        Map<String, Object> plan = runtime.plan(agent);
+        Map<String, Object> agentDef = getAgentDef(plan);
+
+        assertEquals(Boolean.FALSE, agentDef.get("synthesize"),
+                "[synthesize=false swarm] agentDef.synthesize must be false. Got: " + agentDef.get("synthesize"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wfDef = (Map<String, Object>) plan.get("workflowDef");
+        long finalCount = countFinalTasks(wfDef, "e2e_synth_false_swarm");
+        assertEquals(0, finalCount,
+                "[synthesize=false swarm] workflow must NOT have a _final task, got " + finalCount);
+    }
+}

--- a/sdk/java/src/test/java/dev/agentspan/e2e/E2eSuite4Termination.java
+++ b/sdk/java/src/test/java/dev/agentspan/e2e/E2eSuite4Termination.java
@@ -103,13 +103,36 @@ class E2eSuite4Termination extends E2eBaseTest {
     }
 
     /**
+     * Agent with a nonexistent model must end in FAILED or TERMINATED — never COMPLETED.
+     *
+     * COUNTERFACTUAL: if model validation is ignored, status is COMPLETED → fails.
+     */
+    @Test
+    @Order(2)
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void test_invalid_model_fails() {
+        Agent agent = Agent.builder()
+            .name("e2e_java_bad_model")
+            .model("nonexistent/xyz-model-does-not-exist")
+            .instructions("This agent should never execute successfully.")
+            .build();
+
+        AgentResult result = runtime.run(agent, "Hello.");
+
+        assertNotEquals(AgentStatus.COMPLETED, result.getStatus(),
+            "[invalid model] Expected FAILED or TERMINATED for nonexistent model, "
+            + "got COMPLETED. The server should reject unknown models. "
+            + "COUNTERFACTUAL: if model validation is broken, this returns COMPLETED.");
+    }
+
+    /**
      * TextMentionTermination stops agent when it produces the trigger text.
      *
      * COUNTERFACTUAL: if TextMentionTermination doesn't work, agent ignores the
      * trigger text and runs all 25 turns.
      */
     @Test
-    @Order(2)
+    @Order(3)
     @Timeout(value = 300, unit = TimeUnit.SECONDS)
     @SuppressWarnings("unchecked")
     void test_text_mention_termination() {


### PR DESCRIPTION
## Summary

- **Java SDK**: `Agent.Builder.synthesize(boolean)` — opt-out of the final LLM synthesis step in handoff/router/swarm strategies
- **Java e2e**: `E2eSuite10Synthesize` — 4 plan-based structural tests for synthesize flag
- **Java e2e**: `test_invalid_model_fails` in `E2eSuite4Termination` — server must reject unknown models with FAILED/TERMINATED
- **Mutations**: 3 new mutations in `mutation_test_java.sh` (all killed)

## Changes

| File | What |
|---|---|
| `Agent.java` | `Builder.synthesize(boolean)`, getter |
| `AgentConfigSerializer.java` | emits `synthesize: false` only when disabled |
| `E2eSuite10Synthesize.java` | 4 plan-based tests (new suite) |
| `E2eSuite4Termination.java` | `test_invalid_model_fails` (new test) |
| `mutation_test_java.sh` | mutations 17–19 |

## Test plan
- [ ] `./gradlew :sdk-java:test -Dgroups=e2e`
- [ ] `./e2e/mutation_test_java.sh` — mutations 17, 18, 19 must be killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)