### PR TITLE
fix(ui): update logo brand colors to new palette

### DIFF
--- a/server/src/main/resources/static/agentspan-icon.svg
+++ b/server/src/main/resources/static/agentspan-icon.svg
@@ -1,5 +1,5 @@
 <svg width="40" height="56" viewBox="6 8 76 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="10" y="12" width="40" height="10" rx="5" fill="#4F46E5"/>
-  <rect x="22" y="35" width="56" height="10" rx="5" fill="#4F46E5" opacity="0.65"/>
-  <rect x="14" y="58" width="32" height="10" rx="5" fill="#4F46E5" opacity="0.38"/>
+  <rect x="10" y="12" width="40" height="10" rx="5" fill="#3C3CDC"/>
+  <rect x="22" y="35" width="56" height="10" rx="5" fill="#8C78F0"/>
+  <rect x="14" y="58" width="32" height="10" rx="5" fill="#B4B4F0"/>
 </svg>

--- a/server/src/main/resources/static/agentspan-logo-dark.svg
+++ b/server/src/main/resources/static/agentspan-logo-dark.svg
@@ -1,8 +1,8 @@
 <svg width="400" height="80" viewBox="0 0 400 80" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Icon: 3 staggered bars -->
-  <rect x="10" y="12" width="40" height="10" rx="5" fill="#818CF8"/>
-  <rect x="22" y="35" width="56" height="10" rx="5" fill="#818CF8" opacity="0.65"/>
-  <rect x="14" y="58" width="32" height="10" rx="5" fill="#818CF8" opacity="0.38"/>
+  <rect x="10" y="12" width="40" height="10" rx="5" fill="#3C3CDC"/>
+  <rect x="22" y="35" width="56" height="10" rx="5" fill="#8C78F0"/>
+  <rect x="14" y="58" width="32" height="10" rx="5" fill="#B4B4F0"/>
   <!-- Text -->
   <text x="82" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="42" font-weight="700" fill="#E0E7FF" letter-spacing="-1">agentspan</text>
 </svg>

--- a/server/src/main/resources/static/agentspan-logo-light.svg
+++ b/server/src/main/resources/static/agentspan-logo-light.svg
@@ -1,8 +1,8 @@
 <svg width="400" height="80" viewBox="0 0 400 80" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Icon: 3 staggered bars -->
-  <rect x="10" y="12" width="40" height="10" rx="5" fill="#4F46E5"/>
-  <rect x="22" y="35" width="56" height="10" rx="5" fill="#4F46E5" opacity="0.65"/>
-  <rect x="14" y="58" width="32" height="10" rx="5" fill="#4F46E5" opacity="0.38"/>
+  <rect x="10" y="12" width="40" height="10" rx="5" fill="#3C3CDC"/>
+  <rect x="22" y="35" width="56" height="10" rx="5" fill="#8C78F0"/>
+  <rect x="14" y="58" width="32" height="10" rx="5" fill="#B4B4F0"/>
   <!-- Text -->
   <text x="82" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="42" font-weight="700" fill="#1E1B4B" letter-spacing="-1">agentspan</text>
 </svg>

--- a/ui/public/agentspan-icon.svg
+++ b/ui/public/agentspan-icon.svg
@@ -1,5 +1,5 @@
 <svg width="40" height="56" viewBox="6 8 76 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="10" y="12" width="40" height="10" rx="5" fill="#4F46E5"/>
-  <rect x="22" y="35" width="56" height="10" rx="5" fill="#4F46E5" opacity="0.65"/>
-  <rect x="14" y="58" width="32" height="10" rx="5" fill="#4F46E5" opacity="0.38"/>
+  <rect x="10" y="12" width="40" height="10" rx="5" fill="#3C3CDC"/>
+  <rect x="22" y="35" width="56" height="10" rx="5" fill="#8C78F0"/>
+  <rect x="14" y="58" width="32" height="10" rx="5" fill="#B4B4F0"/>
 </svg>

--- a/ui/public/agentspan-logo-dark.svg
+++ b/ui/public/agentspan-logo-dark.svg
@@ -1,8 +1,8 @@
 <svg width="400" height="80" viewBox="0 0 400 80" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Icon: 3 staggered bars -->
-  <rect x="10" y="12" width="40" height="10" rx="5" fill="#818CF8"/>
-  <rect x="22" y="35" width="56" height="10" rx="5" fill="#818CF8" opacity="0.65"/>
-  <rect x="14" y="58" width="32" height="10" rx="5" fill="#818CF8" opacity="0.38"/>
+  <rect x="10" y="12" width="40" height="10" rx="5" fill="#3C3CDC"/>
+  <rect x="22" y="35" width="56" height="10" rx="5" fill="#8C78F0"/>
+  <rect x="14" y="58" width="32" height="10" rx="5" fill="#B4B4F0"/>
   <!-- Text -->
   <text x="82" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="42" font-weight="700" fill="#E0E7FF" letter-spacing="-1">agentspan</text>
 </svg>

--- a/ui/public/agentspan-logo-light.svg
+++ b/ui/public/agentspan-logo-light.svg
@@ -1,8 +1,8 @@
 <svg width="400" height="80" viewBox="0 0 400 80" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Icon: 3 staggered bars -->
-  <rect x="10" y="12" width="40" height="10" rx="5" fill="#4F46E5"/>
-  <rect x="22" y="35" width="56" height="10" rx="5" fill="#4F46E5" opacity="0.65"/>
-  <rect x="14" y="58" width="32" height="10" rx="5" fill="#4F46E5" opacity="0.38"/>
+  <rect x="10" y="12" width="40" height="10" rx="5" fill="#3C3CDC"/>
+  <rect x="22" y="35" width="56" height="10" rx="5" fill="#8C78F0"/>
+  <rect x="14" y="58" width="32" height="10" rx="5" fill="#B4B4F0"/>
   <!-- Text -->
   <text x="82" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="42" font-weight="700" fill="#1E1B4B" letter-spacing="-1">agentspan</text>
 </svg>


### PR DESCRIPTION
Closes #153
Closes #99

## Summary
- Dark logo (`agentspan-logo-dark.svg`): `#818CF8` → `#3C3CDC / #8C78F0 / #B4B4F0`
- Light logo (`agentspan-logo-light.svg`): `#4F46E5` → `#3C3CDC / #8C78F0 / #B4B4F0`
- Icon (`agentspan-icon.svg`): `#4F46E5` → `#3C3CDC / #8C78F0 / #B4B4F0`
- Updated both `ui/public/` (source) and `server/src/main/resources/static/` (served directly)

## Test plan
- [ ] Open `http://localhost:6767` and verify the header/sidebar logo shows the new three-color bars
- [ ] Toggle dark/light mode — verify both variants use the new brand palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)