### PR TITLE
fix(java-sdk): rename workflowId → executionId to match other SDKs

### DIFF
--- a/sdk/java/e2e/BaseTest.java
+++ b/sdk/java/e2e/BaseTest.java
@@ -78,25 +78,25 @@ public abstract class BaseTest {
     /**
      * Fetch a full workflow execution from the server.
      *
-     * @param workflowId the workflow execution ID
+     * @param executionId the execution ID
      * @return the workflow data map
      */
     @SuppressWarnings("unchecked")
-    protected Map<String, Object> getWorkflow(String workflowId) {
+    protected Map<String, Object> getWorkflow(String executionId) {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(BASE_URL + "/api/workflow/" + workflowId))
+                .uri(URI.create(BASE_URL + "/api/workflow/" + executionId))
                 .timeout(Duration.ofSeconds(10))
                 .GET()
                 .build();
             HttpResponse<String> response = HTTP_CLIENT.send(request,
                 HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() >= 400) {
-                fail("Failed to fetch workflow " + workflowId + ": HTTP " + response.statusCode());
+                fail("Failed to fetch workflow " + executionId + ": HTTP " + response.statusCode());
             }
             return MAPPER.readValue(response.body(), Map.class);
         } catch (Exception e) {
-            fail("Failed to fetch workflow " + workflowId + ": " + e.getMessage());
+            fail("Failed to fetch workflow " + executionId + ": " + e.getMessage());
             return null; // unreachable
         }
     }

--- a/sdk/java/e2e/Suite10CodeExecution.java
+++ b/sdk/java/e2e/Suite10CodeExecution.java
@@ -62,8 +62,8 @@ class Suite10CodeExecution extends BaseTest {
      * contains "execute_code".
      */
     @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> findExecuteCodeTasks(String workflowId) {
-        Map<String, Object> workflow = getWorkflow(workflowId);
+    private List<Map<String, Object>> findExecuteCodeTasks(String executionId) {
+        Map<String, Object> workflow = getWorkflow(executionId);
         List<Map<String, Object>> allTasks = (List<Map<String, Object>>) workflow.get("tasks");
         if (allTasks == null) return List.of();
         return allTasks.stream()
@@ -296,10 +296,10 @@ class Suite10CodeExecution extends BaseTest {
             + "Status: " + result.getStatus()
             + ". Error: " + result.getError());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        List<Map<String, Object>> execTasks = findExecuteCodeTasks(workflowId);
+        List<Map<String, Object>> execTasks = findExecuteCodeTasks(executionId);
 
         assertFalse(execTasks.isEmpty(),
             "No execute_code task found in workflow. "
@@ -350,10 +350,10 @@ class Suite10CodeExecution extends BaseTest {
             + "Status: " + result.getStatus()
             + ". Error: " + result.getError());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        List<Map<String, Object>> execTasks = findExecuteCodeTasks(workflowId);
+        List<Map<String, Object>> execTasks = findExecuteCodeTasks(executionId);
 
         assertFalse(execTasks.isEmpty(),
             "No execute_code task found in workflow. "
@@ -407,10 +407,10 @@ class Suite10CodeExecution extends BaseTest {
                 || result.getStatus() == AgentStatus.TERMINATED,
             "Expected a terminal status. Got: " + result.getStatus());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        List<Map<String, Object>> execTasks = findExecuteCodeTasks(workflowId);
+        List<Map<String, Object>> execTasks = findExecuteCodeTasks(executionId);
 
         if (!execTasks.isEmpty()) {
             // Verify that the timeout error message appears in at least one task

--- a/sdk/java/e2e/Suite12HandoffApprove.java
+++ b/sdk/java/e2e/Suite12HandoffApprove.java
@@ -89,9 +89,9 @@ class Suite12HandoffApprove extends BaseTest {
         try (AgentStream stream = runtime.stream(support,
                 "Please run: UPDATE users SET active = true WHERE id = 1")) {
 
-            String topWorkflowId = stream.getWorkflowId();
-            assertNotNull(topWorkflowId);
-            assertFalse(topWorkflowId.isEmpty());
+            String topExecutionId = stream.getExecutionId();
+            assertNotNull(topExecutionId);
+            assertFalse(topExecutionId.isEmpty());
 
             AgentEvent waiting = null;
             for (AgentEvent event : stream) {
@@ -104,12 +104,12 @@ class Suite12HandoffApprove extends BaseTest {
 
             assertNotNull(waiting, "expected a WAITING event from the sub-agent's approval-required tool");
 
-            String waitingExecId = waiting.getWorkflowId();
+            String waitingExecId = waiting.getExecutionId();
             assertNotNull(waitingExecId, "WAITING event must carry an execution id");
             assertFalse(waitingExecId.isEmpty(), "WAITING event execution id must not be empty");
-            assertNotEquals(topWorkflowId, waitingExecId,
+            assertNotEquals(topExecutionId, waitingExecId,
                 "under HANDOFF the HUMAN task lives in the sub-execution, "
-                + "so the WAITING event id must differ from the top-level workflow id");
+                + "so the WAITING event id must differ from the top-level execution id");
         }
     }
 
@@ -170,7 +170,7 @@ class Suite12HandoffApprove extends BaseTest {
                 /*args*/ null,
                 /*result*/ null,
                 /*output*/ null,
-                /*workflowId*/ "",
+                /*executionId*/ "",
                 /*guardrailName*/ null,
                 /*target*/ null
             );

--- a/sdk/java/e2e/Suite12HandoffApprove.java
+++ b/sdk/java/e2e/Suite12HandoffApprove.java
@@ -180,8 +180,8 @@ class Suite12HandoffApprove extends BaseTest {
                 () -> stream.approve(eventWithNoId));
 
             assertNotNull(thrown.getMessage());
-            assertTrue(thrown.getMessage().contains("workflow id"),
-                "exception should mention the missing workflow id, got: " + thrown.getMessage());
+            assertTrue(thrown.getMessage().contains("execution id"),
+                "exception should mention the missing execution id, got: " + thrown.getMessage());
         }
     }
 }

--- a/sdk/java/e2e/Suite12TerminationGates.java
+++ b/sdk/java/e2e/Suite12TerminationGates.java
@@ -73,10 +73,10 @@ class Suite12TerminationGates extends BaseTest {
             + ". Termination gates complete the loop, not fail it.");
 
         // Fetch the workflow and count DO_WHILE iterations
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
         List<Map<String, Object>> allTasks = (List<Map<String, Object>>) workflow.get("tasks");
         assertNotNull(allTasks, "workflow has no 'tasks' field");
 
@@ -151,10 +151,10 @@ class Suite12TerminationGates extends BaseTest {
             + ". Termination gates complete the loop, not fail it.");
 
         // Fetch the workflow and check iterations stayed low
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
         List<Map<String, Object>> allTasks = (List<Map<String, Object>>) workflow.get("tasks");
         assertNotNull(allTasks, "workflow has no 'tasks' field");
 

--- a/sdk/java/e2e/Suite14StatefulDomain.java
+++ b/sdk/java/e2e/Suite14StatefulDomain.java
@@ -319,21 +319,21 @@ class Suite14StatefulDomain extends BaseTest {
             "Run 1 must succeed; status=" + r1.getStatus() + " error=" + r1.getError());
         assertTrue(r2.isSuccess(),
             "Run 2 must succeed; status=" + r2.getStatus() + " error=" + r2.getError());
-        assertNotEquals(r1.getWorkflowId(), r2.getWorkflowId(),
+        assertNotEquals(r1.getExecutionId(), r2.getExecutionId(),
             "Concurrent runs must have distinct execution IDs.");
 
         Map<String, Object> ttd1 = (Map<String, Object>)
-            getWorkflow(r1.getWorkflowId()).getOrDefault("taskToDomain", Map.of());
+            getWorkflow(r1.getExecutionId()).getOrDefault("taskToDomain", Map.of());
         Map<String, Object> ttd2 = (Map<String, Object>)
-            getWorkflow(r2.getWorkflowId()).getOrDefault("taskToDomain", Map.of());
+            getWorkflow(r2.getExecutionId()).getOrDefault("taskToDomain", Map.of());
 
         assertFalse(ttd1.isEmpty(),
             "Run 1 taskToDomain is empty — stateful agent must have a domain "
-            + "assignment. wfId=" + r1.getWorkflowId()
+            + "assignment. wfId=" + r1.getExecutionId()
             + ". COUNTERFACTUAL: missing runId on start would produce an empty map.");
         assertFalse(ttd2.isEmpty(),
             "Run 2 taskToDomain is empty — stateful agent must have a domain "
-            + "assignment. wfId=" + r2.getWorkflowId());
+            + "assignment. wfId=" + r2.getExecutionId());
 
         Set<String> domains1 = new HashSet<>();
         for (Object v : ttd1.values()) if (v != null) domains1.add(v.toString());
@@ -442,12 +442,12 @@ class Suite14StatefulDomain extends BaseTest {
 
         assertTrue(r1.isSuccess(), "Run 1: " + r1.getStatus() + " " + r1.getError());
         assertTrue(r2.isSuccess(), "Run 2: " + r2.getStatus() + " " + r2.getError());
-        assertNotEquals(r1.getWorkflowId(), r2.getWorkflowId());
+        assertNotEquals(r1.getExecutionId(), r2.getExecutionId());
 
         Map<String, Object> ttd1 = (Map<String, Object>)
-            getWorkflow(r1.getWorkflowId()).getOrDefault("taskToDomain", Map.of());
+            getWorkflow(r1.getExecutionId()).getOrDefault("taskToDomain", Map.of());
         Map<String, Object> ttd2 = (Map<String, Object>)
-            getWorkflow(r2.getWorkflowId()).getOrDefault("taskToDomain", Map.of());
+            getWorkflow(r2.getExecutionId()).getOrDefault("taskToDomain", Map.of());
 
         assertFalse(ttd1.isEmpty(),
             "Per-tool stateful MUST cause a non-empty taskToDomain even when "

--- a/sdk/java/e2e/Suite6PdfTools.java
+++ b/sdk/java/e2e/Suite6PdfTools.java
@@ -340,16 +340,16 @@ class Suite6PdfTools extends BaseTest {
             agent,
             "Convert the following markdown to a PDF. Pass it exactly to generate_pdf:\n\n" + sampleMarkdown);
 
-        assertNotNull(result.getWorkflowId(),
+        assertNotNull(result.getExecutionId(),
             "Agent run must produce an executionId. status=" + result.getStatus()
             + " error=" + result.getError());
         assertTrue(result.isSuccess(),
             "Agent run did not succeed: status=" + result.getStatus()
             + ", error=" + result.getError());
 
-        Map<String, Object> wf = getWorkflow(result.getWorkflowId());
+        Map<String, Object> wf = getWorkflow(result.getExecutionId());
         List<Map<String, Object>> tasks = (List<Map<String, Object>>) wf.get("tasks");
-        assertNotNull(tasks, "Workflow has no tasks array. wfId=" + result.getWorkflowId());
+        assertNotNull(tasks, "Workflow has no tasks array. wfId=" + result.getExecutionId());
 
         Map<String, Object> pdfTask = tasks.stream()
             .filter(t -> {

--- a/sdk/java/e2e/Suite7MediaTools.java
+++ b/sdk/java/e2e/Suite7MediaTools.java
@@ -341,9 +341,9 @@ class Suite7MediaTools extends BaseTest {
             "Agent run did not succeed: status=" + result.getStatus()
             + ", error=" + result.getError());
 
-        Map<String, Object> wf = getWorkflow(result.getWorkflowId());
+        Map<String, Object> wf = getWorkflow(result.getExecutionId());
         List<Map<String, Object>> tasks = (List<Map<String, Object>>) wf.get("tasks");
-        assertNotNull(tasks, "Workflow has no tasks. wfId=" + result.getWorkflowId());
+        assertNotNull(tasks, "Workflow has no tasks. wfId=" + result.getExecutionId());
 
         Map<String, Object> imgTask = tasks.stream()
             .filter(t -> {

--- a/sdk/java/e2e/Suite9Handoffs.java
+++ b/sdk/java/e2e/Suite9Handoffs.java
@@ -96,10 +96,10 @@ class Suite9Handoffs extends BaseTest {
             + "Status: " + result.getStatus()
             + ". Error: " + result.getError());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
         Map<String, Object> workflowDef = (Map<String, Object>) workflow.get("workflowDef");
         if (workflowDef == null) {
             // Fall back to the execution-level tasks
@@ -151,10 +151,10 @@ class Suite9Handoffs extends BaseTest {
             + "Status: " + result.getStatus()
             + ". Error: " + result.getError());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
 
         // Check at the workflowDef level (plan tasks)
         Map<String, Object> workflowDef = (Map<String, Object>) workflow.get("workflowDef");
@@ -214,10 +214,10 @@ class Suite9Handoffs extends BaseTest {
             + "Status: " + result.getStatus()
             + ". Error: " + result.getError());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
 
         // Check for SUB_WORKFLOW tasks (from plan) or executed sub-workflow tasks
         Map<String, Object> workflowDef = (Map<String, Object>) workflow.get("workflowDef");
@@ -294,10 +294,10 @@ class Suite9Handoffs extends BaseTest {
             + "Status: " + result.getStatus()
             + ". Error: " + result.getError());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
         Map<String, Object> workflowDef = (Map<String, Object>) workflow.get("workflowDef");
 
         if (workflowDef != null) {
@@ -357,10 +357,10 @@ class Suite9Handoffs extends BaseTest {
             + "Status: " + result.getStatus()
             + ". Error: " + result.getError());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
 
         // Check execution-level tasks for a SUB_WORKFLOW whose referenceTaskName contains "math"
         List<Map<String, Object>> allExecTasks = (List<Map<String, Object>>) workflow.get("tasks");
@@ -415,10 +415,10 @@ class Suite9Handoffs extends BaseTest {
                 || result.getStatus() == AgentStatus.TERMINATED,
             "Expected a terminal status (COMPLETED/FAILED/TERMINATED). Got: " + result.getStatus());
 
-        String workflowId = result.getWorkflowId();
-        assertNotNull(workflowId, "workflowId is null");
+        String executionId = result.getExecutionId();
+        assertNotNull(executionId, "executionId is null");
 
-        Map<String, Object> workflow = getWorkflow(workflowId);
+        Map<String, Object> workflow = getWorkflow(executionId);
 
         List<Map<String, Object>> allExecTasks = (List<Map<String, Object>>) workflow.get("tasks");
         assertNotNull(allExecTasks, "workflow has no 'tasks' field");

--- a/sdk/java/examples/src/main/java/ai/agentspan/examples/Example09bHandoffHumanInTheLoop.java
+++ b/sdk/java/examples/src/main/java/ai/agentspan/examples/Example09bHandoffHumanInTheLoop.java
@@ -24,8 +24,8 @@ import java.util.List;
  * {@code dba} sub-workflow, not the orchestrator's workflow.
  *
  * <p>The {@code WAITING} SSE event from the sub-workflow carries that
- * sub-workflow's id in its {@code workflowId} field; the SDK uses it to POST
- * {@code /api/agent/{subWorkflowId}/respond} when {@link AgentStream#approve()}
+ * sub-workflow's id in its {@code executionId} field; the SDK uses it to POST
+ * {@code /api/agent/{executionId}/respond} when {@link AgentStream#approve()}
  * is called. No manual task-tree walking required from the user.
  *
  * <p>Run against a server with an LLM provider configured (e.g. {@code
@@ -67,8 +67,8 @@ public class Example09bHandoffHumanInTheLoop {
             AgentStream stream = runtime.stream(support,
                 "Please run: UPDATE users SET active = true WHERE id = 1");
 
-            String topWorkflowId = stream.getWorkflowId();
-            System.out.println("Top-level workflow id: " + topWorkflowId);
+            String topExecutionId = stream.getExecutionId();
+            System.out.println("Top-level execution id: " + topExecutionId);
 
             for (AgentEvent event : stream) {
                 EventType type = event.getType();
@@ -78,14 +78,14 @@ public class Example09bHandoffHumanInTheLoop {
                     System.out.println("[TOOL_CALL] " + event.getToolName()
                         + " " + event.getArgs());
                 } else if (type == EventType.WAITING) {
-                    // event.workflowId is the SUB-execution id when the HUMAN task lives
+                    // event.executionId is the SUB-execution id when the HUMAN task lives
                     // in a sub-agent (handoff/sequential/parallel). Pass the event to
                     // approve() so the SDK POSTs /respond to the right execution.
                     // (stream.approve() with no args targets the top-level execution and
                     // would 500 here.)
-                    System.out.println("[WAITING] event.workflowId=" + event.getWorkflowId()
+                    System.out.println("[WAITING] event.executionId=" + event.getExecutionId()
                         + " (the sub-execution that owns the HUMAN task)");
-                    System.out.println("          stream.workflowId=" + topWorkflowId
+                    System.out.println("          stream.executionId=" + topExecutionId
                         + " (top-level orchestrator — approve() with no args would 500 here)");
                     System.out.println("Calling stream.approve(event)...");
                     stream.approve(event);

--- a/sdk/java/examples/src/main/java/ai/agentspan/examples/Example12LongRunning.java
+++ b/sdk/java/examples/src/main/java/ai/agentspan/examples/Example12LongRunning.java
@@ -33,7 +33,7 @@ public class Example12LongRunning {
             AgentHandle handle = runtime.start(analyst,
                 "What are the key metrics to track for a SaaS product?");
 
-            System.out.println("Agent started: " + handle.getWorkflowId());
+            System.out.println("Agent started: " + handle.getExecutionId());
             System.out.println("Polling for result...");
 
             // Simulate doing other work while the agent runs

--- a/sdk/java/examples/src/main/java/ai/agentspan/examples/Example18ManualSelection.java
+++ b/sdk/java/examples/src/main/java/ai/agentspan/examples/Example18ManualSelection.java
@@ -73,7 +73,7 @@ public class Example18ManualSelection {
             + "then have it reviewed for accuracy and style.";
 
         AgentHandle handle = Agentspan.start(editorialTeam, prompt);
-        System.out.println("Workflow ID: " + handle.getWorkflowId());
+        System.out.println("Execution ID: " + handle.getExecutionId());
 
         // Drive the 3 manual turns. Each turn the MANUAL strategy creates a
         // HumanTask and sets isWaiting=true. We poll for that state, then send

--- a/sdk/java/examples/src/main/java/ai/agentspan/examples/Example32HumanGuardrail.java
+++ b/sdk/java/examples/src/main/java/ai/agentspan/examples/Example32HumanGuardrail.java
@@ -91,7 +91,7 @@ public class Example32HumanGuardrail {
         AgentHandle handle = Agentspan.start(financeAgent,
             "What is the current price of AAPL and is it a good risk-free investment?");
 
-        System.out.println("Workflow ID: " + handle.getWorkflowId());
+        System.out.println("Execution ID: " + handle.getExecutionId());
         System.out.println("Waiting for compliance guardrail review...");
 
         // Poll for the WAITING state; auto-approve to simulate human approval

--- a/sdk/java/src/main/java/ai/agentspan/AgentRuntime.java
+++ b/sdk/java/src/main/java/ai/agentspan/AgentRuntime.java
@@ -173,10 +173,10 @@ public class AgentRuntime implements AutoCloseable {
             logger.debug("Starting agent '{}' with prompt: {}", agent.getName(), prompt);
 
             Map<String, Object> response = httpApi.startAgent(agentConfig, prompt, sessionId, runId);
-            String workflowId = extractWorkflowId(response);
+            String executionId = extractExecutionId(response);
 
-            logger.info("Agent '{}' started with workflow ID: {}", agent.getName(), workflowId);
-            return new AgentHandle(workflowId, httpApi);
+            logger.info("Agent '{}' started with execution ID: {}", agent.getName(), executionId);
+            return new AgentHandle(executionId, httpApi);
         });
     }
 
@@ -208,13 +208,13 @@ public class AgentRuntime implements AutoCloseable {
         workerManager.startAll();
 
         return startAsync(agent, prompt).thenApply(handle -> {
-            String workflowId = handle.getWorkflowId();
-            String sseUrl = config.getServerUrl() + "/api/agent/stream/" + workflowId;
+            String executionId = handle.getExecutionId();
+            String sseUrl = config.getServerUrl() + "/api/agent/stream/" + executionId;
 
             SseClient sseClient = new SseClient(sseUrl, config, httpApi.getHttpClient());
             sseClient.connect();
 
-            return new AgentStream(workflowId, sseClient, httpApi);
+            return new AgentStream(executionId, sseClient, httpApi);
         });
     }
 
@@ -744,11 +744,11 @@ public class AgentRuntime implements AutoCloseable {
         return result;
     }
 
-    private String extractWorkflowId(Map<String, Object> response) {
-        // Try several possible keys — server renamed workflowId → executionId
+    private String extractExecutionId(Map<String, Object> response) {
         Object id = response.get("executionId");
         if (id != null) return id.toString();
 
+        // Legacy fallback — older server versions may still return workflowId
         id = response.get("workflowId");
         if (id != null) return id.toString();
 
@@ -758,11 +758,10 @@ public class AgentRuntime implements AutoCloseable {
         id = response.get("correlationId");
         if (id != null) return id.toString();
 
-        // If only one value in the map, use it
         if (response.size() == 1) {
             return response.values().iterator().next().toString();
         }
 
-        throw new RuntimeException("Cannot extract workflow ID from response: " + response);
+        throw new RuntimeException("Cannot extract execution ID from response: " + response);
     }
 }

--- a/sdk/java/src/main/java/ai/agentspan/internal/HttpApi.java
+++ b/sdk/java/src/main/java/ai/agentspan/internal/HttpApi.java
@@ -42,7 +42,7 @@ public class HttpApi {
      * @param agentConfig serialized agent configuration
      * @param prompt      user prompt
      * @param sessionId   optional session ID
-     * @return server response containing workflowId
+     * @return server response containing executionId
      */
     public Map<String, Object> startAgent(Map<String, Object> agentConfig, String prompt, String sessionId) {
         return startAgent(agentConfig, prompt, sessionId, null);
@@ -60,7 +60,7 @@ public class HttpApi {
      * @param prompt      user prompt
      * @param sessionId   optional session ID
      * @param runId       optional per-execution UUID — set for stateful agents
-     * @return server response containing workflowId
+     * @return server response containing executionId
      */
     public Map<String, Object> startAgent(
             Map<String, Object> agentConfig, String prompt, String sessionId, String runId) {
@@ -94,29 +94,29 @@ public class HttpApi {
     }
 
     /**
-     * Get the current status of an agent workflow.
+     * Get the current status of an agent execution.
      *
-     * @param workflowId the workflow ID
+     * @param executionId the execution ID
      * @return status response map
      */
-    public Map<String, Object> getAgentStatus(String workflowId) {
-        return get("/api/agent/" + workflowId + "/status");
+    public Map<String, Object> getAgentStatus(String executionId) {
+        return get("/api/agent/" + executionId + "/status");
     }
 
     /**
      * Respond to a waiting agent (approve/reject a tool or send a message).
      *
-     * @param workflowId the workflow ID
-     * @param approved   whether to approve
-     * @param reason     optional rejection reason
+     * @param executionId the execution ID
+     * @param approved    whether to approve
+     * @param reason      optional rejection reason
      */
-    public void respondToAgent(String workflowId, boolean approved, String reason) {
+    public void respondToAgent(String executionId, boolean approved, String reason) {
         Map<String, Object> body = new HashMap<>();
         body.put("approved", approved);
         if (reason != null && !reason.isEmpty()) {
             body.put("reason", reason);
         }
-        post("/api/agent/" + workflowId + "/respond", body);
+        post("/api/agent/" + executionId + "/respond", body);
     }
 
     /**
@@ -125,11 +125,11 @@ public class HttpApi {
      * <p>Used for structured responses such as manual agent selection:
      * {@code {"selected": "writer"}}.
      *
-     * @param workflowId the workflow ID
-     * @param data       the response payload
+     * @param executionId the execution ID
+     * @param data        the response payload
      */
-    public void respondWithData(String workflowId, Map<String, Object> data) {
-        post("/api/agent/" + workflowId + "/respond", data);
+    public void respondWithData(String executionId, Map<String, Object> data) {
+        post("/api/agent/" + executionId + "/respond", data);
     }
 
     /**
@@ -252,13 +252,13 @@ public class HttpApi {
     }
 
     /**
-     * Get the workflow status for resume (extracts domain/run_id).
+     * Get the workflow data for an execution (extracts domain/run_id).
      *
-     * @param workflowId the workflow ID
+     * @param executionId the execution ID
      * @return workflow data map
      */
-    public Map<String, Object> getWorkflow(String workflowId) {
-        return get("/api/workflow/" + workflowId);
+    public Map<String, Object> getWorkflow(String executionId) {
+        return get("/api/workflow/" + executionId);
     }
 
     // ── Internal helpers ─────────────────────────────────────────────────
@@ -328,9 +328,9 @@ public class HttpApi {
             if (responseBody.startsWith("{")) {
                 return JsonMapper.fromJson(responseBody, Map.class);
             } else if (responseBody.startsWith("\"") || (!responseBody.startsWith("[") && !responseBody.startsWith("{"))) {
-                // Plain string response (e.g., workflow ID)
+                // Plain string response (e.g., execution ID)
                 Map<String, Object> result = new HashMap<>();
-                result.put("workflowId", responseBody.replace("\"", ""));
+                result.put("executionId", responseBody.replace("\"", ""));
                 return result;
             } else {
                 return JsonMapper.fromJson(responseBody, Map.class);

--- a/sdk/java/src/main/java/ai/agentspan/model/AgentEvent.java
+++ b/sdk/java/src/main/java/ai/agentspan/model/AgentEvent.java
@@ -21,7 +21,7 @@ public class AgentEvent {
     private final Map<String, Object> args;
     private final Object result;
     private final Object output;
-    private final String workflowId;
+    private final String executionId;
     private final String guardrailName;
     private final String target;
 
@@ -32,7 +32,7 @@ public class AgentEvent {
             Map<String, Object> args,
             Object result,
             Object output,
-            String workflowId,
+            String executionId,
             String guardrailName,
             String target) {
         this.type = type;
@@ -41,7 +41,7 @@ public class AgentEvent {
         this.args = args;
         this.result = result;
         this.output = output;
-        this.workflowId = workflowId;
+        this.executionId = executionId;
         this.guardrailName = guardrailName;
         this.target = target;
     }
@@ -52,7 +52,7 @@ public class AgentEvent {
     public Map<String, Object> getArgs() { return args; }
     public Object getResult() { return result; }
     public Object getOutput() { return output; }
-    public String getWorkflowId() { return workflowId; }
+    public String getExecutionId() { return executionId; }
     public String getGuardrailName() { return guardrailName; }
     public String getTarget() { return target; }
 

--- a/sdk/java/src/main/java/ai/agentspan/model/AgentHandle.java
+++ b/sdk/java/src/main/java/ai/agentspan/model/AgentHandle.java
@@ -27,16 +27,16 @@ public class AgentHandle {
     private static final long DEFAULT_POLL_INTERVAL_MS = 2000;
     private static final long DEFAULT_TIMEOUT_MS = 600_000; // 10 minutes
 
-    private final String workflowId;
+    private final String executionId;
     private final HttpApi httpApi;
 
-    public AgentHandle(String workflowId, HttpApi httpApi) {
-        this.workflowId = workflowId;
+    public AgentHandle(String executionId, HttpApi httpApi) {
+        this.executionId = executionId;
         this.httpApi = httpApi;
     }
 
-    public String getWorkflowId() {
-        return workflowId;
+    public String getExecutionId() {
+        return executionId;
     }
 
     /**
@@ -62,15 +62,15 @@ public class AgentHandle {
 
         while (System.currentTimeMillis() - startTime < timeoutMs) {
             try {
-                Map<String, Object> status = httpApi.getAgentStatus(workflowId);
+                Map<String, Object> status = httpApi.getAgentStatus(executionId);
                 String workflowStatus = (String) status.get("status");
 
                 if (workflowStatus == null) {
-                    logger.debug("Waiting for agent {} — status unknown", workflowId);
+                    logger.debug("Waiting for agent {} — status unknown", executionId);
                 } else if (isTerminalStatus(workflowStatus)) {
                     return buildResult(status, workflowStatus);
                 } else {
-                    logger.debug("Waiting for agent {} — status: {}", workflowId, workflowStatus);
+                    logger.debug("Waiting for agent {} — status: {}", executionId, workflowStatus);
                 }
 
                 Thread.sleep(pollIntervalMs);
@@ -88,14 +88,14 @@ public class AgentHandle {
             }
         }
 
-        throw new RuntimeException("Agent timed out after " + timeoutMs + "ms: " + workflowId);
+        throw new RuntimeException("Agent timed out after " + timeoutMs + "ms: " + executionId);
     }
 
     /**
      * Approve a pending tool call that requires human approval.
      */
     public void approve() {
-        httpApi.respondToAgent(workflowId, true, null);
+        httpApi.respondToAgent(executionId, true, null);
     }
 
     /**
@@ -104,7 +104,7 @@ public class AgentHandle {
      * @param reason rejection reason
      */
     public void reject(String reason) {
-        httpApi.respondToAgent(workflowId, false, reason);
+        httpApi.respondToAgent(executionId, false, reason);
     }
 
     /**
@@ -116,7 +116,7 @@ public class AgentHandle {
      * @param data the response payload
      */
     public void respond(Map<String, Object> data) {
-        httpApi.respondWithData(workflowId, data);
+        httpApi.respondWithData(executionId, data);
     }
 
     /**
@@ -125,7 +125,7 @@ public class AgentHandle {
      * @param message the message to send
      */
     public void send(String message) {
-        httpApi.respondToAgent(workflowId, true, null);
+        httpApi.respondToAgent(executionId, true, null);
     }
 
     /**
@@ -135,7 +135,7 @@ public class AgentHandle {
      */
     public boolean isWaiting() {
         try {
-            Map<String, Object> status = httpApi.getAgentStatus(workflowId);
+            Map<String, Object> status = httpApi.getAgentStatus(executionId);
             Object waiting = status.get("isWaiting");
             return Boolean.TRUE.equals(waiting);
         } catch (Exception e) {
@@ -153,7 +153,7 @@ public class AgentHandle {
         long start = System.currentTimeMillis();
         while (System.currentTimeMillis() - start < timeoutMs) {
             try {
-                Map<String, Object> status = httpApi.getAgentStatus(workflowId);
+                Map<String, Object> status = httpApi.getAgentStatus(executionId);
                 Object waiting = status.get("isWaiting");
                 if (Boolean.TRUE.equals(waiting)) return true;
                 String workflowStatus = (String) status.get("status");
@@ -213,7 +213,7 @@ public class AgentHandle {
         TokenUsage tokenUsage = null;
         List<Map<String, Object>> toolCalls = new ArrayList<>();
         try {
-            Map<String, Object> workflow = httpApi.getWorkflow(workflowId);
+            Map<String, Object> workflow = httpApi.getWorkflow(executionId);
             Object tasksRaw = workflow.get("tasks");
             if (tasksRaw instanceof List) {
                 int promptT = 0, completionT = 0, totalT = 0;
@@ -271,10 +271,10 @@ public class AgentHandle {
                 }
             }
         } catch (Exception e) {
-            logger.debug("Could not extract tokens/toolCalls for {}: {}", workflowId, e.getMessage());
+            logger.debug("Could not extract tokens/toolCalls for {}: {}", executionId, e.getMessage());
         }
 
-        return new AgentResult(output, workflowId, status, toolCalls, null, tokenUsage, error);
+        return new AgentResult(output, executionId, status, toolCalls, null, tokenUsage, error);
     }
 
     private int toInt(Object value) {
@@ -289,6 +289,6 @@ public class AgentHandle {
 
     @Override
     public String toString() {
-        return "AgentHandle{workflowId=" + workflowId + "}";
+        return "AgentHandle{executionId=" + executionId + "}";
     }
 }

--- a/sdk/java/src/main/java/ai/agentspan/model/AgentResult.java
+++ b/sdk/java/src/main/java/ai/agentspan/model/AgentResult.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 public class AgentResult {
     private final Object output;
-    private final String workflowId;
+    private final String executionId;
     private final AgentStatus status;
     private final List<Map<String, Object>> toolCalls;
     private final List<AgentEvent> events;
@@ -25,14 +25,14 @@ public class AgentResult {
 
     public AgentResult(
             Object output,
-            String workflowId,
+            String executionId,
             AgentStatus status,
             List<Map<String, Object>> toolCalls,
             List<AgentEvent> events,
             TokenUsage tokenUsage,
             String error) {
         this.output = output;
-        this.workflowId = workflowId != null ? workflowId : "";
+        this.executionId = executionId != null ? executionId : "";
         this.status = status != null ? status : AgentStatus.COMPLETED;
         this.toolCalls = toolCalls != null ? toolCalls : new ArrayList<>();
         this.events = events != null ? events : new ArrayList<>();
@@ -41,7 +41,7 @@ public class AgentResult {
     }
 
     public Object getOutput() { return output; }
-    public String getWorkflowId() { return workflowId; }
+    public String getExecutionId() { return executionId; }
     public AgentStatus getStatus() { return status; }
     public List<Map<String, Object>> getToolCalls() { return toolCalls; }
     public List<AgentEvent> getEvents() { return events; }
@@ -143,8 +143,8 @@ public class AgentResult {
             System.out.println("Tokens: -");
         }
         System.out.println("Status: " + status);
-        if (!workflowId.isEmpty()) {
-            System.out.println("Workflow ID: " + workflowId);
+        if (!executionId.isEmpty()) {
+            System.out.println("Execution ID: " + executionId);
         }
         System.out.println();
     }

--- a/sdk/java/src/main/java/ai/agentspan/model/AgentStream.java
+++ b/sdk/java/src/main/java/ai/agentspan/model/AgentStream.java
@@ -36,21 +36,21 @@ import java.util.NoSuchElementException;
 public class AgentStream implements Iterable<AgentEvent>, AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(AgentStream.class);
 
-    private final String workflowId;
+    private final String executionId;
     private final SseClient sseClient;
     private final HttpApi httpApi;
     private final List<AgentEvent> capturedEvents = new ArrayList<>();
     private AgentResult result;
     private boolean exhausted = false;
 
-    public AgentStream(String workflowId, SseClient sseClient, HttpApi httpApi) {
-        this.workflowId = workflowId;
+    public AgentStream(String executionId, SseClient sseClient, HttpApi httpApi) {
+        this.executionId = executionId;
         this.sseClient = sseClient;
         this.httpApi = httpApi;
     }
 
-    public String getWorkflowId() {
-        return workflowId;
+    public String getExecutionId() {
+        return executionId;
     }
 
     @Override
@@ -76,7 +76,7 @@ public class AgentStream implements Iterable<AgentEvent>, AutoCloseable {
     /**
      * Approve a pending HUMAN task on the <b>top-level</b> workflow.
      *
-     * <p>This targets the workflow id from {@link #getWorkflowId()} — i.e. the
+     * <p>This targets the execution id from {@link #getExecutionId()} — i.e. the
      * orchestrator/root execution. It is the right method when:
      * <ul>
      *   <li>You are running a single agent (HUMAN task lives at the top level).</li>
@@ -86,17 +86,17 @@ public class AgentStream implements Iterable<AgentEvent>, AutoCloseable {
      * <p>Under {@link ai.agentspan.enums.Strategy#HANDOFF}, {@code SEQUENTIAL}, or
      * {@code PARALLEL} the HUMAN task usually lives in a <b>sub</b>-execution (the
      * sub-agent's own workflow). In that case this method POSTs to the wrong
-     * workflow id and the server returns HTTP 500 ("No pending HUMAN task found"):
+     * execution id and the server returns HTTP 500 ("No pending HUMAN task found"):
      * use {@link #approve(AgentEvent)} with the {@code WAITING} event instead.
      */
     public void approve() {
-        httpApi.respondToAgent(workflowId, true, null);
+        httpApi.respondToAgent(executionId, true, null);
     }
 
     /**
      * Approve the pending HUMAN task associated with the given {@code WAITING} event.
      *
-     * <p>Reads the owning execution id from {@link AgentEvent#getWorkflowId()} —
+     * <p>Reads the owning execution id from {@link AgentEvent#getExecutionId()} —
      * the sub-execution that emitted the event — and POSTs to it. Use this whenever
      * the HUMAN task may live below the top level (handoff/sequential/parallel).
      *
@@ -112,7 +112,7 @@ public class AgentStream implements Iterable<AgentEvent>, AutoCloseable {
      * @param reason optional rejection reason
      */
     public void reject(String reason) {
-        httpApi.respondToAgent(workflowId, false, reason);
+        httpApi.respondToAgent(executionId, false, reason);
     }
 
     /**
@@ -133,7 +133,7 @@ public class AgentStream implements Iterable<AgentEvent>, AutoCloseable {
     public void send(String message) {
         java.util.Map<String, Object> body = new java.util.HashMap<>();
         body.put("message", message);
-        httpApi.respondWithData(workflowId, body);
+        httpApi.respondWithData(executionId, body);
     }
 
     /**
@@ -152,9 +152,9 @@ public class AgentStream implements Iterable<AgentEvent>, AutoCloseable {
         if (event == null) {
             throw new IllegalArgumentException("event must not be null");
         }
-        String id = event.getWorkflowId();
+        String id = event.getExecutionId();
         if (id == null || id.isEmpty()) {
-            throw new IllegalArgumentException("event has no workflow id");
+            throw new IllegalArgumentException("event has no execution id");
         }
         return id;
     }
@@ -216,7 +216,7 @@ public class AgentStream implements Iterable<AgentEvent>, AutoCloseable {
             }
         }
 
-        return new AgentResult(output, workflowId, status, toolCalls, new ArrayList<>(capturedEvents), null, error);
+        return new AgentResult(output, executionId, status, toolCalls, new ArrayList<>(capturedEvents), null, error);
     }
 
     private class SseEventIterator implements Iterator<AgentEvent> {

--- a/sdk/java/src/main/java/ai/agentspan/model/ToolContext.java
+++ b/sdk/java/src/main/java/ai/agentspan/model/ToolContext.java
@@ -16,23 +16,23 @@ import java.util.Map;
  */
 public class ToolContext {
     private final String sessionId;
-    private final String workflowId;
+    private final String executionId;
     private final String taskId;
     private final Map<String, Object> state;
 
-    public ToolContext(String sessionId, String workflowId, String taskId) {
-        this(sessionId, workflowId, taskId, new HashMap<>());
+    public ToolContext(String sessionId, String executionId, String taskId) {
+        this(sessionId, executionId, taskId, new HashMap<>());
     }
 
-    public ToolContext(String sessionId, String workflowId, String taskId, Map<String, Object> initialState) {
+    public ToolContext(String sessionId, String executionId, String taskId, Map<String, Object> initialState) {
         this.sessionId = sessionId;
-        this.workflowId = workflowId;
+        this.executionId = executionId;
         this.taskId = taskId;
         this.state = initialState != null ? new HashMap<>(initialState) : new HashMap<>();
     }
 
     public String getSessionId() { return sessionId; }
-    public String getWorkflowId() { return workflowId; }
+    public String getExecutionId() { return executionId; }
     public String getTaskId() { return taskId; }
 
     /**

--- a/sdk/java/src/main/java/ai/agentspan/openai/RunResult.java
+++ b/sdk/java/src/main/java/ai/agentspan/openai/RunResult.java
@@ -35,7 +35,7 @@ public class RunResult {
 
     /** The Agentspan execution ID for debugging. */
     public String getExecutionId() {
-        return agentResult.getWorkflowId();
+        return agentResult.getExecutionId();
     }
 
     /** The underlying AgentResult. */

--- a/sdk/java/src/test/java/ai/agentspan/ModelExecutionIdTest.java
+++ b/sdk/java/src/test/java/ai/agentspan/ModelExecutionIdTest.java
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Agentspan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package ai.agentspan;
+
+import ai.agentspan.enums.AgentStatus;
+import ai.agentspan.enums.EventType;
+import ai.agentspan.model.AgentEvent;
+import ai.agentspan.model.AgentHandle;
+import ai.agentspan.model.AgentResult;
+import ai.agentspan.model.ToolContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verify that all public model classes expose {@code getExecutionId()} (not the
+ * legacy {@code getWorkflowId()}) — issue #254.
+ */
+class ModelExecutionIdTest {
+
+    @Test
+    void agentResult_getExecutionId() {
+        AgentResult result = new AgentResult(
+                Map.of("result", "ok"), "exec-123", AgentStatus.COMPLETED,
+                List.of(), List.of(), null, null);
+        assertEquals("exec-123", result.getExecutionId());
+    }
+
+    @Test
+    void agentResult_executionId_defaults_to_empty() {
+        AgentResult result = new AgentResult(null, null, null, null, null, null, null);
+        assertEquals("", result.getExecutionId());
+    }
+
+    @Test
+    void agentEvent_getExecutionId() {
+        AgentEvent event = new AgentEvent(
+                EventType.TOOL_CALL, null, "my_tool", Map.of(), null, null,
+                "exec-456", null, null);
+        assertEquals("exec-456", event.getExecutionId());
+    }
+
+    @Test
+    void agentEvent_fromMap_reads_executionId_key() {
+        Map<String, Object> data = Map.of(
+                "type", "tool_call",
+                "toolName", "fetch",
+                "executionId", "exec-789");
+        AgentEvent event = AgentEvent.fromMap(data);
+        assertEquals("exec-789", event.getExecutionId());
+    }
+
+    @Test
+    void toolContext_getExecutionId() {
+        ToolContext ctx = new ToolContext("session-1", "exec-abc", "task-1");
+        assertEquals("exec-abc", ctx.getExecutionId());
+    }
+
+    @Test
+    void toolContext_state_is_mutable() {
+        ToolContext ctx = new ToolContext("s", "e", "t");
+        ctx.getState().put("key", "value");
+        assertEquals("value", ctx.getState().get("key"));
+    }
+}


### PR DESCRIPTION
Closes #254

## Summary

- Renames `workflowId` → `executionId` across the Java SDK to match Python, TypeScript, C#, and the server
- All 5 public model classes now expose `getExecutionId()` instead of `getWorkflowId()`:
  - `AgentHandle.getExecutionId()`
  - `AgentResult.getExecutionId()`
  - `AgentStream.getExecutionId()`
  - `AgentEvent.getExecutionId()`
  - `ToolContext.getExecutionId()`
- Internal code (`AgentRuntime`, `HttpApi`), e2e tests (8 files), and examples (4 files) updated
- Legacy JSON key fallback preserved in `extractExecutionId()` for backward compat with older servers
- Added `ModelExecutionIdTest` with 6 unit tests covering the renamed getters

## Files changed (20 + 1 new)

| Category | Files |
|---|---|
| **Public API** | `AgentHandle`, `AgentResult`, `AgentStream`, `AgentEvent`, `ToolContext` |
| **Internal** | `AgentRuntime`, `HttpApi`, `RunResult` (OpenAI bridge) |
| **E2E tests** | `BaseTest`, `Suite6/7/9/10/12/14` |
| **Examples** | `Example09b/12/18/32` |
| **New test** | `ModelExecutionIdTest` (6 tests) |

## Discussion: backward compatibility

Since we're at `0.1.0`, this PR does a hard break. An alternative approach is to keep `@Deprecated getWorkflowId()` one-liners that delegate to `getExecutionId()`, giving users a migration window. Happy to add those if the team prefers a softer transition.

## Test plan

- [x] `./gradlew :compileJava :compileTestJava :examples:compileJava` — builds clean
- [x] `./gradlew :test` — all unit tests pass (52 serializer + 6 model)
- [ ] E2E tests pass against running server (same assertions, just renamed vars)