### PR TITLE
ci(java-sdk): switch to Central Portal API (vanniktech plugin)

### DIFF
--- a/.github/workflows/release-java-sdk.yml
+++ b/.github/workflows/release-java-sdk.yml
@@ -37,12 +37,11 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          ./gradlew :publish :spring:publish \
-            -Pversion=${{ steps.version.outputs.version }} \
-            -PmavenCentral=true \
-            -Pusername=${{ secrets.SONATYPE_USERNAME }} \
-            -Ppassword=${{ secrets.SONATYPE_PASSWORD }}
+          ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache \
+            -Pversion=${{ steps.version.outputs.version }}
         env:
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'com.vanniktech.maven.publish' version '0.30.0'
+    id 'com.vanniktech.maven.publish' version '0.34.0'
 }
 
 group = 'ai.agentspan'
@@ -54,7 +54,7 @@ tasks.withType(Javadoc).configureEach {
 }
 
 mavenPublishing {
-    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL, true)
+    publishToMavenCentral(true)
     if (project.findProperty('signingInMemoryKey') != null) {
         signAllPublications()
     }

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java-library'
-    id 'maven-publish'
-    id 'signing'
+    id 'com.vanniktech.maven.publish' version '0.30.0'
 }
 
 group = 'ai.agentspan'
@@ -10,8 +9,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
-    withSourcesJar()
-    withJavadocJar()
 }
 
 repositories {
@@ -52,69 +49,40 @@ test {
     }
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            groupId = 'ai.agentspan'
-            artifactId = 'java-sdk'
-            version = project.version
-
-            pom {
-                name = 'Agentspan Java SDK'
-                description = 'Java SDK for the Agentspan agent orchestration platform'
-                url = 'https://github.com/agentspan-ai/agentspan'
-                licenses {
-                    license {
-                        name = 'MIT License'
-                        url = 'https://opensource.org/licenses/MIT'
-                    }
-                }
-                developers {
-                    developer {
-                        organization = 'Agentspan'
-                        organizationUrl = 'https://agentspan.ai'
-                        name = 'Agentspan Development Team'
-                        email = 'developers@orkes.io'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/agentspan-ai/agentspan.git'
-                    developerConnection = 'scm:git:ssh://github.com/agentspan-ai/agentspan.git'
-                    url = 'https://github.com/agentspan-ai/agentspan'
-                }
-            }
-        }
-    }
-    repositories {
-        if (project.hasProperty('mavenCentral')) {
-            maven {
-                name = 'mavenCentral'
-                url = project.version.toString().endsWith('-SNAPSHOT')
-                    ? 'https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/'
-                    : 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
-                credentials {
-                    username = project.findProperty('username')
-                    password = project.findProperty('password')
-                }
-            }
-        } else {
-            mavenLocal()
-        }
-    }
-}
-
-signing {
-    required = { project.hasProperty('mavenCentral') }
-    def signingKeyId = project.findProperty('signingKeyId')
-    def signingKey = project.findProperty('signingKey')
-    def signingPassword = project.findProperty('signingPassword')
-    if (signingKeyId && signingKey && signingPassword) {
-        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    }
-    sign publishing.publications.mavenJava
-}
-
 tasks.withType(Javadoc).configureEach {
     options.addStringOption('Xdoclint:none', '-quiet')
+}
+
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL, true)
+    if (project.findProperty('signingInMemoryKey') != null) {
+        signAllPublications()
+    }
+
+    coordinates('ai.agentspan', 'java-sdk', project.version.toString())
+
+    pom {
+        name = 'Agentspan Java SDK'
+        description = 'Java SDK for the Agentspan agent orchestration platform'
+        url = 'https://github.com/agentspan-ai/agentspan'
+        licenses {
+            license {
+                name = 'MIT License'
+                url = 'https://opensource.org/licenses/MIT'
+            }
+        }
+        developers {
+            developer {
+                organization = 'Agentspan'
+                organizationUrl = 'https://agentspan.ai'
+                name = 'Agentspan Development Team'
+                email = 'developers@orkes.io'
+            }
+        }
+        scm {
+            connection = 'scm:git:git://github.com/agentspan-ai/agentspan.git'
+            developerConnection = 'scm:git:ssh://github.com/agentspan-ai/agentspan.git'
+            url = 'https://github.com/agentspan-ai/agentspan'
+        }
+    }
 }

--- a/sdk/java/spring/build.gradle
+++ b/sdk/java/spring/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'com.vanniktech.maven.publish' version '0.30.0'
+    id 'com.vanniktech.maven.publish' version '0.34.0'
 }
 
 group = 'ai.agentspan'
@@ -46,7 +46,7 @@ tasks.withType(Javadoc).configureEach {
 }
 
 mavenPublishing {
-    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL, true)
+    publishToMavenCentral(true)
     if (project.findProperty('signingInMemoryKey') != null) {
         signAllPublications()
     }

--- a/sdk/java/spring/build.gradle
+++ b/sdk/java/spring/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java-library'
-    id 'maven-publish'
-    id 'signing'
+    id 'com.vanniktech.maven.publish' version '0.30.0'
 }
 
 group = 'ai.agentspan'
@@ -10,8 +9,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
-    withSourcesJar()
-    withJavadocJar()
 }
 
 repositories {
@@ -44,69 +41,40 @@ test {
     useJUnitPlatform()
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            groupId = 'ai.agentspan'
-            artifactId = 'java-sdk-spring'
-            version = project.version
-
-            pom {
-                name = 'Agentspan Java SDK Spring Boot Starter'
-                description = 'Spring Boot auto-configuration for the Agentspan Java SDK'
-                url = 'https://github.com/agentspan-ai/agentspan'
-                licenses {
-                    license {
-                        name = 'MIT License'
-                        url = 'https://opensource.org/licenses/MIT'
-                    }
-                }
-                developers {
-                    developer {
-                        organization = 'Agentspan'
-                        organizationUrl = 'https://agentspan.ai'
-                        name = 'Agentspan Development Team'
-                        email = 'developers@orkes.io'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/agentspan-ai/agentspan.git'
-                    developerConnection = 'scm:git:ssh://github.com/agentspan-ai/agentspan.git'
-                    url = 'https://github.com/agentspan-ai/agentspan'
-                }
-            }
-        }
-    }
-    repositories {
-        if (project.hasProperty('mavenCentral')) {
-            maven {
-                name = 'mavenCentral'
-                url = project.version.toString().endsWith('-SNAPSHOT')
-                    ? 'https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/'
-                    : 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
-                credentials {
-                    username = project.findProperty('username')
-                    password = project.findProperty('password')
-                }
-            }
-        } else {
-            mavenLocal()
-        }
-    }
-}
-
-signing {
-    required = { project.hasProperty('mavenCentral') }
-    def signingKeyId = project.findProperty('signingKeyId')
-    def signingKey = project.findProperty('signingKey')
-    def signingPassword = project.findProperty('signingPassword')
-    if (signingKeyId && signingKey && signingPassword) {
-        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    }
-    sign publishing.publications.mavenJava
-}
-
 tasks.withType(Javadoc).configureEach {
     options.addStringOption('Xdoclint:none', '-quiet')
+}
+
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL, true)
+    if (project.findProperty('signingInMemoryKey') != null) {
+        signAllPublications()
+    }
+
+    coordinates('ai.agentspan', 'java-sdk-spring', project.version.toString())
+
+    pom {
+        name = 'Agentspan Java SDK Spring Boot Starter'
+        description = 'Spring Boot auto-configuration for the Agentspan Java SDK'
+        url = 'https://github.com/agentspan-ai/agentspan'
+        licenses {
+            license {
+                name = 'MIT License'
+                url = 'https://opensource.org/licenses/MIT'
+            }
+        }
+        developers {
+            developer {
+                organization = 'Agentspan'
+                organizationUrl = 'https://agentspan.ai'
+                name = 'Agentspan Development Team'
+                email = 'developers@orkes.io'
+            }
+        }
+        scm {
+            connection = 'scm:git:git://github.com/agentspan-ai/agentspan.git'
+            developerConnection = 'scm:git:ssh://github.com/agentspan-ai/agentspan.git'
+            url = 'https://github.com/agentspan-ai/agentspan'
+        }
+    }
 }


### PR DESCRIPTION
## Why

The OSSRH-shim staging endpoint (`ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/`) silently dropped uploads from `ai.agentspan`. Reproduced across `0.1.0-rc1`, `0.1.0-rc2`, and `0.1.0`:

- Workflow runs all returned `BUILD SUCCESSFUL` with 12-14s of upload time.
- `manual/search/repositories` returned `{"repositories":[]}` immediately after each upload, with the same token used by CI.
- `repo1.maven.org/maven2/ai/agentspan/...` returned 404.
- Deployments UI at `central.sonatype.com/publishing/deployments` showed nothing.
- URLs were byte-for-byte identical to conductor-oss/java-sdk's working setup; their grandfathered namespace works on the shim, ours doesn't.

## What

Replace `maven-publish` + `signing` + custom `promoteToMavenCentral` task with [`com.vanniktech.maven.publish`](https://vanniktech.github.io/gradle-maven-publish-plugin/central/) `0.34.0`, which uses the modern Central Portal ZIP-bundle API (`central.sonatype.com/api/v1/publisher/upload`).

- Plugin bundles jar/sources/javadoc/pom/module + signatures into a ZIP per module and POSTs as a multipart upload.
- Returns a deployment ID surfaced in the Deployments UI.
- Auto-releases when invoked via `publishAndReleaseToMavenCentral` (configured with `publishToMavenCentral(true)` — Central Portal is the default since 0.33).

## Version pin: 0.34.0

We're pinned to **0.34.0** (latest is 0.36.0). Release-by-release impact:

- **0.33.0**: `SonatypeHost` argument deprecated; no-arg `publishToMavenCentral()` defaults to Central Portal.
- **0.34.0** *(breaking)*: OSSRH removed entirely; `SonatypeHost` removed from DSL. Last version compatible with our Gradle 8.10 wrapper.
- **0.35.0**: Min Gradle 8.13 → would force a wrapper bump.
- **0.36.0**: Min Gradle 9.0 + JDK 17 + validation default behavior change → bigger upgrade.

When we bump the Gradle wrapper to 9.x we can revisit jumping to 0.36.

## Diff

- Both `build.gradle` files: dropped `maven-publish` + `signing` plugins and ~50 lines of `publishing { ... } / signing { ... }` config; added `mavenPublishing { ... }` block (~25 lines).
- Workflow: single command `./gradlew publishAndReleaseToMavenCentral`. Credentials map to the plugin's env vars (`ORG_GRADLE_PROJECT_mavenCentralUsername` etc).
- `signAllPublications()` is conditional on the signing key being present so `publishToMavenLocal` still works on dev machines.

## Secrets — no rotation needed

Existing `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `SIGNING_KEY_ID`, `SIGNING_KEY`, `SIGNING_PASSWORD` are reused. Only the env var names mapping them changed.

## Supersedes

PR #209 (auto-promote task) — obsolete; vanniktech handles promotion natively. Close after merging this.

## Test plan

- [x] `./gradlew tasks --all` shows `publishAndReleaseToMavenCentral` and `publishToMavenCentral` for both `:` and `:spring`.
- [x] `./gradlew publishToMavenLocal -Pversion=0.1.0-LOCAL` produces full artifact set in `~/.m2/repository/ai/agentspan/{java-sdk,java-sdk-spring}/0.1.0-LOCAL/` on the 0.34.0 pin.
- [x] `./gradlew build` passes — no test regressions.
- [ ] Trigger workflow with `version=0.1.0-rc4`; confirm a deployment shows up at https://central.sonatype.com/publishing/deployments and (after auto-release) at https://repo1.maven.org/maven2/ai/agentspan/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)