### PR TITLE
ci(java-sdk): auto-promote staged artifacts to Maven Central

### DIFF
--- a/.github/workflows/release-java-sdk.yml
+++ b/.github/workflows/release-java-sdk.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          ./gradlew :publish :spring:publish \
+          ./gradlew :publish :spring:publish promoteToMavenCentral \
             -Pversion=${{ steps.version.outputs.version }} \
             -PmavenCentral=true \
             -Pusername=${{ secrets.SONATYPE_USERNAME }} \

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -118,3 +118,49 @@ signing {
 tasks.withType(Javadoc).configureEach {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
+
+tasks.register('promoteToMavenCentral') {
+    group = 'publishing'
+    description = 'Promotes open staging repositories to Maven Central (publishing_type=automatic)'
+
+    onlyIf {
+        project.hasProperty('mavenCentral') &&
+            project.hasProperty('username') &&
+            project.hasProperty('password') &&
+            !project.version.toString().endsWith('-SNAPSHOT')
+    }
+
+    doLast {
+        def username = project.findProperty('username')
+        def password = project.findProperty('password')
+        def token = "${username}:${password}".bytes.encodeBase64().toString()
+
+        def listConn = new URL('https://ossrh-staging-api.central.sonatype.com/manual/search/repositories').openConnection()
+        listConn.setRequestProperty('Authorization', "Basic ${token}")
+        listConn.setRequestProperty('Content-Type', 'application/json')
+        def repos = new groovy.json.JsonSlurper().parse(listConn.inputStream)
+
+        def promoted = 0
+        repos.repositories.each { repo ->
+            if (repo.state == 'open') {
+                logger.lifecycle("Promoting repository ${repo.key} (publishing_type=automatic)")
+                def promoteUrl = "https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/${repo.key}?publishing_type=automatic"
+                def conn = new URL(promoteUrl).openConnection()
+                conn.setRequestMethod('POST')
+                conn.setRequestProperty('Authorization', "Basic ${token}")
+                conn.setRequestProperty('Content-Type', 'application/json')
+                def code = conn.responseCode
+                if (code == 200 || code == 204) {
+                    logger.lifecycle("Promoted ${repo.key}")
+                    promoted++
+                } else {
+                    throw new GradleException("Failed to promote ${repo.key}: HTTP ${code} ${conn.responseMessage}")
+                }
+            }
+        }
+
+        if (promoted == 0) {
+            logger.warn('No open staging repositories found to promote.')
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `promoteToMavenCentral` Gradle task and wires it into the release workflow so Java SDK publishes go **straight to Maven Central** without a manual intervention.

## How it works

After `:publish :spring:publish` upload artifacts to the OSSRH-shim staging endpoint, the new task:

1. `GET /manual/search/repositories` — lists open staging repositories.
2. For each `state == "open"` repo, `POST /manual/upload/repository/{key}?publishing_type=automatic` — Sonatype validates and pushes to Maven Central in one shot.

## Trade-off

`publishing_type=automatic` skips the human gate at https://central.sonatype.com/publishing/deployments. A bad version is irreversible — Maven Central never lets you take a published version back. Mitigations:

- `workflow_dispatch`-only trigger (no auto-fire on releases).
- Version is an explicit `version` input on the dispatch.
- Build + tests run before the publish step.

If we want a manual gate back, flip `publishing_type=automatic` -> `user_managed`.

## Test plan

- [x] `./gradlew tasks --group=publishing` shows the new `promoteToMavenCentral` task.
- [x] Task `onlyIf` skips when `-PmavenCentral` not set (verified locally — task only registers in publishing group; doesn't run without flags).
- [ ] Trigger workflow with `version=0.1.0-rc2`; confirm artifacts appear at https://repo1.maven.org/maven2/ai/agentspan/java-sdk/0.1.0-rc2/ within ~30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)