### PR TITLE
fix(py-e2e): bump test_pdf_generation_and_roundtrip timeout 120s → 240s

### DIFF
--- a/sdk/python/e2e/test_suite6_pdf_tools.py
+++ b/sdk/python/e2e/test_suite6_pdf_tools.py
@@ -20,7 +20,12 @@ pytestmark = [
     pytest.mark.e2e,
 ]
 
-TIMEOUT = 120
+# PDF generation is LLM call + tool call + PDF rendering — three serial
+# stages where the bottom of the budget is the LLM (~30-60s on CI for the
+# big SAMPLE_MARKDOWN payload). 120s left zero headroom and the test hit
+# the wall with status=RUNNING on CI run 25972790281. Bump to 240s so a
+# single slow LLM hop doesn't fail the suite.
+TIMEOUT = 240
 
 # ── Sample Markdown ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

CI run [25972790281](https://github.com/agentspan-ai/agentspan/actions/runs/25972790281/job/76347987331) failed with:

\`\`\`
[PDF Gen] Run did not complete. status=RUNNING |
execution_id=a532df56-fde4-4570-af99-dc8fc135c5e5
assert 'RUNNING' == 'COMPLETED'
\`\`\`

The workflow was still alive when the test's 120s budget expired. PDF generation is a serial pipeline: LLM call → \`generate_pdf\` tool → render markdown → upload. The LLM step alone runs 30-60s on CI for the big \`SAMPLE_MARKDOWN\` payload — 120s leaves zero headroom for the rest.

The test had been \`SKIPPED\` in every prior CI run (markitdown not installed, plan-step bailout), masking the timing issue. Once it actually started running it hit the wall on the first iteration.

## Change

Bump \`TIMEOUT\` from 120 → 240 in \`test_suite6_pdf_tools.py\`. The test's work is bounded; 240s comfortably covers a slow LLM hop. Total suite budget impact is small because this test is gated on optional deps.

## Test plan

- [x] YAML/Python parse.
- [ ] CI run on this PR exercises the longer budget.

Unrelated to PR #245 (which scopes the \`test_local_timeout\` assertion); they just happened to land on the same CI run.