### PR TITLE
fix(java-e2e): unbreak main + add java-e2e to CI so this can't slip past again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,3 +270,53 @@ jobs:
           name: typescript-e2e-results
           path: e2e-results/
           retention-days: 14
+
+  # ── Java E2E Tests ─────────────────────────────────────────────────
+  java-e2e:
+    runs-on: ubuntu-latest
+    needs: [build-server, test]
+    timeout-minutes: 45
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AGENTSPAN_SERVER_URL: http://localhost:6767/api
+      AGENTSPAN_LLM_MODEL: openai/gpt-4o-mini
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Download server JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: server-jar
+          path: server/build/libs/
+
+      - name: Install mcp-testkit
+        run: pip install mcp-testkit
+
+      - name: Start mcp-testkit
+        run: |
+          mcp-testkit --transport http --port 3001 &
+          sleep 2
+
+      - name: Start server
+        run: |
+          java -jar server/build/libs/agentspan-runtime.jar --server.port=6767 &
+          for i in $(seq 1 30); do curl -sf http://localhost:6767/health && break; sleep 2; done
+
+      - name: Run Java e2e suites
+        working-directory: sdk/java
+        run: ./gradlew test -Pe2e
+
+      - name: Upload Java e2e results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-e2e-results
+          path: sdk/java/build/reports/tests/test/
+          retention-days: 14

--- a/sdk/java/e2e/Suite18ToolTypes.java
+++ b/sdk/java/e2e/Suite18ToolTypes.java
@@ -1,7 +1,6 @@
 // Copyright (c) 2025 Agentspan
 // Licensed under the MIT License. See LICENSE file in the project root for details.
 
-package ai.agentspan.e2e;
 
 import ai.agentspan.Agent;
 import ai.agentspan.AgentRuntime;
@@ -36,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("e2e")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Timeout(value = 300, unit = TimeUnit.SECONDS)
-class E2eSuite13ToolTypes extends E2eBaseTest {
+class Suite18ToolTypes extends BaseTest {
 
     private static AgentRuntime runtime;
 


### PR DESCRIPTION
## Summary

Two changes:
1. **Fix:** move `E2eSuite13ToolTypes.java` to the post-#223 flat layout so `compileTestJava` passes on main again.
2. **Prevention:** add a `java-e2e` job to `ci.yml` so Java e2e tests run on every PR — they were previously `workflow_dispatch`-only and never ran automatically.

## Why main is broken today

`./gradlew compileTestJava` fails with:
```
sdk/java/src/test/java/ai/agentspan/e2e/E2eSuite13ToolTypes.java:39: error: cannot find symbol
class E2eSuite13ToolTypes extends E2eBaseTest
```

### Root cause — PR merge-order accident

| PR | What it did | Merged |
|---|---|---|
| **#223** | Reorganized e2e tests `sdk/java/src/test/java/.../e2e/` → flat `sdk/java/e2e/`. Renamed `E2eBaseTest` → `BaseTest`. | First (`8e886c61`) |
| **#236** | Added `E2eSuite13ToolTypes.java` at the **old** path, extending the **old** `E2eBaseTest`. | Second (`420d9202`) — broke main |

PR #236 was rebased before #223 landed; its own CI on its branch ran green, but the post-#223 main was never re-tested.

## Fix (commit `28049468`)

Move the file into the new flat layout:
- Path: `sdk/java/src/test/java/ai/agentspan/e2e/E2eSuite13ToolTypes.java` → `sdk/java/e2e/Suite18ToolTypes.java`
- Remove `package ai.agentspan.e2e;` (flat layout uses default package)
- Rename class `E2eSuite13ToolTypes` → `Suite18ToolTypes`
- Update `extends E2eBaseTest` → `extends BaseTest`

Suite #18 chosen because `Suite13Callbacks` (Python-parity name from #223) already occupies #13, and 16/17 are the existing Java-extras range.

## Prevention (commit `146b33ff`)

Java SDK e2e tests were only triggerable via `workflow_dispatch` (`ci-java-sdk-e2e.yml`) — never ran automatically on PRs. Add a `java-e2e` job to `ci.yml` mirroring the existing `python-e2e` and `typescript-e2e` shape:
- Runs on every push to main + every PR to main
- Depends on `build-server` + `test` (java unit tests)
- Downloads the `server-jar` artifact from `build-server`
- Starts `mcp-testkit` on :3001 (Suite4 MCP, Suite5 HTTP need it)
- Runs `./gradlew test -Pe2e`
- Uploads test reports on failure
- Uses `openai/gpt-4o-mini` (same cost choice as python-e2e)

With this in place, a similar layout/rename mismatch in the future will fail CI on the originating PR, not break main silently.

## Test plan

- [x] `./gradlew compileTestJava` (local) — BUILD SUCCESSFUL
- [ ] CI on this PR runs `java-e2e` job for the first time end-to-end
- [ ] If `java-e2e` passes, future PRs get the same gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)