### PR TITLE
fix(ci): drop dangling `needs: test` from java-e2e (unbreaks main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,14 @@ jobs:
   # ── Java E2E Tests ─────────────────────────────────────────────────
   java-e2e:
     runs-on: ubuntu-latest
-    needs: [build-server, test]
+    # ``test`` was the job name in the separate ci-java-sdk.yml workflow.
+    # GitHub Actions ``needs:`` only resolves jobs in the same workflow, so
+    # listing it here was a dangling reference that invalidated ci.yml as a
+    # whole — every push to main produced a 0-job failure run with the
+    # workflow name displayed as ``.github/workflows/ci.yml`` instead of
+    # ``CI``. Depend only on ``build-server`` (the actual server-jar
+    # producer); the separate java-sdk workflow runs in parallel.
+    needs: [build-server]
     timeout-minutes: 45
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary

PR #239 added a `java-e2e` job to `ci.yml` with `needs: [build-server, test]`. `test` is the job name inside the *separate* `ci-java-sdk.yml` workflow, but GitHub Actions `needs:` only resolves jobs in the *same* workflow file. The dangling reference invalidates `ci.yml` as a whole:

- Every push to main produces a 0-job failure run.
- Workflow name displays as `.github/workflows/ci.yml` (the file path) instead of `CI`.
- Example failing run: https://github.com/agentspan-ai/agentspan/actions/runs/25955164702

This also blocks pull_request runs for the `CI` workflow on every PR until the underlying workflow file becomes valid again, so every open PR has degraded CI.

## Change

Drop the dangling `test` dep from `java-e2e.needs`. The two workflows already run in parallel by being separate workflow files; `build-server` (the actual server-jar producer that java-e2e consumes) is the only real prerequisite from inside `ci.yml`.

## Test plan

- [x] `yaml.safe_load` parses; 9 jobs, no broken `needs:` references.
- [ ] After merge, the next push to main produces a multi-job CI run with `CI` displayed as the workflow name.

This is the same fix that's already on PR #238 (feat/pac-pae, commit `bf362224`). Landing it here unblocks every open PR immediately rather than waiting for the larger PAC/PAE branch to land.