### PR TITLE
fix(java-e2e): move E2eSuite12HandoffApprove to new layout (cannot find symbol)

### DIFF
--- a/sdk/java/e2e/Suite12HandoffApprove.java
+++ b/sdk/java/e2e/Suite12HandoffApprove.java
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 Agentspan
 // Licensed under the MIT License. See LICENSE file in the project root for details.
 
-package ai.agentspan.e2e;
-
 import ai.agentspan.Agent;
 import ai.agentspan.AgentRuntime;
 import ai.agentspan.annotations.Tool;
@@ -33,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("e2e")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Timeout(value = 300, unit = TimeUnit.SECONDS)
-class E2eSuite12HandoffApprove extends E2eBaseTest {
+class Suite12HandoffApprove extends BaseTest {
 
     private static AgentRuntime runtime;
 


### PR DESCRIPTION
## Summary

PR #228 (approve() targets sub-execution under handoff, commit `dd6ba05a`) added `E2eSuite12HandoffApprove.java` at the **old** test path (`sdk/java/src/test/java/ai/agentspan/e2e/`), extending the now-deleted `E2eBaseTest`. PR #223 had earlier moved all e2e tests to a flat `sdk/java/e2e/` layout with no package and `BaseTest` as the parent class — the reviewer missed the convention.

Result: `java-e2e` on `main` (and every PR's merge tree) fails with 5x `cannot find symbol: E2eBaseTest`. Same broken pattern PR #239 surfaced for `E2eSuite13ToolTypes` and PR #240 unblocked at the workflow level.

Failing CI run: https://github.com/agentspan-ai/agentspan/actions/runs/25966916074/job/76332262258

## Change

Apply the PR #223 layout:
- Move `sdk/java/src/test/java/ai/agentspan/e2e/E2eSuite12HandoffApprove.java` → `sdk/java/e2e/Suite12HandoffApprove.java`
- Drop `package ai.agentspan.e2e;`
- Rename class `E2eSuite12HandoffApprove` → `Suite12HandoffApprove`
- Change `extends E2eBaseTest` → `extends BaseTest`

Behaviour, assertions, and test ids unchanged — pure layout fix.

## Test plan

- [x] `./gradlew compileTestJava` (sdk/java) → BUILD SUCCESSFUL.
- [ ] Next CI run on main should have `java-e2e` compile cleanly.