### PR TITLE
fix: address issue #164

### DIFF
--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -532,3 +532,32 @@ func (c *Client) SetBinding(logicalKey, storeName string) error {
 	resp.Body.Close()
 	return nil
 }
+
+// ─── Execution deletion ───────────────────────────────────────────────────────
+
+// DeleteExecution permanently removes a single execution record (and its
+// sub-workflows / parent workflow) from the server's persistence layer.
+func (c *Client) DeleteExecution(executionID string) error {
+	resp, err := c.doRequest("DELETE", "/api/agent/executions/"+url.PathEscape(executionID)+"?purge=true", nil)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// BulkDeleteRequest is the payload for DELETE /api/agent/executions/bulk/delete.
+type BulkDeleteRequest struct {
+	IDs []string `json:"ids"`
+}
+
+// BulkDeleteExecutions permanently removes multiple execution records (and their
+// related sub-workflows / parent workflows) from the server's persistence layer.
+func (c *Client) BulkDeleteExecutions(ids []string) error {
+	resp, err := c.doRequest("DELETE", "/api/agent/executions/bulk/delete", &BulkDeleteRequest{IDs: ids})
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/cli/client/client_test.go
+++ b/cli/client/client_test.go
@@ -457,3 +457,91 @@ func TestDoRequest_Returns4xxError(t *testing.T) {
 		t.Errorf("error = %q, want to contain 400", err.Error())
 	}
 }
+
+// ─── DeleteExecution ─────────────────────────────────────────────────────────
+
+func TestDeleteExecution_SendsDeleteWithPurge(t *testing.T) {
+	var gotMethod, gotPath string
+	_, c := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.RawPath
+		if gotPath == "" {
+			gotPath = r.URL.Path
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	if err := c.DeleteExecution("exec-abc"); err != nil {
+		t.Fatalf("DeleteExecution: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if !strings.Contains(gotPath, "exec-abc") {
+		t.Errorf("path = %q, want to contain exec-abc", gotPath)
+	}
+}
+
+func TestDeleteExecution_PathEscapesExecutionID(t *testing.T) {
+	var gotPath string
+	_, c := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RawPath
+		if gotPath == "" {
+			gotPath = r.URL.Path
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	if err := c.DeleteExecution("id/with/slashes"); err != nil {
+		t.Fatalf("DeleteExecution: %v", err)
+	}
+	if !strings.Contains(gotPath, "id%2Fwith%2Fslashes") {
+		t.Errorf("path = %q, want escaped slashes", gotPath)
+	}
+}
+
+// ─── BulkDeleteExecutions ────────────────────────────────────────────────────
+
+func TestBulkDeleteExecutions_SendsCorrectPayload(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody BulkDeleteRequest
+	_, c := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	ids := []string{"id-1", "id-2", "id-3"}
+	if err := c.BulkDeleteExecutions(ids); err != nil {
+		t.Fatalf("BulkDeleteExecutions: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/api/agent/executions/bulk/delete" {
+		t.Errorf("path = %q, want /api/agent/executions/bulk/delete", gotPath)
+	}
+	if len(gotBody.IDs) != 3 {
+		t.Errorf("ids count = %d, want 3", len(gotBody.IDs))
+	}
+	for i, id := range ids {
+		if gotBody.IDs[i] != id {
+			t.Errorf("ids[%d] = %q, want %q", i, gotBody.IDs[i], id)
+		}
+	}
+}
+
+func TestBulkDeleteExecutions_ReturnsErrorOn4xx(t *testing.T) {
+	_, c := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+
+	err := c.BulkDeleteExecutions([]string{"id-1"})
+	if err == nil {
+		t.Fatal("expected error for 400")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error = %q, want to contain 400", err.Error())
+	}
+}

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var pruneOlderThan string
+
+var serverPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Delete completed execution records older than a given age",
+	Long: `Search for completed (COMPLETED, FAILED, TERMINATED) execution records
+older than the specified duration and permanently delete them from the database.
+
+Duration format: 30s, 5m, 1h, 6h, 1d, 7d, 1mo, 1y
+
+Examples:
+  agentspan server prune --older-than 30d
+  agentspan server prune --older-than 7d`,
+	RunE: runServerPrune,
+}
+
+func init() {
+	serverPruneCmd.Flags().StringVar(&pruneOlderThan, "older-than", "", "Delete executions older than this duration (e.g. 30d, 7d, 1mo) [required]")
+	_ = serverPruneCmd.MarkFlagRequired("older-than")
+	serverCmd.AddCommand(serverPruneCmd)
+}
+
+func runServerPrune(cmd *cobra.Command, args []string) error {
+	dur, err := parseTimeSpec(pruneOlderThan)
+	if err != nil {
+		return fmt.Errorf("invalid --older-than value: %w", err)
+	}
+
+	cutoff := time.Now().Add(-dur)
+	cutoffMs := cutoff.UnixMilli()
+
+	cfg := getConfig()
+	c := newClient(cfg)
+
+	// Search for terminal executions older than the cutoff across all statuses.
+	terminalStatuses := []string{"COMPLETED", "FAILED", "TERMINATED", "TIMED_OUT"}
+
+	var allIDs []string
+	for _, status := range terminalStatuses {
+		freeText := fmt.Sprintf("startTime:[* TO %d]", cutoffMs)
+		result, err := c.SearchExecutions(0, 1000, "", status, freeText)
+		if err != nil {
+			return fmt.Errorf("failed to search %s executions: %w", status, err)
+		}
+		for _, ex := range result.Results {
+			allIDs = append(allIDs, ex.ExecutionID)
+		}
+	}
+
+	if len(allIDs) == 0 {
+		color.Yellow("No executions found older than %s.", pruneOlderThan)
+		return nil
+	}
+
+	color.Yellow("Found %d execution(s) older than %s (before %s).",
+		len(allIDs), pruneOlderThan, cutoff.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Deleting %d execution record(s)...\n", len(allIDs))
+
+	if err := c.BulkDeleteExecutions(allIDs); err != nil {
+		return fmt.Errorf("bulk delete failed: %w", err)
+	}
+
+	color.Green("Successfully deleted %d execution record(s).", len(allIDs))
+	return nil
+}

--- a/cli/tui/views/doctor.go
+++ b/cli/tui/views/doctor.go
@@ -219,8 +219,6 @@ func renderCheckResult(r CheckResult) string {
 	return style.Render(line)
 }
 
-
-
 // ─── Check Commands ──────────────────────────────────────────────────────────
 
 func (m DoctorModel) runSystemChecks() tea.Cmd {
@@ -351,6 +349,6 @@ func min(a, b int) int {
 
 // ─── Test accessors ───────────────────────────────────────────────────────────
 
-func (m DoctorModel) Running() bool                    { return m.running }
-func (m DoctorModel) Sections() map[string][]CheckResult { return m.sections }
+func (m DoctorModel) Running() bool                           { return m.running }
+func (m DoctorModel) Sections() map[string][]CheckResult      { return m.sections }
 func (m *DoctorModel) SetSections(s map[string][]CheckResult) { m.sections = s; m.running = false }

--- a/cli/tui/views/executions.go
+++ b/cli/tui/views/executions.go
@@ -264,8 +264,8 @@ func (m ExecutionsModel) Searching() bool     { return m.searching }
 func (m ExecutionsModel) SearchQuery() string { return m.searchQuery }
 func (m ExecutionsModel) Loading() bool       { return m.loading }
 
-func (m *ExecutionsModel) SetTotal(n int64)   { m.total = n }
-func (m *ExecutionsModel) SetPageSize(n int)  { m.pageSize = n }
+func (m *ExecutionsModel) SetTotal(n int64)  { m.total = n }
+func (m *ExecutionsModel) SetPageSize(n int) { m.pageSize = n }
 
 func (m *ExecutionsModel) InjectRunning(id string) {
 	m.executions = []client.AgentExecutionSummary{{

--- a/cli/tui/views/server.go
+++ b/cli/tui/views/server.go
@@ -620,12 +620,12 @@ func (m ServerModel) FooterHints() string {
 
 // ─── Test accessors ───────────────────────────────────────────────────────────
 
-func (m ServerModel) Following() bool         { return m.following }
-func (m ServerModel) Action() ServerAction    { return m.action }
-func (m ServerModel) Err() string             { return m.err }
-func (m ServerModel) Checking() bool          { return m.checking }
-func (m *ServerModel) SetHealthy(v bool)      { m.healthy = v; m.checking = false }
-func (m *ServerModel) SetErr(e string)        { m.err = e }
+func (m ServerModel) Following() bool      { return m.following }
+func (m ServerModel) Action() ServerAction { return m.action }
+func (m ServerModel) Err() string          { return m.err }
+func (m ServerModel) Checking() bool       { return m.checking }
+func (m *ServerModel) SetHealthy(v bool)   { m.healthy = v; m.checking = false }
+func (m *ServerModel) SetErr(e string)     { m.err = e }
 
 // WantsEsc returns true when there is a confirm dialog open.
 func (m ServerModel) WantsEsc() bool {

--- a/server/src/main/java/dev/agentspan/runtime/controller/AgentController.java
+++ b/server/src/main/java/dev/agentspan/runtime/controller/AgentController.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.core.exception.NotFoundException;
 import dev.agentspan.runtime.model.AgentExecutionDetail;
 import dev.agentspan.runtime.model.AgentRun;
 import dev.agentspan.runtime.model.AgentSummary;
+import dev.agentspan.runtime.model.BulkDeleteRequest;
 import dev.agentspan.runtime.model.CompileResponse;
 import dev.agentspan.runtime.model.CreateTrackingWorkflowRequest;
 import dev.agentspan.runtime.model.CreateTrackingWorkflowResponse;
@@ -265,9 +266,20 @@ public class AgentController {
         return agentService.rerunExecution(executionId, request);
     }
 
-    /** Terminate a running execution (used by UI delete action). */
+    /**
+     * Delete an execution record from persistence.
+     *
+     * <p>If {@code purge=false}, falls back to terminate behavior for compatibility.</p>
+     */
     @DeleteMapping("/executions/{executionId}")
-    public void terminateExecution(@PathVariable String executionId, @RequestParam(required = false) String reason) {
+    public void terminateExecution(
+            @PathVariable String executionId,
+            @RequestParam(defaultValue = "true") boolean purge,
+            @RequestParam(required = false) String reason) {
+        if (purge) {
+            agentService.deleteExecutionCascade(executionId);
+            return;
+        }
         agentService.cancelAgent(executionId, reason);
     }
 
@@ -349,6 +361,19 @@ public class AgentController {
     @PostMapping("/executions/bulk/terminate")
     public void bulkTerminate(@RequestBody List<String> ids, @RequestParam(required = false) String reason) {
         ids.forEach(id -> agentService.cancelAgent(id, reason));
+    }
+
+    /**
+     * Permanently delete multiple execution records (and their sub-workflows / parent workflows)
+     * from persistence.
+     *
+     * <p>Accepts a JSON body: {@code {"ids": ["id1", "id2", ...]}}.</p>
+     */
+    @DeleteMapping("/executions/bulk/delete")
+    public void bulkDeleteExecutions(@RequestBody BulkDeleteRequest request) {
+        if (request.getIds() != null && !request.getIds().isEmpty()) {
+            agentService.bulkDeleteExecutions(request.getIds());
+        }
     }
 
     // ── Definition metadata ─────────────────────────────────────────

--- a/server/src/main/java/dev/agentspan/runtime/model/BulkDeleteRequest.java
+++ b/server/src/main/java/dev/agentspan/runtime/model/BulkDeleteRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Request body for bulk-delete execution endpoint. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkDeleteRequest {
+
+    /** Execution IDs to permanently remove from persistence. */
+    private List<String> ids;
+}

--- a/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -1355,4 +1355,106 @@ public class AgentService {
     public List<TaskExecLog> getTaskLogs(String taskId) {
         return executionService.getTaskLogs(taskId);
     }
+
+    // ── Execution deletion ───────────────────────────────────────────
+
+    /**
+     * Permanently delete a single execution record and all related sub-workflow
+     * records from persistence.
+     *
+     * <p>Resolution rules:
+     * <ol>
+     *   <li>Fetch the workflow. If it has a parent, resolve the root parent first.</li>
+     *   <li>Collect the root parent ID plus all sub-workflow IDs reachable from it.</li>
+     *   <li>Delete every collected ID via {@code workflowService.deleteWorkflow}.</li>
+     * </ol>
+     * </p>
+     */
+    public void deleteExecutionCascade(String executionId) {
+        Set<String> toDelete = resolveExecutionFamily(executionId);
+        for (String id : toDelete) {
+            try {
+                workflowService.deleteWorkflow(id, false);
+                log.info("Deleted execution record: {}", id);
+            } catch (Exception e) {
+                log.warn("Failed to delete execution {}: {}", id, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Permanently delete multiple execution records (and their sub-workflows /
+     * parent workflows) from persistence.
+     *
+     * <p>Each ID is resolved to its full family (parent + all sub-workflows) before
+     * deletion, so passing either a parent or a child ID produces the same result.</p>
+     */
+    public void bulkDeleteExecutions(List<String> ids) {
+        Set<String> toDelete = new LinkedHashSet<>();
+        for (String id : ids) {
+            try {
+                toDelete.addAll(resolveExecutionFamily(id));
+            } catch (Exception e) {
+                log.warn("Could not resolve execution family for {}: {}", id, e.getMessage());
+                toDelete.add(id); // best-effort: delete what was asked
+            }
+        }
+        for (String id : toDelete) {
+            try {
+                workflowService.deleteWorkflow(id, false);
+                log.info("Bulk-deleted execution record: {}", id);
+            } catch (Exception e) {
+                log.warn("Failed to bulk-delete execution {}: {}", id, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Given any execution ID (parent or sub-workflow), return the full set of IDs
+     * that should be deleted together: the root parent plus every sub-workflow
+     * reachable from it.
+     */
+    private Set<String> resolveExecutionFamily(String executionId) {
+        Set<String> family = new LinkedHashSet<>();
+        String rootId = resolveRootParent(executionId);
+        collectSubWorkflowIds(rootId, family);
+        return family;
+    }
+
+    /**
+     * Walk up the parent chain to find the root (top-level) workflow ID.
+     * Returns {@code executionId} itself if it has no parent.
+     */
+    private String resolveRootParent(String executionId) {
+        try {
+            Workflow wf = executionService.getExecutionStatus(executionId, false);
+            String parentId = wf.getParentWorkflowId();
+            if (parentId != null && !parentId.isBlank()) {
+                return resolveRootParent(parentId);
+            }
+        } catch (Exception e) {
+            log.debug("Could not fetch workflow {} to resolve parent: {}", executionId, e.getMessage());
+        }
+        return executionId;
+    }
+
+    /**
+     * Recursively collect {@code rootId} and all sub-workflow IDs reachable from it.
+     */
+    private void collectSubWorkflowIds(String workflowId, Set<String> collected) {
+        if (!collected.add(workflowId)) {
+            return; // already visited
+        }
+        try {
+            Workflow wf = executionService.getExecutionStatus(workflowId, true);
+            for (Task task : wf.getTasks()) {
+                String subId = task.getSubWorkflowId();
+                if (subId != null && !subId.isBlank()) {
+                    collectSubWorkflowIds(subId, collected);
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Could not fetch sub-workflows for {}: {}", workflowId, e.getMessage());
+        }
+    }
 }

--- a/server/src/test/java/dev/agentspan/runtime/service/AgentServiceDeleteTest.java
+++ b/server/src/test/java/dev/agentspan/runtime/service/AgentServiceDeleteTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.service.ExecutionService;
+import com.netflix.conductor.service.WorkflowService;
+
+import dev.agentspan.runtime.compiler.AgentCompiler;
+import dev.agentspan.runtime.normalizer.NormalizerRegistry;
+import dev.agentspan.runtime.util.ProviderValidator;
+
+@ExtendWith(MockitoExtension.class)
+class AgentServiceDeleteTest {
+
+    @Mock
+    private AgentCompiler agentCompiler;
+
+    @Mock
+    private NormalizerRegistry normalizerRegistry;
+
+    @Mock
+    private ExecutionDAO executionDAO;
+
+    @Mock
+    private MetadataDAO metadataDAO;
+
+    @Mock
+    private WorkflowExecutor workflowExecutor;
+
+    @Mock
+    private WorkflowService workflowService;
+
+    @Mock
+    private AgentStreamRegistry streamRegistry;
+
+    @Mock
+    private ExecutionService executionService;
+
+    @Mock
+    private ProviderValidator providerValidator;
+
+    private AgentService agentService;
+
+    @BeforeEach
+    void setUp() {
+        agentService = new AgentService(
+                agentCompiler,
+                normalizerRegistry,
+                executionDAO,
+                metadataDAO,
+                workflowExecutor,
+                workflowService,
+                streamRegistry,
+                executionService,
+                providerValidator,
+                null);
+    }
+
+    // ── deleteExecutionCascade ───────────────────────────────────────────────
+
+    @Test
+    void deleteExecutionCascade_deletesRootWorkflow_whenNoParentNoChildren() {
+        Workflow wf = makeWorkflow("wf-1", null, List.of());
+        when(executionService.getExecutionStatus(eq("wf-1"), anyBoolean())).thenReturn(wf);
+
+        agentService.deleteExecutionCascade("wf-1");
+
+        verify(workflowService).deleteWorkflow("wf-1", false);
+        verifyNoMoreInteractions(workflowService);
+    }
+
+    @Test
+    void deleteExecutionCascade_deletesSubWorkflows_whenParentHasChildren() {
+        // Parent has two sub-workflow tasks
+        Task subTask1 = makeSubWorkflowTask("sub-1");
+        Task subTask2 = makeSubWorkflowTask("sub-2");
+        Workflow parent = makeWorkflow("parent-1", null, List.of(subTask1, subTask2));
+
+        // Sub-workflows have no further children
+        Workflow sub1 = makeWorkflow("sub-1", "parent-1", List.of());
+        Workflow sub2 = makeWorkflow("sub-2", "parent-1", List.of());
+
+        when(executionService.getExecutionStatus(eq("parent-1"), anyBoolean())).thenReturn(parent);
+        when(executionService.getExecutionStatus(eq("sub-1"), anyBoolean())).thenReturn(sub1);
+        when(executionService.getExecutionStatus(eq("sub-2"), anyBoolean())).thenReturn(sub2);
+
+        agentService.deleteExecutionCascade("parent-1");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+        verify(workflowService, times(3)).deleteWorkflow(idCaptor.capture(), eq(false));
+        assertThat(idCaptor.getAllValues()).containsExactlyInAnyOrder("parent-1", "sub-1", "sub-2");
+    }
+
+    @Test
+    void deleteExecutionCascade_resolvesParent_whenSubWorkflowIdGiven() {
+        // sub-1 has parent-1 as parent
+        Workflow sub1 = makeWorkflow("sub-1", "parent-1", List.of());
+        // parent-1 has sub-1 as child
+        Task subTask = makeSubWorkflowTask("sub-1");
+        Workflow parent = makeWorkflow("parent-1", null, List.of(subTask));
+
+        when(executionService.getExecutionStatus(eq("sub-1"), anyBoolean())).thenReturn(sub1);
+        when(executionService.getExecutionStatus(eq("parent-1"), anyBoolean())).thenReturn(parent);
+
+        agentService.deleteExecutionCascade("sub-1");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+        verify(workflowService, times(2)).deleteWorkflow(idCaptor.capture(), eq(false));
+        assertThat(idCaptor.getAllValues()).containsExactlyInAnyOrder("parent-1", "sub-1");
+    }
+
+    // ── bulkDeleteExecutions ─────────────────────────────────────────────────
+
+    @Test
+    void bulkDeleteExecutions_deletesAllIds() {
+        Workflow wf1 = makeWorkflow("wf-1", null, List.of());
+        Workflow wf2 = makeWorkflow("wf-2", null, List.of());
+
+        when(executionService.getExecutionStatus(eq("wf-1"), anyBoolean())).thenReturn(wf1);
+        when(executionService.getExecutionStatus(eq("wf-2"), anyBoolean())).thenReturn(wf2);
+
+        agentService.bulkDeleteExecutions(List.of("wf-1", "wf-2"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+        verify(workflowService, times(2)).deleteWorkflow(idCaptor.capture(), eq(false));
+        assertThat(idCaptor.getAllValues()).containsExactlyInAnyOrder("wf-1", "wf-2");
+    }
+
+    @Test
+    void bulkDeleteExecutions_deduplicatesRelatedIds() {
+        // wf-1 has sub-1 as child; if both wf-1 and sub-1 are passed, sub-1 should only be deleted once
+        Task subTask = makeSubWorkflowTask("sub-1");
+        Workflow parent = makeWorkflow("wf-1", null, List.of(subTask));
+        Workflow sub1 = makeWorkflow("sub-1", "wf-1", List.of());
+
+        when(executionService.getExecutionStatus(eq("wf-1"), anyBoolean())).thenReturn(parent);
+        when(executionService.getExecutionStatus(eq("sub-1"), anyBoolean())).thenReturn(sub1);
+
+        agentService.bulkDeleteExecutions(List.of("wf-1", "sub-1"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+        verify(workflowService, times(2)).deleteWorkflow(idCaptor.capture(), eq(false));
+        assertThat(idCaptor.getAllValues()).containsExactlyInAnyOrder("wf-1", "sub-1");
+    }
+
+    @Test
+    void bulkDeleteExecutions_emptyList_doesNothing() {
+        agentService.bulkDeleteExecutions(List.of());
+        verifyNoInteractions(workflowService);
+    }
+
+    @Test
+    void bulkDeleteExecutions_continuesOnPartialFailure() {
+        Workflow wf1 = makeWorkflow("wf-1", null, List.of());
+        Workflow wf2 = makeWorkflow("wf-2", null, List.of());
+
+        when(executionService.getExecutionStatus(eq("wf-1"), anyBoolean())).thenReturn(wf1);
+        when(executionService.getExecutionStatus(eq("wf-2"), anyBoolean())).thenReturn(wf2);
+
+        // First delete throws, second should still proceed
+        doThrow(new RuntimeException("DB error")).when(workflowService).deleteWorkflow(eq("wf-1"), eq(false));
+
+        agentService.bulkDeleteExecutions(List.of("wf-1", "wf-2"));
+
+        verify(workflowService).deleteWorkflow("wf-1", false);
+        verify(workflowService).deleteWorkflow("wf-2", false);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private Workflow makeWorkflow(String id, String parentId, List<Task> tasks) {
+        Workflow wf = new Workflow();
+        wf.setWorkflowId(id);
+        wf.setParentWorkflowId(parentId);
+        wf.setTasks(new ArrayList<>(tasks));
+        return wf;
+    }
+
+    private Task makeSubWorkflowTask(String subWorkflowId) {
+        Task task = new Task();
+        task.setSubWorkflowId(subWorkflowId);
+        task.setTaskType("SUB_WORKFLOW");
+        task.setStatus(Task.Status.COMPLETED);
+        return task;
+    }
+}


### PR DESCRIPTION
Fixes #164

## Summary

# Implementation Report — Issue #164: Execution History Pruning

## Summary
Implemented execution history pruning to prevent unbounded DB growth. Added server-side cascade delete, bulk delete endpoint, and CLI `prune` command.

## Files Changed

### New Files
- `server/src/main/java/dev/agentspan/runtime/model/BulkDeleteRequest.java` — Request body model for bulk delete endpoint (`{ "ids": [...] }`)
- `cli/cmd/prune.go` — CLI command `agentspan server prune --older-than <duration>` (e.g. `30d`, `7d`)
- `server/src/test/java/dev/agentspan/runtime/service/AgentServiceDeleteTest.java` — 6 unit tests for delete service logic

### Modified Files
- `server/src/main/java/dev/agentspan/runtime/service/AgentService.java`
  - Added `deleteExecutionCascade(String executionId)` — resolves root parent, collects all sub-workflow IDs, deletes all via `workflowService.deleteWorkflow(id, false)`
  - Added `bulkDeleteExecutions(List<String> ids)` — resolves full family for each ID, deduplicates, bulk-deletes
  - Added private helpers: `resolveExecutionFamily`, `resolveRootParent`, `collectSubWorkflowIds`

- `server/src/main/java/dev/agentspan/runtime/controller/AgentController.java`
  - Updated `DELETE /api/agent/executions/{executionId}` — now calls `deleteExecutionCascade` when `purge=true` (default), falls back to terminate when `purge=false`
  - Added `DELETE /api/agent/executions/bulk/delete` — accepts `BulkDeleteRequest` body, calls `bulkDeleteExecutions`
  - Added import for `BulkDeleteRequest`

- `cli/client/client.go`
  - Added `DeleteExecution(executionID string) error` — calls `DELETE /api/agent/executions/{id}?purge=true`
  - Added `BulkDeleteExecutions(ids []string) error` — calls `DELETE /api/agent/executions/bulk/delete`
  - Added `BulkDeleteRequest` struct

- `cli/client/client_test.go`
  - Added `TestDeleteExecution_SendsDeleteWithPurge`
  - Added `TestDeleteExecution_PathEscapesExecutionID`
  - Added `TestBulkDeleteExecutions_SendsCorrectPayload`
  - Added `TestBulk

<details><summary>Coder Context</summary>

# Issue #164 - Execution History Pruning - Status Update

## Files Written/Edited
1. `server/src/main/java/dev/agentspan/runtime/service/AgentService.java` - Added `deleteExecutionCascade`, `bulkDeleteExecutions`, `resolveExecutionFamily`, `resolveRootParent`, `collectSubWorkflowIds`
2. `server/src/main/java/dev/agentspan/runtime/controller/AgentController.java` - Added `bulkDeleteExecutions` endpoint (`DELETE /executions/bulk/delete`), updated `terminateExecution` to call `deleteExecutionCascade` when `purge=true`
3. `server/src/main/java/dev/agentspan/runtime/model/BulkDeleteRequest.java` - New model for bulk delete body
4. `cli/client/client.go` - Added `DeleteExecution`, `BulkDeleteExecutions`, `BulkDeleteRequest`
5. `cli/cmd/prune.go` - New file with `agentspan server prune --older-than <duration>` command
6. `server/src/test/java/dev/agentspan/runtime/service/AgentServiceDeleteTest.java` - New test file with 6 tests
7. `cli/client/client_test.go` - Added 4 new tests for DeleteExecution and BulkDeleteExecutions

## Build/Lint Status
- Java server: BUILD SUCCESSFUL (all tasks pass)
- Java spotless: UP-TO-DATE (no formatting issues in our new code)
- Go build: PASS (cli builds successfully)
- Go vet: Pre-existing lint issue in `cli/tui/app_test.go:319,338,362` - `BackgroundColorMsg` struct literal uses unkeyed fields. This is a PRE-EXISTING issue NOT introduced by our changes.

## Checklist
- [x] Understand existing code
- [x] Add `deleteExecutionCascade` to AgentService (single + cascade sub-workflows + parent resolution)
- [x] Add `bulkDeleteExecutions` to AgentService
- [x] Add bulk delete endpoint to AgentController (`DELETE /executions/bulk/delete`)
- [x] Add BulkDeleteRequest model
- [x] Add `DeleteExecution` and `BulkDeleteExecutions` to CLI client
- [x] Add `agentspan server prune --older-than` CLI command
- [x] Add tests for AgentService delete methods (6 tests)
- [x] Add tests for CLI client delete methods (4 tests)
- [x] Build check PASS
- [x] Lint/format PASS (pre-existing Go vet issue in tui/app_test.go not introduced by us)


</details>

<details><summary>Issue / PR Context</summary>

# Issue #164: Add execution history pruning to prevent unbounded DB growth
Author: deeptireddy-lab
Labels: none
Repo: agentspan-ai/agentspan
Branch: fix/issue-164
Mode: new issue fix

## Issue Body
## Problem
The DB grows forever. Every agent run permanently appends task records and there is no way to delete completed executions today — not via API, not via CLI.

## What's needed
1. **Server endpoint** — `DELETE /api/agent/executions/{id}` that removes the execution record from the DB (wraps Conductor's `deleteWorkflow`)
2. **CLI command** — `agentspan server prune --older-than 30d` that searches for completed executions older than N days and bulk-deletes them

## Notes
- Conductor has `deleteWorkflow` and bulk delete APIs internally — we just need to expose them
- Current `DELETE /api/agent/executions/{id}` only terminates (cancels) a running execution, does not remove the record
- No automated sweeper exists in this version of Conductor for completed execution cleanup

## Issue Comments

**@v1r3n:**
1. Add bulk delete endpoints so multiple ids can be passed as payload
2. When deleting an agent run, delete all the sub-agents (sub-workflows). 
3. If the sub-workflow id is passed, then also delete the parent

</details>

<details><summary>Agent Context</summary>

```json
{
  "repo": "agentspan-ai/agentspan",
  "issue": 164,
  "source": "agentspan_issue_fixer"
}
```

</details>
