### PR TITLE
fix(py-e2e): scope test_local_timeout assertion to the sleep task

### DIFF
--- a/sdk/python/e2e/test_suite10_code_execution.py
+++ b/sdk/python/e2e/test_suite10_code_execution.py
@@ -470,9 +470,30 @@ class TestSuite10CodeExecution:
             f"[Timeout] Unexpected status '{result.status}'. {diag}"
         )
 
-        # The execute_code task output should NOT contain "done" as stdout
+        # The execute_code task output should NOT contain "done" as stdout.
+        #
+        # Scope the assertion to tasks that actually ran the *sleep* code.
+        # With ``max_turns=2`` the agent gets a second LLM turn after the
+        # first task's timeout, and the model often "fixes" the issue by
+        # re-running ``print("done")`` *without* the sleep — that follow-up
+        # task legitimately completes with ``stdout="done\n"``. The
+        # contract is "the sleeping code timed out", not "no code ever
+        # completed across the whole run".
         exec_tasks = _find_execute_code_tasks(result.execution_id)
-        for task in exec_tasks:
+
+        def _ran_sleep(task) -> bool:
+            inp = task.get("inputData") or {}
+            code = inp.get("code") or inp.get("source") or ""
+            return "sleep" in str(code).lower()
+
+        sleep_tasks = [t for t in exec_tasks if _ran_sleep(t)]
+        assert sleep_tasks, (
+            f"[Timeout] No execute_code task ran the sleep code — the LLM "
+            f"never invoked the tool with the sleep snippet. "
+            f"exec_tasks={len(exec_tasks)} | {diag}"
+        )
+
+        for task in sleep_tasks:
             output_data = task.get("outputData", {})
             stdout = ""
             if isinstance(output_data, dict):
@@ -480,20 +501,20 @@ class TestSuite10CodeExecution:
                 if isinstance(result_data, dict):
                     stdout = str(result_data.get("stdout", ""))
             assert "done" not in stdout, (
-                f"[Timeout] Code completed despite timeout=3! stdout={stdout[:200]}"
+                f"[Timeout] Sleep code completed despite timeout=3! "
+                f"stdout={stdout[:200]}"
             )
 
-        # Verify timeout error appeared somewhere in the task output
-        if exec_tasks:
-            any_timeout = any(
-                "timed out" in _task_output_str(t).lower()
-                or "timeout" in _task_output_str(t).lower()
-                for t in exec_tasks
-            )
-            assert any_timeout, (
-                f"[Timeout] Expected timeout error in task output. "
-                f"Task outputs: {[_task_output_str(t)[:200] for t in exec_tasks]}"
-            )
+        # Verify timeout error appeared on the sleep task(s).
+        any_timeout = any(
+            "timed out" in _task_output_str(t).lower()
+            or "timeout" in _task_output_str(t).lower()
+            for t in sleep_tasks
+        )
+        assert any_timeout, (
+            f"[Timeout] Expected timeout error in sleep task output. "
+            f"Sleep task outputs: {[_task_output_str(t)[:200] for t in sleep_tasks]}"
+        )
 
     # -- Docker Python execution -------------------------------------------
 


### PR DESCRIPTION
## Summary

\`test_suite10_code_execution.test_local_timeout\` prompts the agent with \`time.sleep(30); print("done")\` and a 3-second executor timeout, then iterates **every** \`execute_code\` task in the workflow and fails if any has \`"done"\` in stdout.

With \`max_turns=2\` the agent has a second LLM turn after the first task times out — and \`gpt-4o-mini\`'s usual response is to "fix" the problem by re-running just \`print("done")\` without the sleep. That follow-up task legitimately completes with \`stdout="done\\n"\` and the loop fails on it:

\`\`\`
assert 'done' not in 'done\\n'
\`\`\`

…even though the original sleep call **did** time out as the test was actually trying to verify.

Failing run: https://github.com/agentspan-ai/agentspan/actions/runs/25970342340/job/76342483608

## Change

Scope both assertions to tasks whose input code contains \`sleep\`. Contract: "the sleeping code timed out", not "no code ever completed". Also surface a clearer error when the LLM never invoked the tool with the sleep snippet at all.

## Test plan

- [x] \`pytest test_suite10_code_execution.py::test_local_timeout\` passes locally — was failing on CI for the reason above.
- [ ] Next CI run on this PR exercises the scoped path.