### PR TITLE
ci(csharp-sdk): drop nuget environment from release workflow

### DIFF
--- a/.github/workflows/release-csharp-sdk.yml
+++ b/.github/workflows/release-csharp-sdk.yml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   publish-nuget:
     runs-on: ubuntu-latest
-    environment: nuget
     defaults:
       run:
         working-directory: sdk/csharp


### PR DESCRIPTION
## Summary
- Remove `environment: nuget` from `.github/workflows/release-csharp-sdk.yml` so the NuGet publish job runs without waiting on a GitHub environment approval gate.

## Notes
- `NUGET_API_KEY` must be available as a repo-level (or org-level) secret. If it was only scoped to the `nuget` GitHub environment, the publish step will fail with an empty key until the secret is mirrored at repo scope.

## Test plan
- [ ] Confirm `NUGET_API_KEY` exists as a repo/org secret (not only on the `nuget` environment).
- [ ] Trigger `Publish C# SDK to NuGet` via `workflow_dispatch` against a dry-run/test version and confirm the publish step authenticates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)