### PR TITLE
feat(java-sdk-spring): add Spring Boot auto-configuration module

### DIFF
--- a/.github/workflows/ci-java-sdk-spring.yml
+++ b/.github/workflows/ci-java-sdk-spring.yml
@@ -1,0 +1,31 @@
+name: CI Java SDK Spring
+
+on:
+  pull_request:
+    paths:
+      - 'sdk/java/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'sdk/java/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/java
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Build and run tests
+        run: ./gradlew :spring:test

--- a/sdk/java/settings.gradle
+++ b/sdk/java/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'java-sdk'
 
 include 'examples'
+include 'spring'

--- a/sdk/java/spring/build.gradle
+++ b/sdk/java/spring/build.gradle
@@ -1,0 +1,71 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+group = 'ai.agentspan'
+version = '0.1.0'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    withSourcesJar()
+    withJavadocJar()
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    springBootVersion = '3.3.5'
+}
+
+dependencies {
+    api project(':')
+
+    compileOnly "org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}"
+    compileOnly "org.springframework.boot:spring-boot:${springBootVersion}"
+
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}"
+
+    testImplementation "org.springframework.boot:spring-boot-test:${springBootVersion}"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:${springBootVersion}"
+    testImplementation "org.springframework:spring-test:6.1.14"
+    testImplementation "org.junit.jupiter:junit-jupiter:5.11.0"
+    testImplementation "org.assertj:assertj-core:3.26.3"
+    testRuntimeOnly "org.slf4j:slf4j-simple:2.0.13"
+}
+
+compileJava.options.compilerArgs << '-parameters'
+
+test {
+    useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            groupId = 'ai.agentspan'
+            artifactId = 'java-sdk-spring'
+            version = project.version
+
+            pom {
+                name = 'Agentspan Java SDK Spring Boot Starter'
+                description = 'Spring Boot auto-configuration for the Agentspan Java SDK'
+                url = 'https://github.com/agentspan-ai/agentspan'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
+}

--- a/sdk/java/spring/src/main/java/ai/agentspan/spring/AgentspanAutoConfiguration.java
+++ b/sdk/java/spring/src/main/java/ai/agentspan/spring/AgentspanAutoConfiguration.java
@@ -1,0 +1,31 @@
+package ai.agentspan.spring;
+
+import ai.agentspan.AgentConfig;
+import ai.agentspan.AgentRuntime;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@EnableConfigurationProperties(AgentspanProperties.class)
+public class AgentspanAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AgentConfig agentspanConfig(AgentspanProperties props) {
+        return new AgentConfig(
+            props.getServerUrl(),
+            props.getAuthKey(),
+            props.getAuthSecret(),
+            props.getWorkerPollIntervalMs(),
+            props.getWorkerThreadCount()
+        );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AgentRuntime agentRuntime(AgentConfig agentConfig) {
+        return new AgentRuntime(agentConfig);
+    }
+}

--- a/sdk/java/spring/src/main/java/ai/agentspan/spring/AgentspanProperties.java
+++ b/sdk/java/spring/src/main/java/ai/agentspan/spring/AgentspanProperties.java
@@ -1,0 +1,28 @@
+package ai.agentspan.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "agentspan")
+public class AgentspanProperties {
+
+    private String serverUrl = "http://localhost:6767";
+    private String authKey;
+    private String authSecret;
+    private int workerPollIntervalMs = 100;
+    private int workerThreadCount = 1;
+
+    public String getServerUrl() { return serverUrl; }
+    public void setServerUrl(String serverUrl) { this.serverUrl = serverUrl; }
+
+    public String getAuthKey() { return authKey; }
+    public void setAuthKey(String authKey) { this.authKey = authKey; }
+
+    public String getAuthSecret() { return authSecret; }
+    public void setAuthSecret(String authSecret) { this.authSecret = authSecret; }
+
+    public int getWorkerPollIntervalMs() { return workerPollIntervalMs; }
+    public void setWorkerPollIntervalMs(int workerPollIntervalMs) { this.workerPollIntervalMs = workerPollIntervalMs; }
+
+    public int getWorkerThreadCount() { return workerThreadCount; }
+    public void setWorkerThreadCount(int workerThreadCount) { this.workerThreadCount = workerThreadCount; }
+}

--- a/sdk/java/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sdk/java/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ai.agentspan.spring.AgentspanAutoConfiguration

--- a/sdk/java/spring/src/test/java/ai/agentspan/spring/AgentspanAutoConfigurationTest.java
+++ b/sdk/java/spring/src/test/java/ai/agentspan/spring/AgentspanAutoConfigurationTest.java
@@ -1,0 +1,75 @@
+package ai.agentspan.spring;
+
+import ai.agentspan.AgentConfig;
+import ai.agentspan.AgentRuntime;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AgentspanAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(AgentspanAutoConfiguration.class));
+
+    @Test
+    void registersAgentConfigAndRuntimeBeansWithDefaults() {
+        runner.run(ctx -> {
+            assertTrue(ctx.containsBean("agentspanConfig"));
+            assertTrue(ctx.containsBean("agentRuntime"));
+
+            AgentConfig config = ctx.getBean(AgentConfig.class);
+            assertEquals("http://localhost:6767", config.getServerUrl());
+            assertEquals(100, config.getWorkerPollIntervalMs());
+            assertEquals(1, config.getWorkerThreadCount());
+            assertNull(config.getAuthKey());
+            assertNull(config.getAuthSecret());
+        });
+    }
+
+    @Test
+    void respectsCustomProperties() {
+        runner
+            .withPropertyValues(
+                "agentspan.server-url=http://myserver:9090",
+                "agentspan.auth-key=mykey",
+                "agentspan.auth-secret=mysecret",
+                "agentspan.worker-thread-count=4",
+                "agentspan.worker-poll-interval-ms=250"
+            )
+            .run(ctx -> {
+                AgentConfig config = ctx.getBean(AgentConfig.class);
+                assertEquals("http://myserver:9090", config.getServerUrl());
+                assertEquals("mykey", config.getAuthKey());
+                assertEquals("mysecret", config.getAuthSecret());
+                assertEquals(4, config.getWorkerThreadCount());
+                assertEquals(250, config.getWorkerPollIntervalMs());
+            });
+    }
+
+    @Test
+    void doesNotOverrideUserDefinedAgentConfigBean() {
+        AgentConfig custom = new AgentConfig("http://custom:1234", null, null, 50, 2);
+        runner
+            .withBean(AgentConfig.class, () -> custom)
+            .run(ctx -> {
+                AgentConfig config = ctx.getBean(AgentConfig.class);
+                assertSame(custom, config);
+                assertEquals("http://custom:1234", config.getServerUrl());
+            });
+    }
+
+    @Test
+    void doesNotOverrideUserDefinedAgentRuntimeBean() {
+        AgentConfig config = new AgentConfig("http://localhost:6767", null, null, 100, 1);
+        AgentRuntime customRuntime = new AgentRuntime(config);
+        runner
+            .withBean(AgentRuntime.class, () -> customRuntime)
+            .run(ctx -> {
+                AgentRuntime runtime = ctx.getBean(AgentRuntime.class);
+                assertSame(customRuntime, runtime);
+                customRuntime.shutdown();
+            });
+    }
+}


### PR DESCRIPTION
## Summary

New Gradle subproject `ai.agentspan:java-sdk-spring` — a Spring Boot 3 starter that wires up the Agentspan SDK automatically.

**What it provides:**
- `AgentspanProperties` — binds all `AgentConfig` settings via `application.properties` / `application.yml` under `agentspan.*`
- `AgentspanAutoConfiguration` — registers `AgentConfig` and `AgentRuntime` as Spring beans; both are `@ConditionalOnMissingBean` so user-defined beans take precedence
- `META-INF/spring/AutoConfiguration.imports` — Spring Boot 3 auto-discovery (no `@EnableAgentspan` annotation needed)

**Usage after adding the dependency:**
\`\`\`yaml
# application.yml
agentspan:
  server-url: http://my-agentspan-server:6767
  auth-key: mykey
  auth-secret: mysecret
  worker-thread-count: 4
\`\`\`
\`\`\`java
@Autowired AgentRuntime runtime; // ready to use
\`\`\`

> ⚠️ Depends on PR #186 (package rename to `ai.agentspan` + Gradle migration). Merge that first.

## Test plan

- [x] `./gradlew :spring:test` passes — **4 tests, 0 failures**
  - defaults wired correctly
  - custom properties respected
  - user-defined `AgentConfig` bean not overridden
  - user-defined `AgentRuntime` bean not overridden
- [x] CI workflow `ci-java-sdk-spring.yml` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)