### PR TITLE
fix(python-sdk): surface task-level failure reason in AgentResult.error

### DIFF
--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -2541,6 +2541,7 @@ class AgentRuntime:
         tool_calls: List[Dict[str, Any]] = []
         messages: List[Dict[str, Any]] = []
         token_usage: Optional[TokenUsage] = None
+        task_failure_reason: Optional[str] = None
         try:
             wf = self._workflow_client.get_workflow(
                 execution_id,
@@ -2549,8 +2550,16 @@ class AgentRuntime:
             tool_calls = self._extract_tool_calls(wf)
             messages = self._extract_messages(wf)
             token_usage = self._extract_token_usage(execution_id)
+            if raw_status == "FAILED":
+                task_failure_reason = self._extract_failed_task_reason(wf)
         except Exception as exc:
             logger.debug("Could not fetch execution details for %s: %s", execution_id, exc)
+
+        # Build the richest error message available: prefer task-level reason
+        # (includes which task failed and why) over the workflow-level reason.
+        error_reason: Optional[str] = None
+        if raw_status in ("FAILED", "TERMINATED"):
+            error_reason = task_failure_reason or status.reason
 
         logger.info("Agent '%s' completed (execution_id=%s)", agent.name, execution_id)
         return AgentResult(
@@ -2559,7 +2568,7 @@ class AgentRuntime:
             correlation_id=correlation_id,
             status=raw_status,
             finish_reason=self._derive_finish_reason(raw_status, status.output),
-            error=status.reason if raw_status in ("FAILED", "TERMINATED") else None,
+            error=error_reason,
             tool_calls=tool_calls,
             messages=messages,
             token_usage=token_usage,
@@ -2624,13 +2633,20 @@ class AgentRuntime:
         tool_calls: List[Dict[str, Any]] = []
         messages: List[Dict[str, Any]] = []
         token_usage: Optional[TokenUsage] = None
+        task_failure_reason: Optional[str] = None
         try:
             wf = self._workflow_client.get_workflow(execution_id, include_tasks=True)
             tool_calls = self._extract_tool_calls(wf)
             messages = self._extract_messages(wf)
             token_usage = self._extract_token_usage(execution_id)
+            if status.status == "FAILED":
+                task_failure_reason = self._extract_failed_task_reason(wf)
         except Exception as exc:
             logger.debug("Could not fetch execution details: %s", exc)
+
+        error_reason: Optional[str] = None
+        if status.status in ("FAILED", "TERMINATED"):
+            error_reason = task_failure_reason or status.reason
 
         return AgentResult(
             output=output,
@@ -2638,7 +2654,7 @@ class AgentRuntime:
             correlation_id=correlation_id,
             status=status.status,
             finish_reason=self._derive_finish_reason(status.status, status.output),
-            error=status.reason if status.status in ("FAILED", "TERMINATED") else None,
+            error=error_reason,
             tool_calls=tool_calls,
             messages=messages,
             token_usage=token_usage,
@@ -5038,6 +5054,26 @@ class AgentRuntime:
         if output is None:
             return {"result": None}
         return {"result": output}
+
+    @staticmethod
+    def _extract_failed_task_reason(wf: Any) -> Optional[str]:
+        """Return a descriptive error from the first FAILED task in a workflow.
+
+        Combines the task reference name with its reasonForIncompletion so
+        callers can diagnose intermittent failures without manual inspection
+        of the execution history UI.
+        """
+        if not hasattr(wf, "tasks") or not wf.tasks:
+            return None
+        for task in wf.tasks:
+            status = str(getattr(task, "status", "")).upper()
+            if status == "FAILED":
+                ref = getattr(task, "reference_task_name", None) or getattr(task, "task_type", "unknown")
+                reason = getattr(task, "reason_for_incompletion", None)
+                if reason:
+                    return f"Task '{ref}' failed: {reason}"
+                return f"Task '{ref}' failed"
+        return None
 
     @staticmethod
     def _extract_sub_results(output: Dict[str, Any]) -> Dict[str, Any]:

--- a/sdk/python/tests/unit/test_result.py
+++ b/sdk/python/tests/unit/test_result.py
@@ -467,6 +467,66 @@ class TestOutputNormalization:
         assert result.output == {"result": None}
 
 
+class TestExtractFailedTaskReason:
+    """_extract_failed_task_reason returns the first FAILED task's reason for diagnosing issue #41."""
+
+    def _call(self, tasks):
+        from agentspan.agents.runtime.runtime import AgentRuntime
+        from unittest.mock import MagicMock
+
+        wf = MagicMock()
+        wf.tasks = tasks
+        return AgentRuntime._extract_failed_task_reason(wf)
+
+    def _task(self, status, ref="some_task", reason=None):
+        t = MagicMock()
+        t.status = status
+        t.reference_task_name = ref
+        t.reason_for_incompletion = reason
+        return t
+
+    def test_no_tasks_returns_none(self):
+        wf = MagicMock()
+        wf.tasks = []
+        from agentspan.agents.runtime.runtime import AgentRuntime
+
+        assert AgentRuntime._extract_failed_task_reason(wf) is None
+
+    def test_all_completed_returns_none(self):
+        tasks = [self._task("COMPLETED"), self._task("COMPLETED")]
+        assert self._call(tasks) is None
+
+    def test_failed_task_with_reason(self):
+        tasks = [
+            self._task("COMPLETED"),
+            self._task("FAILED", ref="manager_llm", reason="LLM API returned 429"),
+        ]
+        result = self._call(tasks)
+        assert "manager_llm" in result
+        assert "LLM API returned 429" in result
+
+    def test_failed_task_without_reason(self):
+        tasks = [self._task("FAILED", ref="calculate", reason=None)]
+        result = self._call(tasks)
+        assert "calculate" in result
+        assert result is not None
+
+    def test_returns_first_failed_task(self):
+        tasks = [
+            self._task("FAILED", ref="first_fail", reason="timeout"),
+            self._task("FAILED", ref="second_fail", reason="another error"),
+        ]
+        result = self._call(tasks)
+        assert "first_fail" in result
+        assert "second_fail" not in result
+
+    def test_no_tasks_attribute_returns_none(self):
+        from agentspan.agents.runtime.runtime import AgentRuntime
+
+        wf = MagicMock(spec=[])  # no .tasks attribute
+        assert AgentRuntime._extract_failed_task_reason(wf) is None
+
+
 class TestParallelOutputNormalization:
     """BUG-P2-02: Parallel strategy output normalized by server."""
 


### PR DESCRIPTION
## Summary

- When a workflow fails, `AgentResult.error` now includes the specific task that failed and its reason (e.g. `Task 'manager_llm' failed: LLM API returned 429`)
- Previously only the generic workflow-level `reasonForIncompletion` was returned, making intermittent failures hard to diagnose
- Added `_extract_failed_task_reason()` helper that walks task list to find the first FAILED task
- Applied to both the main `run()` path and `_run_by_name()` path

## Root Cause Context

Issue #41 reports 1/10 random FAILED workflows under stress load with no error details. Without this change, you had to manually inspect the execution history UI to find which task failed and why.

## Test Plan

- [ ] 6 unit tests in `TestExtractFailedTaskReason` — verified: 0 collected before fix (method didn't exist), 6 pass after fix
- [ ] Tests cover: no tasks → None, all COMPLETED → None, failed task with/without reason, returns first failed task, no `.tasks` attribute → None
- [ ] Existing test suite passes

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)