### PR TITLE
fix(server): make AgentConfig.synthesize nullable Boolean (unblocks Suite16)

### DIFF
--- a/server/src/main/java/dev/agentspan/runtime/model/AgentConfig.java
+++ b/server/src/main/java/dev/agentspan/runtime/model/AgentConfig.java
@@ -116,7 +116,22 @@ public class AgentConfig {
     private boolean external = false;
 
     /** Whether to append a final LLM synthesis step after specialist agents complete.
-     * Set to false to pass specialist output through unchanged. Default true. */
-    @Builder.Default
-    private boolean synthesize = true;
+     * Set to false to pass specialist output through unchanged. Default true.
+     *
+     * <p>Modelled as nullable Boolean (no Builder.Default) so {@code @JsonInclude(NON_NULL)}
+     * keeps the field out of serialized output when callers leave it unset — the SDKs only
+     * emit ``synthesize`` on the wire when explicitly disabled, and the metadata.agentDef
+     * round-trip must preserve that. {@link #isSynthesize()} treats null as ``true``
+     * for compiler use.
+     *
+     * <p>Without this nullable-Boolean shape, ``Suite16Synthesize.test_handoff_default_has_final_task``
+     * fails: a primitive ``boolean synthesize = true`` always serializes to JSON, so
+     * ``agentDef`` contains ``synthesize: true`` even when the caller never set the flag —
+     * violating the test's contract (omit unless explicitly disabled). */
+    private Boolean synthesize;
+
+    /** True iff synthesize hasn't been explicitly disabled (treats null/unset as default true). */
+    public boolean isSynthesize() {
+        return synthesize == null || synthesize;
+    }
 }


### PR DESCRIPTION
## Summary

Cherry-picks the relevant slice of PR #238's commit `6fb791a4` to unblock `java-e2e > Suite16Synthesize > test_handoff_default_has_final_task` on main.

## What's wrong on main

`AgentConfig.synthesize` is a **primitive** `boolean` with `@Builder.Default = true`. Lombok generates a getter that always returns a value, and Jackson with `@JsonInclude(NON_NULL)` can't omit a primitive — so the field always serializes:

```
agentDef = {..., "synthesize": true}
```

even when the caller never set it. `Suite16Synthesize.test_handoff_default_has_final_task` (Suite16Synthesize.java:89) asserts:

```java
assertFalse(agentDef.containsKey("synthesize"),
    "[default handoff] agentDef should NOT contain 'synthesize' when default.");
```

→ fails on every run.

## Fix

Change the field to `private Boolean synthesize;` (nullable, no `@Builder.Default`) and add an explicit `isSynthesize()` that treats `null` as `true`. `@JsonInclude(NON_NULL)` now keeps the field out of serialized output when callers leave it unset; explicit `synthesize=false` still round-trips through `agentDef`.

All three `MultiAgentCompiler` call sites already consume `config.isSynthesize()` — behavior preserved.

## Test plan

- [x] `./gradlew test` (server) → BUILD SUCCESSFUL.
- [x] `./gradlew test -Pe2e` (sdk/java) on a server jar built from this branch → **178 / 178 pass** (was 177 / 178 with `Suite16Synthesize.test_handoff_default_has_final_task` failing).

Same fix has been on PR #238 since `6fb791a4`; pulling it forward here so main's java-e2e gate is green now, rather than waiting for the bigger PAC/PAE branch to land.