### PR TITLE
ci(csharp-sdk): add NuGet release workflow

### DIFF
--- a/.github/workflows/release-csharp-sdk.yml
+++ b/.github/workflows/release-csharp-sdk.yml
@@ -1,0 +1,48 @@
+name: Publish C# SDK to NuGet
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (e.g. 0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-nuget:
+    runs-on: ubuntu-latest
+    environment: nuget
+    defaults:
+      run:
+        working-directory: sdk/csharp
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Determine version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: ${VERSION}"
+
+      - name: Pack
+        run: |
+          dotnet pack src/Agentspan/Agentspan.csproj \
+            --configuration Release \
+            -p:Version=${{ steps.version.outputs.version }} \
+            --output ./nupkg
+
+      - name: Publish to NuGet
+        run: |
+          dotnet nuget push "./nupkg/*.nupkg" \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary

- Adds `release-csharp-sdk.yml`: a manual `workflow_dispatch` workflow that packs `Agentspan.csproj` with the specified version and publishes to NuGet.org
- Mirrors the Java SDK release workflow pattern (PR #210)

## How it works

1. Trigger from **Actions → Publish C# SDK to NuGet → Run workflow**
2. Enter the version (e.g. `0.2.0`)
3. The workflow packs the SDK overriding `<Version>` at pack time (no file edits needed)
4. Pushes `Agentspan.<version>.nupkg` to `https://api.nuget.org/v3/index.json`

## Required setup (one-time)

Add a `nuget` environment in repo Settings → Environments with:
- `NUGET_API_KEY` — NuGet.org API key scoped to the `Agentspan` package ID

## Test plan

- [ ] Confirm `nuget` environment exists with `NUGET_API_KEY`
- [ ] Trigger workflow with version `0.1.0` and verify package appears on nuget.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)