### PR TITLE
fix(ts-sdk): access structured fields via result.output.result in 09-structured-output

### DIFF
--- a/sdk/typescript/examples/09-structured-output.ts
+++ b/sdk/typescript/examples/09-structured-output.ts
@@ -44,11 +44,14 @@ async function main() {
     result.printResult();
 
     // The output conforms to the ArticleAnalysis schema
+    // result.output is the full server envelope { result: {...}, finishReason, context }.
+    // The structured data lives under result.output.result.
+    const structured = result.output['result'] as Record<string, unknown>;
     console.log('\nStructured output:');
-    console.log('  Title:', result.output['title']);
-    console.log('  Category:', result.output['category']);
-    console.log('  Sentiment:', result.output['sentiment']);
-    console.log('  Key Topics:', result.output['keyTopics']);
+    console.log('  Title:', structured?.['title']);
+    console.log('  Category:', structured?.['category']);
+    console.log('  Sentiment:', structured?.['sentiment']);
+    console.log('  Key Topics:', structured?.['keyTopics']);
 
     // Production pattern:
     // 1. Deploy once during CI/CD:


### PR DESCRIPTION
## Summary

- `result.output` is the full server envelope `{ result: {...}, finishReason, context }` — the structured data lives one level deeper under `result.output['result']`
- The example was accessing `result.output['title']` directly, which is always `undefined`
- Fixed to access `result.output['result']` first, then the individual fields

## Test plan

- [x] Ran `npx tsx examples/09-structured-output.ts` on Windows — now prints `Title`, `Category`, `Sentiment`, `Key Topics` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)