### PR TITLE
Validate credential whitespace before storing

### DIFF
--- a/cli/cmd/credentials.go
+++ b/cli/cmd/credentials.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/tabwriter"
+	"unicode"
 
 	"github.com/agentspan-ai/agentspan/cli/client"
 	"github.com/agentspan-ai/agentspan/cli/config"
@@ -57,9 +59,33 @@ Advanced form (custom store name, explicit binding needed):
 }
 
 func runCredentialsSet(name, value string) error {
+	if err := validateCredentialValue(name, value); err != nil {
+		return err
+	}
 	cfg := config.Load()
 	c := client.New(cfg)
 	return c.SetCredential(name, value)
+}
+
+func validateCredentialValue(name, value string) error {
+	if value != strings.TrimSpace(value) {
+		return fmt.Errorf("credential %q contains leading or trailing whitespace; re-enter it on one line without surrounding spaces", name)
+	}
+	for _, r := range value {
+		switch r {
+		case '\n':
+			return fmt.Errorf("credential %q contains a newline; re-export it on a single line and store it again", name)
+		case '\r':
+			return fmt.Errorf("credential %q contains a carriage return; re-export it on a single line and store it again", name)
+		case '\t':
+			return fmt.Errorf("credential %q contains a tab; re-export it on a single line and store it again", name)
+		default:
+			if unicode.IsControl(r) {
+				return fmt.Errorf("credential %q contains control character 0x%02x; re-export it on a single line and store it again", name, r)
+			}
+		}
+	}
+	return nil
 }
 
 // ─── credentials list ─────────────────────────────────────────────────────────

--- a/cli/cmd/credentials_test.go
+++ b/cli/cmd/credentials_test.go
@@ -73,6 +73,42 @@ func TestCredentialsSetWithStoreName(t *testing.T) {
 	}
 }
 
+func TestCredentialsSetRejectsNewlineValue(t *testing.T) {
+	newTempHome(t)
+
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	saveTestConfig(t, srv.URL)
+
+	err := runCredentialsSet("OPENAI_API_KEY", "sk-test\nwrapped")
+	if err == nil {
+		t.Fatalf("runCredentialsSet should reject newline-containing credentials")
+	}
+	if !strings.Contains(err.Error(), "OPENAI_API_KEY") || !strings.Contains(err.Error(), "newline") {
+		t.Fatalf("error = %q, want credential name and newline hint", err.Error())
+	}
+	if called {
+		t.Fatalf("server should not be called for invalid credentials")
+	}
+}
+
+func TestCredentialsSetRejectsSurroundingWhitespace(t *testing.T) {
+	newTempHome(t)
+
+	err := runCredentialsSet("OPENAI_API_KEY", " sk-test")
+	if err == nil {
+		t.Fatalf("runCredentialsSet should reject credentials with surrounding whitespace")
+	}
+	if !strings.Contains(err.Error(), "leading or trailing whitespace") {
+		t.Fatalf("error = %q, want whitespace hint", err.Error())
+	}
+}
+
 func TestCredentialsList(t *testing.T) {
 	newTempHome(t)
 

--- a/server/src/main/java/dev/agentspan/runtime/controller/CredentialController.java
+++ b/server/src/main/java/dev/agentspan/runtime/controller/CredentialController.java
@@ -84,6 +84,11 @@ public class CredentialController {
         if (name == null || name.isBlank() || value == null) {
             return ResponseEntity.badRequest().body(Map.of("error", "name and value are required"));
         }
+        try {
+            CredentialValueValidator.validate(name, value);
+        } catch (CredentialValueValidator.InvalidCredentialValueException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
         storeProvider.set(userId, name, value);
         log.info("Credential created: user={}, name={}", userId, name);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -96,6 +101,11 @@ public class CredentialController {
         String value = body.get("value");
         if (value == null) {
             return ResponseEntity.badRequest().body(Map.of("error", "value is required"));
+        }
+        try {
+            CredentialValueValidator.validate(name, value);
+        } catch (CredentialValueValidator.InvalidCredentialValueException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
         storeProvider.set(userId, name, value);
         log.info("Credential updated: user={}, name={}", userId, name);

--- a/server/src/main/java/dev/agentspan/runtime/credentials/CredentialEnvSeeder.java
+++ b/server/src/main/java/dev/agentspan/runtime/credentials/CredentialEnvSeeder.java
@@ -131,10 +131,18 @@ public class CredentialEnvSeeder implements ApplicationRunner {
 
         int created = 0;
         int skipped = 0;
+        int invalid = 0;
 
         for (String name : KNOWN_ENV_VARS) {
             String value = envLookup.apply(name);
             if (value == null || value.isBlank()) {
+                continue;
+            }
+            try {
+                CredentialValueValidator.validate(name, value);
+            } catch (CredentialValueValidator.InvalidCredentialValueException e) {
+                log.warn("Credential env import skipped: {}", e.getMessage());
+                invalid++;
                 continue;
             }
 
@@ -178,8 +186,12 @@ public class CredentialEnvSeeder implements ApplicationRunner {
             }
         }
 
-        if (created > 0 || skipped > 0) {
-            log.info("Credential env seeding complete: {} created, {} already existed (skipped)", created, skipped);
+        if (created > 0 || skipped > 0 || invalid > 0) {
+            log.info(
+                    "Credential env seeding complete: {} created, {} already existed (skipped), {} invalid (skipped)",
+                    created,
+                    skipped,
+                    invalid);
         }
     }
 }

--- a/server/src/main/java/dev/agentspan/runtime/credentials/CredentialValueValidator.java
+++ b/server/src/main/java/dev/agentspan/runtime/credentials/CredentialValueValidator.java
@@ -38,7 +38,8 @@ public final class CredentialValueValidator {
     private static InvalidCredentialValueException invalidChar(String name, String charName) {
         return new InvalidCredentialValueException(
                 name,
-                "contains a " + charName + ". This usually means the value was wrapped or pasted with extra whitespace; "
+                "contains a " + charName
+                        + ". This usually means the value was wrapped or pasted with extra whitespace; "
                         + "re-export it on a single line and store it again.");
     }
 

--- a/server/src/main/java/dev/agentspan/runtime/credentials/CredentialValueValidator.java
+++ b/server/src/main/java/dev/agentspan/runtime/credentials/CredentialValueValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License.
+ */
+package dev.agentspan.runtime.credentials;
+
+/** Validates stored credential values before they are reused in HTTP headers. */
+public final class CredentialValueValidator {
+
+    private CredentialValueValidator() {}
+
+    public static void validate(String name, String value) {
+        if (value == null) {
+            throw new InvalidCredentialValueException(name, "value is required");
+        }
+        if (!value.equals(value.strip())) {
+            throw new InvalidCredentialValueException(
+                    name,
+                    "contains leading or trailing whitespace. Re-enter the value on one line without surrounding spaces.");
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '\n') {
+                throw invalidChar(name, "newline");
+            }
+            if (ch == '\r') {
+                throw invalidChar(name, "carriage return");
+            }
+            if (ch == '\t') {
+                throw invalidChar(name, "tab");
+            }
+            if (Character.isISOControl(ch)) {
+                throw invalidChar(name, String.format("control character 0x%02x", (int) ch));
+            }
+        }
+    }
+
+    private static InvalidCredentialValueException invalidChar(String name, String charName) {
+        return new InvalidCredentialValueException(
+                name,
+                "contains a " + charName + ". This usually means the value was wrapped or pasted with extra whitespace; "
+                        + "re-export it on a single line and store it again.");
+    }
+
+    public static class InvalidCredentialValueException extends RuntimeException {
+        public InvalidCredentialValueException(String name, String reason) {
+            super("Credential '" + name + "' " + reason);
+        }
+    }
+}

--- a/server/src/test/java/dev/agentspan/runtime/controller/CredentialControllerTest.java
+++ b/server/src/test/java/dev/agentspan/runtime/controller/CredentialControllerTest.java
@@ -54,6 +54,31 @@ class CredentialControllerTest {
     }
 
     @Test
+    void createCredential_rejectsNewlineValue() throws Exception {
+        mvc.perform(post("/api/credentials")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"" + CRED_NAME + "\",\"value\":\"sk-test\\nwrapped\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString(CRED_NAME)))
+                .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString("newline")));
+    }
+
+    @Test
+    void updateCredential_rejectsSurroundingWhitespace() throws Exception {
+        mvc.perform(post("/api/credentials")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"" + CRED_NAME + "\",\"value\":\"original-value-here\"}"))
+                .andExpect(status().isCreated());
+
+        mvc.perform(put("/api/credentials/" + CRED_NAME)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"value\":\" updated-value-here\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString(CRED_NAME)))
+                .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString("leading or trailing")));
+    }
+
+    @Test
     void deleteCredential_returns204() throws Exception {
         // Create first
         mvc.perform(post("/api/credentials")

--- a/server/src/test/java/dev/agentspan/runtime/credentials/CredentialEnvSeederTest.java
+++ b/server/src/test/java/dev/agentspan/runtime/credentials/CredentialEnvSeederTest.java
@@ -124,6 +124,23 @@ class CredentialEnvSeederTest {
     }
 
     @Test
+    void seeder_skipsEnvVarWithNewline_inRealDb() throws Exception {
+        storeProvider.delete(ANONYMOUS_USER_ID, "ANTHROPIC_API_KEY");
+
+        Function<String, String> envLookup = name -> "ANTHROPIC_API_KEY".equals(name) ? "sk-test\nwrapped" : null;
+
+        CredentialEnvSeeder seeder = new CredentialEnvSeeder(storeProvider, envLookup);
+        var field = CredentialEnvSeeder.class.getDeclaredField("credentialsStore");
+        field.setAccessible(true);
+        field.set(seeder, "built-in");
+
+        seeder.run(new org.springframework.boot.DefaultApplicationArguments());
+
+        String value = storeProvider.get(ANONYMOUS_USER_ID, "ANTHROPIC_API_KEY");
+        assertThat(value).isNull();
+    }
+
+    @Test
     void seeder_skipsWhenStoreIsNotBuiltIn() throws Exception {
         storeProvider.delete(ANONYMOUS_USER_ID, "ANTHROPIC_API_KEY");
 


### PR DESCRIPTION
## Summary
- reject credentials with newlines, tabs, control chars, or surrounding whitespace before they reach OkHttp Authorization headers
- apply the validation in CLI `credentials set`, REST create/update, and startup env seeding
- add regression coverage for CLI validation, REST validation, and env import skipping

Fixes #260

## Verification
- Blocked locally: `./gradlew test --tests dev.agentspan.runtime.controller.CredentialControllerTest --tests dev.agentspan.runtime.credentials.CredentialEnvSeederTest` could not run because this shell has no Java runtime installed.
- Blocked locally: `go test ./cmd -run 'TestCredentials(Set|List|Delete|Bind|Bindings|Bearer|NoAuth)'` could not run because `go` is not installed on PATH.
