### PR TITLE
fix(server): forward tool_calls array on HITL WAITING SSE events (#226)

### DIFF
--- a/sdk/java/e2e/Suite12HandoffApprove.java
+++ b/sdk/java/e2e/Suite12HandoffApprove.java
@@ -17,6 +17,7 @@ import org.conductoross.conductor.ai.internal.ToolRegistry;
 import org.conductoross.conductor.ai.model.AgentEvent;
 import org.conductoross.conductor.ai.model.AgentResult;
 import org.conductoross.conductor.ai.model.AgentStream;
+import org.conductoross.conductor.ai.model.PendingToolCall;
 import org.conductoross.conductor.ai.model.ToolDef;
 import org.junit.jupiter.api.*;
 
@@ -82,6 +83,54 @@ class Suite12HandoffApprove extends BaseTest {
                 .strategy(Strategy.HANDOFF)
                 .maxTurns(1)
                 .build();
+    }
+
+    /**
+     * Regression test for issue #226: the {@code WAITING} SSE event must
+     * carry the pending tool name(s) and arguments so SDK consumers can
+     * decide whether to approve or reject. Before the fix, the server
+     * read the singular {@code tool_name} / {@code parameters} keys (which
+     * the compiler never writes) and shipped {@code null} for both — making
+     * approve/reject decisions blind. Assertion is deterministic: the
+     * approval-required tool in this suite is {@code submit_change}, so
+     * exactly that name must surface on the first WAITING event.
+     */
+    @Test
+    @Order(0)
+    @Timeout(value = 300, unit = TimeUnit.SECONDS)
+    void test_waiting_event_surfaces_pending_tool_calls() {
+        Agent support = buildHandoffAgent("e2e_java_handoff_pending_tool");
+
+        try (AgentStream stream = runtime.stream(
+                support, "Please submit this configuration change: enable feature flag java_e2e_pending_tool.")) {
+
+            AgentEvent firstWaiting = null;
+            int approvals = 0;
+            for (AgentEvent event : stream) {
+                if (event.getType() == EventType.WAITING) {
+                    if (firstWaiting == null) firstWaiting = event;
+                    stream.approve(event);
+                    approvals++;
+                    assertTrue(approvals <= 5, "too many approval prompts; handoff did not settle");
+                }
+            }
+
+            assertNotNull(firstWaiting, "expected a WAITING event from the sub-agent's approval-required tool");
+
+            List<PendingToolCall> calls = firstWaiting.getPendingToolCalls();
+            assertFalse(
+                    calls.isEmpty(),
+                    "WAITING event must surface the pending tool(s); got an empty list. "
+                            + "Before issue #226 fix the server shipped pendingTool.tool_name=null "
+                            + "and toolCalls was unset, leaving SDK consumers blind.");
+            assertEquals(
+                    "submit_change",
+                    calls.get(0).getName(),
+                    "first pending tool must be submit_change (the only approval-required tool in this fixture)");
+            assertNotNull(
+                    calls.get(0).getArgs(),
+                    "pending tool args must be present so consumers can decide whether to approve");
+        }
     }
 
     /**

--- a/sdk/java/src/main/java/org/conductoross/conductor/ai/model/AgentEvent.java
+++ b/sdk/java/src/main/java/org/conductoross/conductor/ai/model/AgentEvent.java
@@ -3,9 +3,12 @@
 
 package org.conductoross.conductor.ai.model;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,6 +27,7 @@ public class AgentEvent {
     private final String executionId;
     private final String guardrailName;
     private final String target;
+    private final Map<String, Object> pendingTool;
 
     public AgentEvent(
             EventType type,
@@ -35,6 +39,20 @@ public class AgentEvent {
             String executionId,
             String guardrailName,
             String target) {
+        this(type, content, toolName, args, result, output, executionId, guardrailName, target, null);
+    }
+
+    public AgentEvent(
+            EventType type,
+            String content,
+            String toolName,
+            Map<String, Object> args,
+            Object result,
+            Object output,
+            String executionId,
+            String guardrailName,
+            String target,
+            Map<String, Object> pendingTool) {
         this.type = type;
         this.content = content;
         this.toolName = toolName;
@@ -44,6 +62,7 @@ public class AgentEvent {
         this.executionId = executionId;
         this.guardrailName = guardrailName;
         this.target = target;
+        this.pendingTool = pendingTool;
     }
 
     public EventType getType() {
@@ -80,6 +99,45 @@ public class AgentEvent {
 
     public String getTarget() {
         return target;
+    }
+
+    /**
+     * Raw {@code pendingTool} block from a {@code waiting} SSE event, or
+     * {@code null} for any other event type. Contains at minimum
+     * {@code taskRefName}; for approval-gated batches it also contains
+     * {@code toolCalls} — the array of tools the LLM proposed this turn.
+     *
+     * <p>Most consumers want {@link #getPendingToolCalls()} instead.
+     */
+    public Map<String, Object> getPendingTool() {
+        return pendingTool;
+    }
+
+    /**
+     * Typed view of {@code pendingTool.toolCalls}. Returns an empty list
+     * (never {@code null}) when no calls are pending — including for non-
+     * {@code waiting} events.
+     *
+     * <p>One HUMAN task gates the whole batch with one {@code {approved,
+     * reason}} verdict. Iterate to see every tool covered by the gate.
+     */
+    @SuppressWarnings("unchecked")
+    public List<PendingToolCall> getPendingToolCalls() {
+        if (pendingTool == null) return Collections.emptyList();
+        Object raw = pendingTool.get("toolCalls");
+        if (!(raw instanceof List<?>)) return Collections.emptyList();
+        List<?> list = (List<?>) raw;
+        List<PendingToolCall> calls = new ArrayList<>(list.size());
+        for (Object entry : list) {
+            if (!(entry instanceof Map<?, ?>)) continue;
+            Map<String, Object> map = (Map<String, Object>) entry;
+            Object name = map.get("name");
+            Object args = map.get("args");
+            calls.add(new PendingToolCall(
+                    name != null ? name.toString() : null,
+                    args instanceof Map<?, ?> ? (Map<String, Object>) args : null));
+        }
+        return calls;
     }
 
     /**
@@ -121,6 +179,10 @@ public class AgentEvent {
             }
         }
 
+        Object rawPendingTool = data.get("pendingTool");
+        Map<String, Object> pendingTool =
+                rawPendingTool instanceof Map<?, ?> ? (Map<String, Object>) rawPendingTool : null;
+
         return new AgentEvent(
                 type,
                 (String) data.get("content"),
@@ -130,7 +192,8 @@ public class AgentEvent {
                 data.get("output"),
                 (String) data.getOrDefault("executionId", ""),
                 (String) data.get("guardrailName"),
-                (String) data.get("target"));
+                (String) data.get("target"),
+                pendingTool);
     }
 
     @Override

--- a/sdk/java/src/main/java/org/conductoross/conductor/ai/model/PendingToolCall.java
+++ b/sdk/java/src/main/java/org/conductoross/conductor/ai/model/PendingToolCall.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 Agentspan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package org.conductoross.conductor.ai.model;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A single tool call awaiting human approval inside a {@link AgentEvent}
+ * of type {@code waiting}.
+ *
+ * <p>One HUMAN task gates a whole batch of tool calls with a single
+ * {@code {approved, reason}} verdict — the array on the event is the
+ * load-bearing field. Iterate it to see every tool the LLM proposed in
+ * this turn.
+ */
+public final class PendingToolCall {
+
+    private final String name;
+    private final Map<String, Object> args;
+
+    public PendingToolCall(String name, Map<String, Object> args) {
+        this.name = name;
+        this.args = args != null ? args : Collections.emptyMap();
+    }
+
+    /** The tool's registered name (e.g. {@code "publish_article"}). */
+    public String getName() {
+        return name;
+    }
+
+    /** The LLM-generated arguments for this tool call. */
+    public Map<String, Object> getArgs() {
+        return args;
+    }
+
+    @Override
+    public String toString() {
+        return "PendingToolCall{name=" + name + ", args=" + args + "}";
+    }
+}

--- a/sdk/java/src/test/java/org/conductoross/conductor/ai/model/AgentEventPendingToolTest.java
+++ b/sdk/java/src/test/java/org/conductoross/conductor/ai/model/AgentEventPendingToolTest.java
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Agentspan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package org.conductoross.conductor.ai.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.enums.EventType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for issue #226. {@link AgentEvent#fromMap(Map)} must surface
+ * the {@code pendingTool} block of a {@code waiting} SSE event so callers can
+ * tell which tool(s) are awaiting approval.
+ *
+ * <p>One HUMAN task gates a batch of tool calls with a single {@code
+ * {approved, reason}} verdict — so the array is the load-bearing field; the
+ * legacy singular {@code tool_name} / {@code parameters} keys remain null
+ * and consumers must iterate {@link AgentEvent#getPendingToolCalls()}.
+ */
+class AgentEventPendingToolTest {
+
+    @Test
+    void fromMap_surfacesPendingToolMapOnWaitingEvent() {
+        Map<String, Object> wire = Map.of(
+                "type", "waiting",
+                "executionId", "wf-1",
+                "pendingTool",
+                        Map.of(
+                                "taskRefName",
+                                "agent_approval_human",
+                                "toolCalls",
+                                List.of(
+                                        Map.of("name", "publish_article", "args", Map.of("title", "Test")),
+                                        Map.of("name", "send_email", "args", Map.of("to", "ops@example.com")))));
+
+        AgentEvent event = AgentEvent.fromMap(wire);
+
+        assertEquals(EventType.WAITING, event.getType());
+        Map<String, Object> pendingTool = event.getPendingTool();
+        assertNotNull(pendingTool, "pendingTool must be surfaced for waiting events");
+        assertEquals("agent_approval_human", pendingTool.get("taskRefName"));
+
+        List<PendingToolCall> calls = event.getPendingToolCalls();
+        assertNotNull(calls, "getPendingToolCalls() must parse the toolCalls array");
+        assertEquals(2, calls.size());
+        assertEquals("publish_article", calls.get(0).getName());
+        assertEquals(Map.of("title", "Test"), calls.get(0).getArgs());
+        assertEquals("send_email", calls.get(1).getName());
+        assertEquals(Map.of("to", "ops@example.com"), calls.get(1).getArgs());
+    }
+
+    @Test
+    void fromMap_returnsEmptyPendingToolCallsWhenNoneEmitted() {
+        Map<String, Object> wire = Map.of(
+                "type", "waiting",
+                "executionId", "wf-2",
+                "pendingTool", Map.of("taskRefName", "agent_approval_human"));
+
+        AgentEvent event = AgentEvent.fromMap(wire);
+
+        assertNotNull(event.getPendingTool());
+        assertTrue(
+                event.getPendingToolCalls().isEmpty(),
+                "pendingToolCalls is an empty list (never null) when the server emits no toolCalls");
+    }
+
+    @Test
+    void fromMap_returnsNullPendingToolForNonWaitingEvents() {
+        Map<String, Object> wire = Map.of(
+                "type", "thinking",
+                "executionId", "wf-3",
+                "content", "agent_llm");
+
+        AgentEvent event = AgentEvent.fromMap(wire);
+
+        assertEquals(EventType.THINKING, event.getType());
+        assertNull(event.getPendingTool());
+        assertTrue(event.getPendingToolCalls().isEmpty());
+    }
+}

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -10317,9 +10317,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11193,9 +11193,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -46,6 +46,10 @@
     "@io-orkes/conductor-javascript": "^3.0.3",
     "dotenv": "^16.0.0"
   },
+  "overrides": {
+    "undici": "^7.28.0",
+    "ws": "^8.21.0"
+  },
   "peerDependencies": {
     "@langchain/core": ">=0.2.0",
     "@langchain/langgraph": ">=0.2.0",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -15,6 +15,8 @@ export type {
   GuardrailDef,
   AgentEvent,
   AgentStatus,
+  PendingTool,
+  PendingToolCall,
   DeploymentInfo,
   PromptTemplate as PromptTemplateInterface,
   CodeExecutionConfig,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -155,6 +155,12 @@ export interface AgentEvent {
   executionId?: string;
   guardrailName?: string;
   timestamp?: number;
+  /**
+   * Tools awaiting human approval. Present on `waiting` events (and carried
+   * straight through from the SSE payload). Mirrors {@link AgentStatus.pendingTool}
+   * so the gate can be read off the event without a `getStatus()` round-trip.
+   */
+  pendingTool?: PendingTool;
 }
 
 /**
@@ -170,7 +176,32 @@ export interface AgentStatus {
   reason?: string;
   currentTask?: string;
   messages: unknown[];
-  pendingTool?: { name: string; args: Record<string, unknown> };
+  pendingTool?: PendingTool;
+}
+
+/**
+ * A single tool call awaiting human approval. The {@link PendingTool} on a
+ * `waiting` event carries an array of these — one HUMAN task gates the
+ * whole batch with a single `{approved, reason}` verdict, so iterate
+ * `toolCalls` to see every tool covered by the gate.
+ */
+export interface PendingToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Payload on a `waiting` SSE event. The legacy singular `tool_name` /
+ * `parameters` keys are always null (the underlying gate is per-batch,
+ * not per-tool) — read `toolCalls` for the real list.
+ */
+export interface PendingTool {
+  taskRefName: string;
+  toolCalls?: PendingToolCall[];
+  tool_name?: string | null;
+  parameters?: Record<string, unknown> | null;
+  response_schema?: unknown;
+  response_ui_schema?: unknown;
 }
 
 /**

--- a/sdk/typescript/tests/unit/stream.test.ts
+++ b/sdk/typescript/tests/unit/stream.test.ts
@@ -75,6 +75,29 @@ describe("AgentStream", () => {
       expect(events[0].args).toEqual({ query: "test" });
     });
 
+    it("forwards pendingTool on a waiting event", async () => {
+      // Mirrors the server's waiting SSE payload: one HUMAN task gates a
+      // batch of tool calls via pendingTool.toolCalls (#226 / PR #270).
+      const sseChunks = [
+        'event:waiting\ndata:{"pendingTool":{"taskRefName":"approve_ref","toolCalls":[{"name":"submit_change","args":{"id":42}}],"tool_name":null,"parameters":null}}\n\n',
+        "event:done\ndata:{}\n\n",
+      ];
+
+      mockFetch(createSSEStream(sseChunks));
+
+      const stream = new AgentStream("http://localhost/sse", {}, "wf-1", vi.fn());
+
+      const events = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      expect(events[0].type).toBe("waiting");
+      expect(events[0].pendingTool?.toolCalls).toHaveLength(1);
+      expect(events[0].pendingTool?.toolCalls?.[0].name).toBe("submit_change");
+      expect(events[0].pendingTool?.toolCalls?.[0].args).toEqual({ id: 42 });
+    });
+
     it("handles multi-line data fields", async () => {
       const sseChunks = [
         'event:message\ndata:{"content":\ndata:"multi-line"}\n\n',

--- a/sdk/typescript/yarn.lock
+++ b/sdk/typescript/yarn.lock
@@ -4968,10 +4968,10 @@ undici-types@~7.16.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
-undici@^7.16.0:
-  version "7.25.0"
-  resolved "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz"
-  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
+undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unique-filename@^1.1.1:
   version "1.1.1"
@@ -5187,10 +5187,10 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.18.0, ws@^8.18.1, ws@>=7:
-  version "8.20.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@^8.18.0, ws@^8.18.1, ws@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 wsl-utils@^0.1.0:
   version "0.1.0"

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/AgentHumanTaskTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/AgentHumanTaskTest.java
@@ -8,6 +8,7 @@ package dev.agentspan.runtime.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -85,6 +86,76 @@ class AgentHumanTaskTest {
 
         // Task should still be IN_PROGRESS even if SSE failed
         assertThat(task.getStatus()).isEqualTo(TaskModel.Status.IN_PROGRESS);
+    }
+
+    /**
+     * Regression test for issue #226.
+     *
+     * <p>The compiler ({@code AgentCompiler} → {@code tool_calls =
+     * ${llm.output.toolCalls}}) writes the plural {@code tool_calls} array into
+     * the HUMAN task's input — never the singular {@code tool_name} /
+     * {@code parameters} keys the older tests fabricated. Production
+     * approval-gated workflows therefore reach this method with input shaped
+     * like {@code {"tool_calls": [{"name": ..., "inputParameters": ...}], ...}}
+     * and the SSE WAITING event must forward the array so SDK consumers can tell
+     * which tool(s) are awaiting approval.
+     *
+     * <p>Uses the canonical {@code inputParameters} key — the same key every
+     * other runtime reader of {@code llm.output.toolCalls} treats as primary
+     * (see {@code JavaScriptBuilder}: {@code tc.inputParameters || tc.input}).
+     */
+    @Test
+    void startForwardsCompilerEmittedToolCallsArray() {
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("wf-tool-calls");
+
+        TaskModel task = new TaskModel();
+        task.setReferenceTaskName("agent_approval_human");
+        // Shape matches what the compiler emits from llm.output.toolCalls at runtime.
+        task.setInputData(Map.of(
+                "tool_calls",
+                List.of(
+                        Map.of("name", "publish_article", "inputParameters", Map.of("title", "Test")),
+                        Map.of("name", "send_email", "inputParameters", Map.of("to", "ops@example.com")))));
+
+        humanTask.start(workflow, task, null);
+
+        ArgumentCaptor<AgentSSEEvent> captor = ArgumentCaptor.forClass(AgentSSEEvent.class);
+        verify(streamRegistry).send(eq("wf-tool-calls"), captor.capture());
+        Map<String, Object> pendingTool = captor.getValue().getPendingTool();
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> calls = (List<Map<String, Object>>) pendingTool.get("toolCalls");
+        assertThat(calls)
+                .as("pendingTool.toolCalls forwarded from compiler input")
+                .hasSize(2);
+        assertThat(calls.get(0)).containsEntry("name", "publish_article");
+        assertThat(calls.get(0)).containsEntry("args", Map.of("title", "Test"));
+        assertThat(calls.get(1)).containsEntry("name", "send_email");
+        assertThat(calls.get(1)).containsEntry("args", Map.of("to", "ops@example.com"));
+    }
+
+    /**
+     * The {@code input} key is accepted as a fallback for the args of a tool
+     * call (LLM-native shape), but {@code inputParameters} wins when both are
+     * present — matching the runtime's {@code tc.inputParameters || tc.input}
+     * precedence.
+     */
+    @Test
+    void extractToolCallsPrefersInputParametersOverInput() {
+        List<Map<String, Object>> calls = AgentHumanTask.extractToolCalls(List.of(
+                Map.of("name", "only_input", "input", Map.of("a", 1)),
+                Map.of(
+                        "name",
+                        "both",
+                        "input",
+                        Map.of("ignored", true),
+                        "inputParameters",
+                        Map.of("canonical", true))));
+
+        assertThat(calls).hasSize(2);
+        assertThat(calls.get(0)).containsEntry("args", Map.of("a", 1));
+        assertThat(calls.get(1)).containsEntry("args", Map.of("canonical", true));
     }
 
     @Test

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentHumanTask.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentHumanTask.java
@@ -7,7 +7,9 @@ package dev.agentspan.runtime.service;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUMAN;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -54,6 +56,10 @@ public class AgentHumanTask extends WorkflowSystemTask {
         if (input != null) {
             pendingTool.put("tool_name", input.get("tool_name"));
             pendingTool.put("parameters", input.get("parameters"));
+            List<Map<String, Object>> toolCalls = extractToolCalls(input.get("tool_calls"));
+            if (toolCalls != null) {
+                pendingTool.put("toolCalls", toolCalls);
+            }
             if (input.get("response_schema") != null) {
                 pendingTool.put("response_schema", input.get("response_schema"));
             }
@@ -74,5 +80,44 @@ public class AgentHumanTask extends WorkflowSystemTask {
     @Override
     public void cancel(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         task.setStatus(TaskModel.Status.CANCELED);
+    }
+
+    /**
+     * Normalise the compiler-emitted {@code tool_calls} array (originally
+     * sourced from {@code ${llm}.output.toolCalls}) into the SSE-facing
+     * {@code [{name, args}, ...]} shape consumers read.
+     *
+     * <p>One HUMAN task gates a whole batch of tool calls with a single
+     * {@code {approved, reason}} verdict, which is why the singular
+     * {@code tool_name} / {@code parameters} keys remain {@code null}: they
+     * cannot honestly represent N tools. Consumers should iterate the
+     * returned array to see every tool awaiting approval.
+     *
+     * <p>Args precedence matches the rest of the runtime (see
+     * {@code JavaScriptBuilder}'s {@code tc.inputParameters || tc.input}):
+     * {@code inputParameters} is the canonical key for an LLM tool-call
+     * element, with {@code input} accepted as a fallback.
+     */
+    @SuppressWarnings("unchecked")
+    static List<Map<String, Object>> extractToolCalls(Object raw) {
+        if (!(raw instanceof List<?> list) || list.isEmpty()) {
+            return null;
+        }
+        List<Map<String, Object>> calls = new ArrayList<>(list.size());
+        for (Object entry : list) {
+            if (!(entry instanceof Map<?, ?> map)) {
+                continue;
+            }
+            Map<String, Object> typed = (Map<String, Object>) map;
+            Object name = typed.get("name");
+            // Conductor task inputs land under inputParameters; LLM-native
+            // tool calls land under input. inputParameters is canonical.
+            Object args = typed.containsKey("inputParameters") ? typed.get("inputParameters") : typed.get("input");
+            Map<String, Object> normalised = new HashMap<>();
+            if (name != null) normalised.put("name", name);
+            if (args != null) normalised.put("args", args);
+            if (!normalised.isEmpty()) calls.add(normalised);
+        }
+        return calls.isEmpty() ? null : calls;
     }
 }

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -1293,6 +1293,11 @@ public class AgentService {
                 if (task.getInputData() != null) {
                     pendingTool.put("tool_name", task.getInputData().get("tool_name"));
                     pendingTool.put("parameters", task.getInputData().get("parameters"));
+                    List<Map<String, Object>> toolCalls =
+                            AgentHumanTask.extractToolCalls(task.getInputData().get("tool_calls"));
+                    if (toolCalls != null) {
+                        pendingTool.put("toolCalls", toolCalls);
+                    }
                     if (task.getInputData().get("response_schema") != null) {
                         pendingTool.put("response_schema", task.getInputData().get("response_schema"));
                     }


### PR DESCRIPTION
## Summary

Closes #226. The `waiting` SSE event for approval-gated tools shipped `pendingTool.tool_name = null` and `pendingTool.parameters = null` because the server was reading singular keys the compiler never writes — SDK consumers calling `event.getToolName()` got nulls and couldn't tell what tool was awaiting approval.

## What the compiler actually emits

`AgentCompiler` wires the HUMAN task input with `tool_calls = ${llm.output.toolCalls}`. So the HUMAN task's input has the **plural `tool_calls` array** — `[{name, inputParameters}, ...]` — never the singular keys.

## Fix

**Server.** `AgentHumanTask.start()` and `AgentService.getStatus()` now read the `tool_calls` array, normalise each entry to `{name, args}`, and emit it as `pendingTool.toolCalls`. The legacy `tool_name` / `parameters` keys are preserved (still null) for back-compat.

The wire shape stays honest about the actual gate: one HUMAN task covers a whole batch of N tool calls with a single `{approved, reason}` verdict, so the array is the load-bearing field. Per-tool approval (Option B) is deferred — see below.

**Args precedence.** Each `llm.output.toolCalls` element carries its args under `inputParameters` (canonical) with `input` as a fallback — the same precedence every other runtime reader uses (`JavaScriptBuilder`: `tc.inputParameters || tc.input`). `extractToolCalls` now follows that order, and the server tests fabricate the canonical `inputParameters` shape (plus an explicit precedence test).

**Java SDK.** `AgentEvent` gains `getPendingTool()` (raw map) and `getPendingToolCalls()` (typed `List<PendingToolCall>`, empty-never-null). `getToolName()` intentionally still returns null on `WAITING` events — consumers iterate `getPendingToolCalls()`.

**TypeScript.** `AgentStatus.pendingTool` / `AgentEvent.pendingTool` are now the real `PendingTool` shape with `toolCalls?: PendingToolCall[]`. Both types exported from `index.ts`.

**Python / C#.** Already surface `pendingTool` as a raw map/dict, so they inherit the fix transparently.

## Rebase note

Rebased onto current `main` after two intervening changes:
- the credentials→secrets rename (`#268`) and
- the **server split (#271)** + Java SDK package move.

Server changes now live under `server/conductor-agentspan/...` (main) and `server/conductor-agentspan-server/...` (tests); the Java SDK changes target the `org.conductoross.conductor.ai.model` package. The earlier conflicting revision targeted the pre-split `server/src/main/...` and `ai.agentspan.model` paths.

## Tests (CLAUDE.md compliance)

Per "write a test, then make it fail to confirm it's valid":

- `AgentHumanTaskTest.startForwardsCompilerEmittedToolCallsArray` — fabricates the real compiler-emitted input (`tool_calls: [{name, inputParameters}, ...]`). **Verified failing** when the fix is neutered (`extractToolCalls` forced to return null) and passing after. Passes: `./gradlew :conductor-agentspan-server:test --tests '*AgentHumanTaskTest'`.
- `AgentHumanTaskTest.extractToolCallsPrefersInputParametersOverInput` — locks in the `inputParameters`-over-`input` precedence.
- `AgentEventPendingToolTest` (new, Java SDK) — parse-path coverage for the typed view, empty-`toolCalls`, and non-`waiting`-event cases. Passes: `./gradlew :test --tests '*AgentEventPendingToolTest'`.
- `stream.test.ts` → "forwards pendingTool on a waiting event" — TS parse-path coverage. Passes (`npx vitest run`, `npx tsc --noEmit` clean).
- `Suite12HandoffApprove.test_waiting_event_surfaces_pending_tool_calls` — e2e regression, deterministic assertion (`submit_change`, no LLM in the assertion path). Compiles; exercised by CI against a live server.

## What this PR explicitly does NOT do

Defers Option B (one HUMAN task per tool call → independent gates → partial approval). Bigger blast radius on agent-loop semantics; tracked separately.

## Test plan

- [x] `./gradlew :conductor-agentspan-server:test --tests '*AgentHumanTaskTest'` (server) — passes, incl. make-it-fail validation
- [x] `./gradlew :test --tests '*AgentEventPendingToolTest'` (sdk/java) — passes
- [x] `npx tsc --noEmit` + `npx vitest run tests/unit/stream.test.ts` (sdk/typescript) — passes
- [x] `spotlessApply` clean (server + sdk/java)
- [ ] CI exercises the e2e (`Suite12HandoffApprove`) against the freshly-built server
