### PR TITLE
ci(jira-sync): make manual (workflow_dispatch) instead of auto

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -1,14 +1,28 @@
 name: Jira Sync
+
+# Manual trigger only while the cross-visibility issue is resolved.
+#
+# This workflow calls a reusable workflow at
+# ``agentspan-ai/github-workflows/.github/workflows/jira-sync.yml@main``,
+# but that source repo is *private* and this one is *public*. GitHub
+# Actions does not allow a public repo to call a reusable workflow
+# from a private repo — the run is rejected at load time, producing a
+# 0-job failure on every trigger. 10 / 10 runs since PR #230 have failed
+# for this reason.
+#
+# Until either (a) ``agentspan-ai/github-workflows`` is made public or
+# (b) the workflow is inlined here, the prior ``pull_request`` /
+# ``issue_comment`` / ``release`` triggers were just noise on every PR.
+# Switch to ``workflow_dispatch`` so the failure surface goes away;
+# someone can still invoke it manually for testing once the access
+# issue is fixed.
 on:
-  pull_request:
-    types: [opened, closed]
-  issue_comment:
-    types: [created]
-  release:
-    types: [published]
+  workflow_dispatch:
+
 permissions:
   contents: write
   pull-requests: write
+
 jobs:
   jira:
     uses: agentspan-ai/github-workflows/.github/workflows/jira-sync.yml@main


### PR DESCRIPTION
## Summary

\`jira-sync\` has failed 10 / 10 times since PR #230 added it (May 12), producing a 0-job failure on every \`pull_request\`, \`issue_comment\`, and \`release\` event — red noise on every PR. Most recent example: https://github.com/agentspan-ai/agentspan/actions/runs/25978132916

## Root cause

Hard GitHub Actions restriction, not a configurable setting:

- \`agentspan-ai/github-workflows\` (source of the reusable workflow) is **private**
- \`agentspan-ai/agentspan\` (caller) is **public**
- GitHub doesn't allow public callers to use private reusable workflows. Org-level access settings don't override this. ([docs](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-to-reusable-workflows))

Two real fixes (both outside this PR):

1. Make \`agentspan-ai/github-workflows\` public
2. Inline the reusable workflow content here (43KB of YAML)

## Change

Switch the trigger from \`pull_request\` / \`issue_comment\` / \`release\` to **\`workflow_dispatch\` only**. The persistent failure surface goes away from PR checks. Anyone can still invoke jira-sync manually from the Actions tab for testing once the access issue is resolved, and the workflow file stays in place ready to re-enable.

## Test plan

- [x] YAML parses; one trigger (\`workflow_dispatch\`); job unchanged.
- [ ] After merge, no jira-sync runs fire on new PRs.