### PR TITLE
Support Agentspan Embedded in Orkes Conductor 

### DIFF
--- a/cli/auth/auth0.go
+++ b/cli/auth/auth0.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+// Package auth implements the Auth0 OAuth Device Authorization Grant (RFC 8628)
+// for browser-based CLI login. This mirrors how the orkes-conductor UI authenticates:
+// it obtains an Auth0-issued JWT and sends it to the backend as the X-Authorization
+// header — there is no orkes-side token exchange. The device flow delegates the actual
+// login to Auth0's hosted page, so it supports whatever the tenant allows
+// (username/password, Google, SSO, MFA, ...).
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// DefaultScope requests an OIDC token plus a refresh token. No audience is requested,
+// matching the UI (which relies on the Auth0 tenant's default audience / ID token).
+const DefaultScope = "openid profile email offline_access"
+
+// DeviceCode is the response from POST /oauth/device/code.
+type DeviceCode struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// Token is the response from POST /oauth/token.
+type Token struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+}
+
+// Auth0Config is the subset of the server's window.authConfig the CLI needs.
+type Auth0Config struct {
+	Domain     string
+	ClientID   string
+	UseIDToken bool
+}
+
+// RequestDeviceCode starts the device authorization flow.
+func RequestDeviceCode(domain, clientID, scope string) (*DeviceCode, error) {
+	if scope == "" {
+		scope = DefaultScope
+	}
+	form := url.Values{"client_id": {clientID}, "scope": {scope}}
+	resp, err := http.PostForm(authURL(domain, "/oauth/device/code"), form)
+	if err != nil {
+		return nil, fmt.Errorf("request device code: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device code request failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+	var dc DeviceCode
+	if err := json.Unmarshal(body, &dc); err != nil {
+		return nil, fmt.Errorf("parse device code: %w", err)
+	}
+	if dc.Interval <= 0 {
+		dc.Interval = 5
+	}
+	return &dc, nil
+}
+
+// PollForToken polls the token endpoint until the user completes login in the browser,
+// the code expires, or login is denied. Honors authorization_pending and slow_down.
+func PollForToken(domain, clientID string, dc *DeviceCode) (*Token, error) {
+	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
+	interval := time.Duration(dc.Interval) * time.Second
+	for {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("device code expired before login completed")
+		}
+		time.Sleep(interval)
+
+		form := url.Values{
+			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+			"device_code": {dc.DeviceCode},
+			"client_id":   {clientID},
+		}
+		resp, err := http.PostForm(authURL(domain, "/oauth/token"), form)
+		if err != nil {
+			return nil, fmt.Errorf("poll token: %w", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			var tok Token
+			if err := json.Unmarshal(body, &tok); err != nil {
+				return nil, fmt.Errorf("parse token: %w", err)
+			}
+			return &tok, nil
+		}
+
+		var e struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(body, &e)
+		switch e.Error {
+		case "authorization_pending":
+			// keep waiting
+		case "slow_down":
+			interval += 5 * time.Second
+		case "expired_token":
+			return nil, fmt.Errorf("device code expired before login completed")
+		case "access_denied":
+			return nil, fmt.Errorf("login was denied")
+		default:
+			return nil, fmt.Errorf("token poll failed (HTTP %d): %s", resp.StatusCode, string(body))
+		}
+	}
+}
+
+// Refresh exchanges a refresh token for a fresh access/ID token.
+func Refresh(domain, clientID, refreshToken string) (*Token, error) {
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {refreshToken},
+	}
+	resp, err := http.PostForm(authURL(domain, "/oauth/token"), form)
+	if err != nil {
+		return nil, fmt.Errorf("refresh token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("refresh failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+	var tok Token
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("parse refreshed token: %w", err)
+	}
+	return &tok, nil
+}
+
+// DiscoverConfig fetches the server's /context.js and extracts the Auth0 config — the
+// same runtime config the UI consumes, with the UI's exact resolution order
+// (auth0-config.ts): authConfig.domain || auth0Identifiers.domain, same for clientId.
+// Handles the real orkes serialization (quoted keys, e.g. {"clientId" : "..."}) as well
+// as bare-key JS object literals.
+func DiscoverConfig(serverBaseURL string) (*Auth0Config, error) {
+	base := strings.TrimRight(serverBaseURL, "/")
+	resp, err := http.Get(base + "/context.js")
+	if err != nil {
+		return nil, fmt.Errorf("fetch /context.js: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("/context.js returned HTTP %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	js := string(body)
+
+	authBlock := sliceBlock(js, "window.authConfig")
+	idsBlock := sliceBlock(js, "window.auth0Identifiers")
+
+	domain := extract(authBlock, "domain")
+	if domain == "" {
+		domain = extract(idsBlock, "domain")
+	}
+	clientID := extract(authBlock, "clientId")
+	if clientID == "" {
+		clientID = extract(idsBlock, "clientId")
+	}
+
+	cfg := &Auth0Config{
+		Domain:     domain,
+		ClientID:   clientID,
+		UseIDToken: useIDTokenTrueRe.MatchString(authBlock),
+	}
+	if cfg.Domain == "" || cfg.ClientID == "" {
+		return nil, fmt.Errorf("server has no Auth0 config in /context.js (is auth enabled?)")
+	}
+	return cfg, nil
+}
+
+var useIDTokenTrueRe = regexp.MustCompile(`["']?useIdToken["']?\s*:\s*true`)
+
+// sliceBlock returns the {...} object literal assigned at `marker` (e.g. "window.authConfig"),
+// or "" when absent. The blocks served by orkes/the UI are flat objects, so the first `}`
+// after the marker closes the block.
+func sliceBlock(js, marker string) string {
+	start := strings.Index(js, marker)
+	if start < 0 {
+		return ""
+	}
+	rest := js[start:]
+	end := strings.Index(rest, "}")
+	if end < 0 {
+		return rest
+	}
+	return rest[:end+1]
+}
+
+// extract pulls a string value for `key` from a JS/JSON object literal, tolerating both
+// quoted and bare keys and arbitrary spacing around the colon.
+func extract(js, key string) string {
+	m := regexp.MustCompile(`["']?` + key + `["']?\s*:\s*["']([^"']+)["']`).FindStringSubmatch(js)
+	if len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+func authURL(domain, path string) string {
+	domain = strings.TrimRight(domain, "/")
+	if !strings.HasPrefix(domain, "http") {
+		domain = "https://" + domain
+	}
+	return domain + path
+}

--- a/cli/auth/auth0_test.go
+++ b/cli/auth/auth0_test.go
@@ -1,0 +1,181 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDeviceFlow drives RequestDeviceCode + PollForToken against a real local HTTP
+// server emulating Auth0's device endpoints, including one authorization_pending poll.
+func TestDeviceFlow(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "dev-123",
+				"user_code":                 "WXYZ-1234",
+				"verification_uri":          "https://example/activate",
+				"verification_uri_complete": "https://example/activate?user_code=WXYZ-1234",
+				"expires_in":                300,
+				"interval":                  1,
+			})
+		case "/oauth/token":
+			polls++
+			if polls < 2 {
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "access-xyz",
+				"id_token":      "id-xyz",
+				"refresh_token": "refresh-xyz",
+				"expires_in":    3600,
+				"token_type":    "Bearer",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dc, err := RequestDeviceCode(srv.URL, "client-id", "")
+	if err != nil {
+		t.Fatalf("RequestDeviceCode: %v", err)
+	}
+	if dc.UserCode != "WXYZ-1234" {
+		t.Errorf("user code = %q", dc.UserCode)
+	}
+
+	tok, err := PollForToken(srv.URL, "client-id", dc)
+	if err != nil {
+		t.Fatalf("PollForToken: %v", err)
+	}
+	if tok.AccessToken != "access-xyz" || tok.RefreshToken != "refresh-xyz" {
+		t.Errorf("unexpected token: %+v", tok)
+	}
+	if polls < 2 {
+		t.Errorf("expected at least 2 polls (one pending), got %d", polls)
+	}
+}
+
+func TestRefresh(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("grant_type") != "refresh_token" || r.FormValue("refresh_token") != "rt" {
+			http.Error(w, "bad refresh", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "new-access", "expires_in": 3600})
+	}))
+	defer srv.Close()
+
+	tok, err := Refresh(srv.URL, "client-id", "rt")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if tok.AccessToken != "new-access" {
+		t.Errorf("refreshed access token = %q", tok.AccessToken)
+	}
+}
+
+func TestDiscoverConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/context.js" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = w.Write([]byte(`window.authConfig = { type: "auth0", domain: "tenant.us.auth0.com", clientId: "abc123", useIdToken: true };`))
+	}))
+	defer srv.Close()
+
+	cfg, err := DiscoverConfig(srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverConfig: %v", err)
+	}
+	if cfg.Domain != "tenant.us.auth0.com" || cfg.ClientID != "abc123" || !cfg.UseIDToken {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+}
+
+// TestDiscoverConfigRealOrkesFormat uses the exact serialization a real orkes server
+// emits — quoted keys with spaces around the colon, plus the window.conductor flags
+// block and the auth0Identifiers fallback block (regression: bare-key-only regex).
+func TestDiscoverConfigRealOrkesFormat(t *testing.T) {
+	body := `window.conductor = {
+  "ENABLE_METRICS_DASHBOARD" : false,
+  "MULTITENANCY_TYPE" : "none"
+};
+
+window.authConfig = {
+  "useIdToken" : false,
+  "clientId" : "s4HLdVbnaJMGvPSgx2YLpynfJlW7GV2e",
+  "domain" : "auth.orkes.io",
+  "type" : "auth0"
+};
+
+window.auth0Identifiers = {
+  "clientId" : "s4HLdVbnaJMGvPSgx2YLpynfJlW7GV2e",
+  "domain" : "auth.orkes.io"
+};`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/context.js" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	cfg, err := DiscoverConfig(srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverConfig: %v", err)
+	}
+	if cfg.Domain != "auth.orkes.io" || cfg.ClientID != "s4HLdVbnaJMGvPSgx2YLpynfJlW7GV2e" {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+	if cfg.UseIDToken {
+		t.Error("useIdToken=false in authConfig but parsed true")
+	}
+}
+
+// TestDiscoverConfigIdentifiersFallback mirrors the UI's auth0-config.ts fallback:
+// authConfig missing -> values from window.auth0Identifiers.
+func TestDiscoverConfigIdentifiersFallback(t *testing.T) {
+	body := `window.auth0Identifiers = {
+  "clientId" : "cid-fallback",
+  "domain" : "tenant.eu.auth0.com"
+};`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	cfg, err := DiscoverConfig(srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverConfig: %v", err)
+	}
+	if cfg.Domain != "tenant.eu.auth0.com" || cfg.ClientID != "cid-fallback" {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestDiscoverConfigNoAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`window.conductor = { stack: "test" };`))
+	}))
+	defer srv.Close()
+
+	if _, err := DiscoverConfig(srv.URL); err == nil {
+		t.Fatal("expected error when /context.js has no authConfig")
+	}
+}

--- a/cli/auth/orkes.go
+++ b/cli/auth/orkes.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package auth
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// MintOrkesToken exchanges an orkes application access key (keyId/keySecret) for a JWT
+// via POST {server}/api/token — orkes' internal/service-account auth path (no external IdP).
+// Returns the JWT and its expiry (unix seconds, decoded from the token's exp claim).
+func MintOrkesToken(serverBase, keyID, keySecret string) (token string, expiresAt int64, err error) {
+	base := strings.TrimRight(serverBase, "/")
+	body, _ := json.Marshal(map[string]string{"keyId": keyID, "keySecret": keySecret})
+	resp, err := http.Post(base+"/api/token", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", 0, fmt.Errorf("mint token: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", 0, fmt.Errorf("token request failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	var r struct {
+		Token string `json:"token"`
+	}
+	if json.Unmarshal(b, &r) != nil || r.Token == "" {
+		return "", 0, fmt.Errorf("no token in response: %s", strings.TrimSpace(string(b)))
+	}
+	return r.Token, TokenExp(r.Token), nil
+}
+
+// TokenExp decodes the `exp` (unix seconds) claim from a JWT without verifying the signature.
+// Returns 0 when the token is opaque or has no exp.
+func TokenExp(jwt string) int64 {
+	parts := strings.Split(jwt, ".")
+	if len(parts) < 2 {
+		return 0
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		if payload, err = base64.URLEncoding.DecodeString(parts[1]); err != nil {
+			return 0
+		}
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if json.Unmarshal(payload, &claims) != nil {
+		return 0
+	}
+	return claims.Exp
+}

--- a/cli/auth/orkes_test.go
+++ b/cli/auth/orkes_test.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMintOrkesToken(t *testing.T) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS512","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"exp":4102444800,"orkes_conductor_token":true}`))
+	jwt := header + "." + payload + ".sig"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/token" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["keyId"] != "kid" || body["keySecret"] != "ksecret" {
+			http.Error(w, "bad creds", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": jwt})
+	}))
+	defer srv.Close()
+
+	token, exp, err := MintOrkesToken(srv.URL, "kid", "ksecret")
+	if err != nil {
+		t.Fatalf("MintOrkesToken: %v", err)
+	}
+	if token != jwt {
+		t.Errorf("token mismatch")
+	}
+	if exp != 4102444800 {
+		t.Errorf("exp = %d, want 4102444800", exp)
+	}
+}
+
+func TestMintOrkesTokenBadCreds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	if _, _, err := MintOrkesToken(srv.URL, "x", "y"); err == nil {
+		t.Fatal("expected error on 401")
+	}
+}
+
+func TestTokenExp(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"exp":1700000000}`))
+	if got := TokenExp("h." + payload + ".s"); got != 1700000000 {
+		t.Errorf("TokenExp = %d, want 1700000000", got)
+	}
+	if got := TokenExp("opaque-token"); got != 0 {
+		t.Errorf("TokenExp(opaque) = %d, want 0", got)
+	}
+}

--- a/cli/auth/pkce.go
+++ b/cli/auth/pkce.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// PKCE implements the OAuth 2.0 Authorization Code flow with PKCE (RFC 7636) over a
+// loopback redirect (RFC 8252 §7.3) — the browser-based login a native CLI uses when the
+// Device Authorization grant is not enabled on the client. It reuses the SAME public
+// clientId the orkes UI uses (authorization_code + PKCE is what the UI itself runs);
+// the only requirement is that the loopback redirect URI is in the Auth0 application's
+// Allowed Callback URLs (the local UI origin, e.g. http://localhost:5001, already is).
+
+// GeneratePKCE returns a code_verifier and its S256 code_challenge.
+func GeneratePKCE() (verifier, challenge string, err error) {
+	buf := make([]byte, 32)
+	if _, err = rand.Read(buf); err != nil {
+		return "", "", fmt.Errorf("generate PKCE verifier: %w", err)
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(buf)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge, nil
+}
+
+// RandomState returns a random opaque state value for CSRF protection.
+func RandomState() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// BuildAuthorizeURL constructs the Auth0 /authorize URL for the code+PKCE flow.
+func BuildAuthorizeURL(domain, clientID, redirectURI, scope, state, challenge string) string {
+	if scope == "" {
+		scope = DefaultScope
+	}
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {redirectURI},
+		"scope":                 {scope},
+		"state":                 {state},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}
+	return authURL(domain, "/authorize") + "?" + q.Encode()
+}
+
+// CodeCapture is a bound loopback listener awaiting the OAuth redirect.
+type CodeCapture struct {
+	srv   *http.Server
+	resCh chan captureResult
+}
+
+type captureResult struct {
+	code string
+	err  error
+}
+
+// StartCodeCapture binds the loopback host:port of redirectURI immediately — failing fast
+// if the port is busy (e.g. the UI dev server holds it) BEFORE any browser is opened — and
+// starts serving the callback. Call Wait to block for the code.
+func StartCodeCapture(redirectURI, expectedState string) (*CodeCapture, error) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		return nil, fmt.Errorf("parse redirect uri: %w", err)
+	}
+	if u.Port() == "" {
+		return nil, fmt.Errorf("redirect uri must include an explicit port (got %q)", redirectURI)
+	}
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+
+	ln, err := net.Listen("tcp", u.Host)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot bind %s — is something (the UI dev server?) running on that port? "+
+				"Stop it during login or pass a different whitelisted --redirect-uri (%w)", u.Host, err)
+	}
+
+	resCh := make(chan captureResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Accept the callback on the redirect path (or root) only.
+		if r.URL.Path != path && r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		if e := q.Get("error"); e != "" {
+			http.Error(w, "Login failed: "+e, http.StatusBadRequest)
+			resCh <- captureResult{err: fmt.Errorf("authorization failed: %s (%s)", e, q.Get("error_description"))}
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			// Not the OAuth callback (e.g. favicon) — ignore.
+			http.NotFound(w, r)
+			return
+		}
+		if q.Get("state") != expectedState {
+			http.Error(w, "State mismatch", http.StatusBadRequest)
+			resCh <- captureResult{err: fmt.Errorf("state mismatch in callback")}
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, "<html><body><h3>Login complete.</h3>You can close this tab and return to the terminal.</body></html>")
+		resCh <- captureResult{code: code}
+	})
+
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	return &CodeCapture{srv: srv, resCh: resCh}, nil
+}
+
+// Wait blocks until the redirect delivers a code, an OAuth error arrives, or timeout.
+// The listener is shut down before returning.
+func (c *CodeCapture) Wait(timeout time.Duration) (string, error) {
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = c.srv.Shutdown(ctx)
+	}()
+	select {
+	case r := <-c.resCh:
+		return r.code, r.err
+	case <-time.After(timeout):
+		return "", fmt.Errorf("timed out waiting for the browser login (after %s)", timeout)
+	}
+}
+
+// ExchangeCode swaps an authorization code + PKCE verifier for tokens (public client).
+func ExchangeCode(domain, clientID, code, verifier, redirectURI string) (*Token, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {clientID},
+		"code":          {code},
+		"code_verifier": {verifier},
+		"redirect_uri":  {redirectURI},
+	}
+	resp, err := http.PostForm(authURL(domain, "/oauth/token"), form)
+	if err != nil {
+		return nil, fmt.Errorf("exchange code: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("code exchange failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var tok Token
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("parse token: %w", err)
+	}
+	return &tok, nil
+}

--- a/cli/auth/pkce_test.go
+++ b/cli/auth/pkce_test.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestGeneratePKCE(t *testing.T) {
+	verifier, challenge, err := GeneratePKCE()
+	if err != nil {
+		t.Fatalf("GeneratePKCE: %v", err)
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if challenge != want {
+		t.Errorf("challenge mismatch: got %q want %q", challenge, want)
+	}
+	if len(verifier) < 43 { // 32 bytes base64url = 43 chars, RFC 7636 minimum
+		t.Errorf("verifier too short: %d", len(verifier))
+	}
+}
+
+func TestBuildAuthorizeURL(t *testing.T) {
+	u, err := url.Parse(BuildAuthorizeURL("tenant.auth0.com", "cid", "http://localhost:5001", "", "st8", "ch4ll"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if u.Host != "tenant.auth0.com" || u.Path != "/authorize" {
+		t.Errorf("unexpected url: %s", u)
+	}
+	q := u.Query()
+	for k, want := range map[string]string{
+		"client_id":             "cid",
+		"response_type":         "code",
+		"redirect_uri":          "http://localhost:5001",
+		"state":                 "st8",
+		"code_challenge":        "ch4ll",
+		"code_challenge_method": "S256",
+		"scope":                 DefaultScope,
+	} {
+		if got := q.Get(k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// freePort grabs an ephemeral port and releases it for the capture server to rebind.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+func TestCodeCapture(t *testing.T) {
+	port := freePort(t)
+	redirect := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	capture, err := StartCodeCapture(redirect, "state-1")
+	if err != nil {
+		t.Fatalf("StartCodeCapture: %v", err)
+	}
+
+	// Simulate the browser redirect.
+	go func() {
+		resp, gerr := http.Get(fmt.Sprintf("%s/?code=auth-code-42&state=state-1", redirect))
+		if gerr == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	code, err := capture.Wait(10 * time.Second)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if code != "auth-code-42" {
+		t.Errorf("code = %q", code)
+	}
+}
+
+func TestCodeCaptureStateMismatch(t *testing.T) {
+	port := freePort(t)
+	redirect := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	capture, err := StartCodeCapture(redirect, "expected")
+	if err != nil {
+		t.Fatalf("StartCodeCapture: %v", err)
+	}
+
+	go func() {
+		resp, gerr := http.Get(fmt.Sprintf("%s/?code=c&state=WRONG", redirect))
+		if gerr == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if _, err := capture.Wait(10 * time.Second); err == nil {
+		t.Fatal("expected state-mismatch error")
+	}
+}
+
+func TestStartCodeCapturePortBusy(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	busy := fmt.Sprintf("http://127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
+
+	// Bind must fail immediately — BEFORE any browser would be opened.
+	if _, err := StartCodeCapture(busy, "s"); err == nil {
+		t.Fatal("expected bind error on busy port")
+	}
+}
+
+func TestExchangeCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("grant_type") != "authorization_code" ||
+			r.FormValue("code") != "the-code" ||
+			r.FormValue("code_verifier") != "the-verifier" ||
+			r.FormValue("redirect_uri") != "http://localhost:5001" {
+			http.Error(w, "bad exchange params", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "at", "id_token": "idt", "refresh_token": "rt", "expires_in": 3600,
+		})
+	}))
+	defer srv.Close()
+
+	tok, err := ExchangeCode(srv.URL, "cid", "the-code", "the-verifier", "http://localhost:5001")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tok.AccessToken != "at" || tok.RefreshToken != "rt" {
+		t.Errorf("unexpected token: %+v", tok)
+	}
+}

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentspan-ai/agentspan/cli/auth"
 	"github.com/agentspan-ai/agentspan/cli/config"
 )
 
@@ -22,13 +23,60 @@ type Client struct {
 	baseURL    string
 	httpClient *http.Client
 	apiKey     string
+	authToken  string // Auth0 JWT sent as X-Authorization (from ~/.agentspan/token)
 }
 
 func New(cfg *config.Config) *Client {
-	return &Client{
+	c := &Client{
 		baseURL:    strings.TrimRight(cfg.ServerURL, "/"),
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 		apiKey:     cfg.APIKey,
+	}
+	c.authToken = resolveAuthToken()
+	return c
+}
+
+// resolveAuthToken loads the stored login token, refreshing it via Auth0 if expired,
+// and returns the JWT to send as X-Authorization. Empty when not logged in.
+func resolveAuthToken() string {
+	t, err := config.LoadToken()
+	if err != nil || t == nil {
+		return ""
+	}
+	if t.Expired() {
+		switch {
+		case t.RefreshToken != "" && t.Auth0Domain != "" && t.ClientID != "":
+			// Auth0 device-flow token: refresh with the refresh token.
+			if nt, rerr := auth.Refresh(t.Auth0Domain, t.ClientID, t.RefreshToken); rerr == nil {
+				t.AccessToken = nt.AccessToken
+				if nt.IDToken != "" {
+					t.IDToken = nt.IDToken
+				}
+				if nt.RefreshToken != "" {
+					t.RefreshToken = nt.RefreshToken
+				}
+				t.ExpiresAt = time.Now().Add(time.Duration(nt.ExpiresIn) * time.Second).Unix()
+				_ = config.SaveToken(t)
+			}
+		case t.KeyID != "" && t.KeySecret != "" && t.ServerURL != "":
+			// orkes access-key token: re-mint via POST /api/token.
+			if tok, exp, merr := auth.MintOrkesToken(t.ServerURL, t.KeyID, t.KeySecret); merr == nil {
+				t.AccessToken = tok
+				t.ExpiresAt = exp
+				_ = config.SaveToken(t)
+			}
+		}
+	}
+	return t.Header()
+}
+
+// applyAuth attaches the auth header: X-Authorization (Auth0 JWT) when logged in,
+// else a legacy Authorization: Bearer from a configured API key. orkes accepts both.
+func (c *Client) applyAuth(req *http.Request) {
+	if c.authToken != "" {
+		req.Header.Set("X-Authorization", c.authToken)
+	} else if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
 }
 
@@ -49,9 +97,7 @@ func (c *Client) doRequest(method, path string, body interface{}) (*http.Respons
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
+	c.applyAuth(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -93,9 +139,7 @@ func (c *Client) doMultipartRequest(path string, manifest []byte, packageBytes [
 		return nil, err
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
+	c.applyAuth(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -196,9 +240,7 @@ func (c *Client) PollTask(taskType string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
+	c.applyAuth(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -578,9 +620,7 @@ func (c *Client) Stream(executionID string, lastEventID string, events chan<- SS
 		if lastEventID != "" {
 			req.Header.Set("Last-Event-ID", lastEventID)
 		}
-		if c.apiKey != "" {
-			req.Header.Set("Authorization", "Bearer "+c.apiKey)
-		}
+		c.applyAuth(req)
 
 		resp, err := streamClient.Do(req)
 		if err != nil {
@@ -645,34 +685,6 @@ func sseFieldValue(line, prefix string) string {
 
 // ─── Auth API ─────────────────────────────────────────────────────────────────
 
-// LoginRequest is the payload for POST /api/auth/login
-type LoginRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-}
-
-// LoginResponse carries the JWT returned by the server
-type LoginResponse struct {
-	Token string `json:"token"`
-}
-
-// Login authenticates with the server and returns a JWT.
-func (c *Client) Login(username, password string) (*LoginResponse, error) {
-	resp, err := c.doRequest("POST", "/api/auth/login", &LoginRequest{
-		Username: username,
-		Password: password,
-	})
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	var result LoginResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode login response: %w", err)
-	}
-	return &result, nil
-}
-
 // ─── Credentials management API ───────────────────────────────────────────────────
 
 // CredentialMeta is the list-view for a stored credential (from GET /api/secrets/v2).
@@ -706,9 +718,7 @@ func (c *Client) SetCredential(name, value string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "text/plain")
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
+	c.applyAuth(req)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)

--- a/cli/cmd/credentials.go
+++ b/cli/cmd/credentials.go
@@ -6,7 +6,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/agentspan-ai/agentspan/cli/client"
-	"github.com/agentspan-ai/agentspan/cli/config"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -37,7 +36,7 @@ var secretsSetCmd = &cobra.Command{
 }
 
 func runSecretsSet(name, value string) error {
-	cfg := config.Load()
+	cfg := getConfig()
 	c := client.New(cfg)
 	return c.SetCredential(name, value)
 }
@@ -58,7 +57,7 @@ var secretsListCmd = &cobra.Command{
 }
 
 func runSecretsList() (string, error) {
-	cfg := config.Load()
+	cfg := getConfig()
 	c := client.New(cfg)
 	secrets, err := c.ListCredentials()
 	if err != nil {
@@ -94,7 +93,7 @@ var secretsDeleteCmd = &cobra.Command{
 }
 
 func runSecretsDelete(name string) error {
-	cfg := config.Load()
+	cfg := getConfig()
 	return client.New(cfg).DeleteCredential(name)
 }
 

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -4,6 +4,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/agentspan-ai/agentspan/cli/client"
 	"github.com/agentspan-ai/agentspan/cli/config"
 )
@@ -12,6 +15,13 @@ func getConfig() *config.Config {
 	cfg := config.Load()
 	if serverURL != "" {
 		cfg.ServerURL = serverURL
+		// An explicitly passed --server becomes the default for subsequent commands.
+		// Notice goes to stderr so piped stdout (JSON output etc.) stays clean.
+		if config.FileServerURL() != serverURL {
+			if err := config.SaveDefaultServer(serverURL); err == nil {
+				fmt.Fprintf(os.Stderr, "Default server set to %s (%s)\n", serverURL, config.ConfigDir())
+			}
+		}
 	}
 	return cfg
 }

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -1,99 +1,308 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
 package cmd
 
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
-	"syscall"
+	"time"
 
-	"github.com/agentspan-ai/agentspan/cli/client"
+	"github.com/agentspan-ai/agentspan/cli/auth"
 	"github.com/agentspan-ai/agentspan/cli/config"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
 
+var (
+	loginDomain      string
+	loginClientID    string
+	loginScope       string
+	loginNoOpen      bool
+	loginKeyID       string
+	loginKeySecret   string
+	loginDevice      bool
+	loginRedirectURI string
+)
+
 var loginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Log in to the AgentSpan server and store an auth token",
-	Long: `Prompts for username and password, authenticates against the server,
-and stores the returned JWT in ~/.agentspan/config.json.
+	Short: "Log in via your browser (Auth0) and store the token",
+	Long: `Logs in through your browser using the same Auth0 application the orkes-conductor
+UI uses (Authorization Code + PKCE with a loopback redirect): your browser opens the
+hosted login page (username/password, Google, SSO — whatever the tenant allows), the
+redirect is captured locally, and the resulting token is stored in ~/.agentspan/token
+and sent to the server as the X-Authorization header on every request.
 
-On localhost with auth disabled, this command is not required — the server
-accepts all requests as anonymous admin automatically.`,
+The Auth0 domain and client id are auto-discovered from the server's /context.js (the
+same runtime config the UI consumes). Override with --auth0-domain / --auth0-client-id.
+
+Alternative grants:
+  --device                  OAuth Device Authorization flow (headless/SSH machines;
+                            requires the Device Code grant enabled on the Auth0 app)
+  --key-id / --key-secret   orkes application access key (service accounts / CI)
+
+On a localhost server with auth disabled, login is not required — requests are accepted
+as anonymous admin automatically.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := getConfig()
 
-		if cfg.IsLocalhost() && cfg.APIKey == "" {
-			color.Yellow("Server is localhost — auth is optional.")
-			fmt.Println("Proceeding without login (anonymous admin mode).")
-			return nil
+		// No --server flag and no env override: ask which instance to log into
+		// (pre-filled with the current default; plain Enter keeps it). TTY only.
+		if serverURL == "" &&
+			os.Getenv("AGENTSPAN_SERVER_URL") == "" && os.Getenv("AGENT_SERVER_URL") == "" &&
+			term.IsTerminal(int(os.Stdin.Fd())) {
+			if entered := promptServerURL(os.Stdin, cfg.ServerURL); entered != "" {
+				cfg.ServerURL = entered
+			}
 		}
 
-		fmt.Print("Username: ")
-		reader := bufio.NewReader(os.Stdin)
-		username, err := reader.ReadString('\n')
+		keyID := loginKeyID
+		if keyID == "" {
+			keyID = os.Getenv("AGENTSPAN_AUTH_KEY")
+		}
+		keySecret := loginKeySecret
+		if keySecret == "" {
+			keySecret = os.Getenv("AGENTSPAN_AUTH_SECRET")
+		}
+
+		var err error
+		if keyID != "" && keySecret != "" {
+			err = loginWithKey(cfg, keyID, keySecret)
+		} else {
+			err = loginWithAuth0(cfg)
+		}
 		if err != nil {
-			return fmt.Errorf("read username: %w", err)
-		}
-		username = strings.TrimSpace(username)
-
-		fmt.Print("Password: ")
-		passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
-		fmt.Println()
-		if err != nil {
-			return fmt.Errorf("read password: %w", err)
-		}
-		password := string(passwordBytes)
-
-		if err := doLogin(cfg, username, password); err != nil {
 			return err
 		}
 
-		color.Green("Logged in successfully.")
-		fmt.Printf("Token stored in %s/config.json\n", config.ConfigDir())
+		// A successful login pins this server as the default for subsequent commands.
+		if config.FileServerURL() != cfg.ServerURL {
+			if serr := config.SaveDefaultServer(cfg.ServerURL); serr == nil {
+				color.Green("Default server set to %s", cfg.ServerURL)
+			}
+		}
 		return nil
 	},
+}
+
+// promptServerURL asks for the server URL, showing the current default. Returns the
+// entered URL ("" = keep current). A missing scheme defaults to http:// (local instances).
+func promptServerURL(r io.Reader, current string) string {
+	fmt.Printf("Server URL [%s]: ", current)
+	line, _ := bufio.NewReader(r).ReadString('\n')
+	s := strings.TrimSpace(line)
+	if s == "" {
+		return ""
+	}
+	if !strings.Contains(s, "://") {
+		s = "http://" + s
+	}
+	return strings.TrimRight(s, "/")
+}
+
+// loginWithKey authenticates via an orkes application access key (keyId/keySecret) —
+// the internal / service-account path: POST /api/token -> JWT. The key/secret are stored
+// (0600) so the client can re-mint the token when it expires.
+func loginWithKey(cfg *config.Config, keyID, keySecret string) error {
+	token, exp, err := auth.MintOrkesToken(cfg.ServerURL, keyID, keySecret)
+	if err != nil {
+		return err
+	}
+	if err := config.SaveToken(&config.TokenInfo{
+		AccessToken: token,
+		ExpiresAt:   exp,
+		KeyID:       keyID,
+		KeySecret:   keySecret,
+		ServerURL:   cfg.ServerURL,
+	}); err != nil {
+		return fmt.Errorf("store token: %w", err)
+	}
+	color.Green("Logged in with access key. Token stored in %s", config.TokenPath())
+	return nil
+}
+
+// loginWithAuth0 runs the Auth0 device authorization grant (browser-based, matching the UI).
+func loginWithAuth0(cfg *config.Config) error {
+	domain, clientID, useIDToken := loginDomain, loginClientID, false
+	if domain == "" || clientID == "" {
+		discovered, err := auth.DiscoverConfig(cfg.ServerURL)
+		if err != nil {
+			return fmt.Errorf(
+				"could not discover Auth0 config from %s (%w).\n"+
+					"Pass --auth0-domain/--auth0-client-id, use --key-id/--key-secret, or confirm the server has auth enabled",
+				cfg.ServerURL, err)
+		}
+		if domain == "" {
+			domain = discovered.Domain
+		}
+		if clientID == "" {
+			clientID = discovered.ClientID
+		}
+		useIDToken = discovered.UseIDToken
+	}
+
+	if loginDevice {
+		return loginWithDeviceFlow(domain, clientID, useIDToken)
+	}
+	// Default: browser Authorization Code + PKCE — the same grant the UI uses, so it
+	// works with the stock UI clientId (device flow requires a tenant-side grant toggle).
+	return loginWithBrowserPKCE(domain, clientID, useIDToken)
+}
+
+// loginWithDeviceFlow runs the OAuth Device Authorization grant (for headless machines).
+// Requires the Device Code grant to be enabled on the Auth0 application.
+func loginWithDeviceFlow(domain, clientID string, useIDToken bool) error {
+	dc, err := auth.RequestDeviceCode(domain, clientID, loginScope)
+	if err != nil {
+		if strings.Contains(err.Error(), "unauthorized_client") {
+			return fmt.Errorf(
+				"the Device Authorization grant is not enabled on this Auth0 client.\n"+
+					"Run without --device to use the browser login, or enable the Device Code grant "+
+					"on the application in the Auth0 dashboard (%w)", err)
+		}
+		return err
+	}
+
+	verifyURL := dc.VerificationURIComplete
+	if verifyURL == "" {
+		verifyURL = dc.VerificationURI
+	}
+	fmt.Println()
+	color.Cyan("To log in, open this URL in your browser:")
+	fmt.Printf("  %s\n", verifyURL)
+	color.Cyan("Confirm this code is shown: %s", dc.UserCode)
+	fmt.Println()
+	if !loginNoOpen {
+		_ = openBrowser(verifyURL) // best-effort; URL is printed regardless
+	}
+	fmt.Println("Waiting for you to complete login in the browser...")
+
+	tok, err := auth.PollForToken(domain, clientID, dc)
+	if err != nil {
+		return err
+	}
+	return saveAuth0Token(tok, useIDToken, domain, clientID)
+}
+
+// loginWithBrowserPKCE runs the Authorization Code + PKCE flow with a loopback redirect
+// (RFC 8252): bind the redirect URI locally, open the hosted login in the browser, capture
+// the ?code= from the redirect, and exchange it with the PKCE verifier. Works with the same
+// public clientId the UI uses — the redirect URI must exactly match one of the Auth0 app's
+// Allowed Callback URLs (the local UI origin, e.g. http://localhost:5001, is whitelisted).
+func loginWithBrowserPKCE(domain, clientID string, useIDToken bool) error {
+	verifier, challenge, err := auth.GeneratePKCE()
+	if err != nil {
+		return err
+	}
+	state, err := auth.RandomState()
+	if err != nil {
+		return err
+	}
+	authorizeURL := auth.BuildAuthorizeURL(domain, clientID, loginRedirectURI, loginScope, state, challenge)
+
+	// Bind the loopback port BEFORE printing anything or opening the browser —
+	// fail fast if it's busy (e.g. the UI dev server holds it).
+	capture, err := auth.StartCodeCapture(loginRedirectURI, state)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	color.Cyan("To log in, open this URL in your browser:")
+	fmt.Printf("  %s\n", authorizeURL)
+	fmt.Println()
+	if !loginNoOpen {
+		_ = openBrowser(authorizeURL)
+	}
+	fmt.Printf("Waiting for the browser login (redirect captured on %s)...\n", loginRedirectURI)
+
+	code, err := capture.Wait(5 * time.Minute)
+	if err != nil {
+		return err
+	}
+
+	tok, err := auth.ExchangeCode(domain, clientID, code, verifier, loginRedirectURI)
+	if err != nil {
+		return err
+	}
+	return saveAuth0Token(tok, useIDToken, domain, clientID)
+}
+
+func saveAuth0Token(tok *auth.Token, useIDToken bool, domain, clientID string) error {
+	if err := config.SaveToken(&config.TokenInfo{
+		AccessToken:  tok.AccessToken,
+		IDToken:      tok.IDToken,
+		RefreshToken: tok.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second).Unix(),
+		UseIDToken:   useIDToken,
+		Auth0Domain:  domain,
+		ClientID:     clientID,
+	}); err != nil {
+		return fmt.Errorf("store token: %w", err)
+	}
+	color.Green("Logged in. Token stored in %s", config.TokenPath())
+	return nil
 }
 
 var logoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Remove the stored auth token",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg := config.Load()
-		if cfg.APIKey == "" {
+		cleared := false
+		if t, _ := config.LoadToken(); t != nil {
+			if err := config.ClearToken(); err != nil {
+				return fmt.Errorf("clear token: %w", err)
+			}
+			cleared = true
+		}
+		// Also clear any legacy API key stored in config.json.
+		if c := config.Load(); c.APIKey != "" {
+			c.APIKey = ""
+			if err := config.Save(c); err != nil {
+				return fmt.Errorf("save config: %w", err)
+			}
+			cleared = true
+		}
+		if cleared {
+			color.Green("Logged out.")
+		} else {
 			color.Yellow("Not currently logged in.")
-			return nil
 		}
-		cfg.APIKey = ""
-		if err := config.Save(cfg); err != nil {
-			return fmt.Errorf("save config: %w", err)
-		}
-		color.Green("Logged out.")
 		return nil
 	},
 }
 
-// doLogin calls the server auth endpoint and persists the returned token.
-// Extracted so tests can call it directly without terminal I/O.
-func doLogin(cfg *config.Config, username, password string) error {
-	c := client.New(cfg)
-	resp, err := c.Login(username, password)
-	if err != nil {
-		return fmt.Errorf("login failed: %w", err)
+// openBrowser best-effort opens a URL in the default browser.
+func openBrowser(url string) error {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name, args = "open", []string{url}
+	case "windows":
+		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		name, args = "xdg-open", []string{url}
 	}
-	if resp.Token == "" {
-		return fmt.Errorf("server returned empty token")
-	}
-	cfg.APIKey = resp.Token
-	if err := config.Save(cfg); err != nil {
-		return fmt.Errorf("save config: %w", err)
-	}
-	return nil
+	return exec.Command(name, args...).Start()
 }
 
 func init() {
+	loginCmd.Flags().StringVar(&loginKeyID, "key-id", "", "orkes access key id (service-account auth; env AGENTSPAN_AUTH_KEY)")
+	loginCmd.Flags().StringVar(&loginKeySecret, "key-secret", "", "orkes access key secret (service-account auth; env AGENTSPAN_AUTH_SECRET)")
+	loginCmd.Flags().StringVar(&loginDomain, "auth0-domain", "", "Auth0 domain (default: discovered from server /context.js)")
+	loginCmd.Flags().StringVar(&loginClientID, "auth0-client-id", "", "Auth0 client id (default: discovered from server /context.js)")
+	loginCmd.Flags().StringVar(&loginScope, "scope", auth.DefaultScope, "OAuth scope to request")
+	loginCmd.Flags().BoolVar(&loginNoOpen, "no-open", false, "Do not auto-open the browser")
+	loginCmd.Flags().BoolVar(&loginDevice, "device", false, "Use the OAuth Device Authorization flow instead of the browser login (headless machines)")
+	loginCmd.Flags().StringVar(&loginRedirectURI, "redirect-uri", "http://localhost:5001", "Loopback redirect URI for the browser login; must exactly match an Allowed Callback URL of the Auth0 app (default: the local orkes UI origin)")
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(logoutCmd)
 }

--- a/cli/cmd/login_test.go
+++ b/cli/cmd/login_test.go
@@ -1,107 +1,104 @@
 package cmd
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentspan-ai/agentspan/cli/config"
 )
 
-func TestLogoutClearsAPIKey(t *testing.T) {
-	newTempHome(t)
-
-	cfg := config.DefaultConfig()
-	cfg.APIKey = "existing-token"
-	if err := config.Save(cfg); err != nil {
-		t.Fatalf("save: %v", err)
+func TestPromptServerURL(t *testing.T) {
+	// Enter accepts the current default.
+	if got := promptServerURL(strings.NewReader("\n"), "http://localhost:6767"); got != "" {
+		t.Errorf("enter should keep current, got %q", got)
 	}
-
-	cfg.APIKey = ""
-	if err := config.Save(cfg); err != nil {
-		t.Fatalf("save cleared: %v", err)
+	// Full URL passes through (trailing slash trimmed).
+	if got := promptServerURL(strings.NewReader("https://my.orkes.io/\n"), "x"); got != "https://my.orkes.io" {
+		t.Errorf("got %q", got)
 	}
-
-	loaded := config.Load()
-	if loaded.APIKey != "" {
-		t.Errorf("APIKey after logout = %q, want empty", loaded.APIKey)
+	// Missing scheme defaults to http:// (local instances).
+	if got := promptServerURL(strings.NewReader("localhost:8080\n"), "x"); got != "http://localhost:8080" {
+		t.Errorf("got %q", got)
 	}
 }
 
-func TestLoginStoresToken(t *testing.T) {
+func TestGetConfigPersistsExplicitServer(t *testing.T) {
 	newTempHome(t)
+	old := serverURL
+	defer func() { serverURL = old }()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/api/auth/login" {
-			http.NotFound(w, r)
-			return
-		}
-		var body map[string]string
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "bad body", http.StatusBadRequest)
-			return
-		}
-		if body["username"] != "alice" || body["password"] != "secret" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"token": "jwt-abc123"})
-	}))
-	defer srv.Close()
-
-	cfg := config.DefaultConfig()
-	cfg.ServerURL = srv.URL
-	if err := config.Save(cfg); err != nil {
-		t.Fatalf("save: %v", err)
+	serverURL = "http://localhost:8080"
+	cfg := getConfig()
+	if cfg.ServerURL != "http://localhost:8080" {
+		t.Fatalf("effective server = %q", cfg.ServerURL)
 	}
-
-	if err := doLogin(cfg, "alice", "secret"); err != nil {
-		t.Fatalf("doLogin: %v", err)
+	// The explicit --server must now be the persisted default.
+	if got := config.FileServerURL(); got != "http://localhost:8080" {
+		t.Errorf("persisted default = %q, want http://localhost:8080", got)
 	}
-
-	loaded := config.Load()
-	if loaded.APIKey != "jwt-abc123" {
-		t.Errorf("APIKey = %q, want jwt-abc123", loaded.APIKey)
+	// And a flag-less invocation picks it up.
+	serverURL = ""
+	if cfg2 := getConfig(); cfg2.ServerURL != "http://localhost:8080" {
+		t.Errorf("flag-less server = %q, want persisted default", cfg2.ServerURL)
 	}
 }
 
-func TestLoginServerError(t *testing.T) {
+func TestSaveDefaultServerPreservesAPIKey(t *testing.T) {
 	newTempHome(t)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	cfg := config.DefaultConfig()
-	cfg.ServerURL = srv.URL
-	if err := config.Save(cfg); err != nil {
+	if err := config.Save(&config.Config{ServerURL: "http://a", APIKey: "keep-me"}); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-
-	if err := doLogin(cfg, "bad", "creds"); err == nil {
-		t.Fatal("expected error from doLogin on 401, got nil")
+	if err := config.SaveDefaultServer("http://b"); err != nil {
+		t.Fatalf("SaveDefaultServer: %v", err)
+	}
+	cfg := config.Load()
+	if cfg.ServerURL != "http://b" || cfg.APIKey != "keep-me" {
+		t.Errorf("got %+v, want server http://b with api key preserved", cfg)
 	}
 }
 
-func TestLoginEmptyTokenError(t *testing.T) {
+func TestLogoutClearsToken(t *testing.T) {
 	newTempHome(t)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"token": ""})
-	}))
-	defer srv.Close()
-
-	cfg := config.DefaultConfig()
-	cfg.ServerURL = srv.URL
-	if err := config.Save(cfg); err != nil {
-		t.Fatalf("save: %v", err)
+	if err := config.SaveToken(&config.TokenInfo{
+		AccessToken: "jwt-abc",
+		ExpiresAt:   time.Now().Add(time.Hour).Unix(),
+	}); err != nil {
+		t.Fatalf("save token: %v", err)
 	}
 
-	if err := doLogin(cfg, "user", "pass"); err == nil {
-		t.Fatal("expected error for empty token, got nil")
+	if err := config.ClearToken(); err != nil {
+		t.Fatalf("clear token: %v", err)
+	}
+
+	tok, err := config.LoadToken()
+	if err != nil {
+		t.Fatalf("load token: %v", err)
+	}
+	if tok != nil {
+		t.Errorf("token after logout = %+v, want nil", tok)
+	}
+}
+
+func TestTokenHeaderSelection(t *testing.T) {
+	access := &config.TokenInfo{AccessToken: "acc", IDToken: "id", UseIDToken: false}
+	if got := access.Header(); got != "acc" {
+		t.Errorf("default header = %q, want access token", got)
+	}
+	idtok := &config.TokenInfo{AccessToken: "acc", IDToken: "id", UseIDToken: true}
+	if got := idtok.Header(); got != "id" {
+		t.Errorf("useIdToken header = %q, want id token", got)
+	}
+}
+
+func TestTokenExpired(t *testing.T) {
+	expired := &config.TokenInfo{ExpiresAt: time.Now().Add(-time.Minute).Unix()}
+	if !expired.Expired() {
+		t.Error("expected expired token to report Expired()=true")
+	}
+	fresh := &config.TokenInfo{ExpiresAt: time.Now().Add(time.Hour).Unix()}
+	if fresh.Expired() {
+		t.Error("expected fresh token to report Expired()=false")
 	}
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -58,7 +58,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&serverURL, "server", "", "Runtime server URL (default: http://localhost:6767)")
+	rootCmd.PersistentFlags().StringVar(&serverURL, "server", "", "Runtime server URL; once passed it is saved as the default for subsequent commands (initial default: http://localhost:6767)")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(tuiCmd)
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -83,3 +83,29 @@ func Save(cfg *Config) error {
 	}
 	return os.WriteFile(configPath(), data, 0o600)
 }
+
+// FileServerURL returns the server URL stored in config.json (no env/default merging).
+// Empty when no config file exists or it has no server_url.
+func FileServerURL() string {
+	data, err := os.ReadFile(configPath())
+	if err != nil {
+		return ""
+	}
+	var fileCfg Config
+	if json.Unmarshal(data, &fileCfg) != nil {
+		return ""
+	}
+	return fileCfg.ServerURL
+}
+
+// SaveDefaultServer persists serverURL as the default in config.json, preserving any
+// other stored fields (e.g. a legacy api_key). Used so an explicitly passed --server
+// (or the URL confirmed at login) becomes the default for subsequent commands.
+func SaveDefaultServer(serverURL string) error {
+	fileCfg := &Config{}
+	if data, err := os.ReadFile(configPath()); err == nil {
+		_ = json.Unmarshal(data, fileCfg)
+	}
+	fileCfg.ServerURL = serverURL
+	return Save(fileCfg)
+}

--- a/cli/config/token.go
+++ b/cli/config/token.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// TokenInfo is the auth token persisted at ~/.agentspan/token. It holds the Auth0
+// JWT sent to orkes as the X-Authorization header, plus the refresh token and the
+// issuer details needed to refresh it without re-login.
+type TokenInfo struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresAt    int64  `json:"expires_at"` // unix seconds
+	UseIDToken   bool   `json:"use_id_token"`
+	Auth0Domain  string `json:"auth0_domain,omitempty"`
+	ClientID     string `json:"client_id,omitempty"`
+
+	// orkes internal-key (service-account) grant: re-mint via POST {ServerURL}/api/token.
+	KeyID     string `json:"key_id,omitempty"`
+	KeySecret string `json:"key_secret,omitempty"`
+	ServerURL string `json:"server_url,omitempty"`
+}
+
+// TokenPath is the dedicated token file: ~/.agentspan/token.
+func TokenPath() string {
+	return filepath.Join(ConfigDir(), "token")
+}
+
+// Header returns the JWT to send as X-Authorization: the ID token when the
+// deployment is configured for it, otherwise the access token (UI default).
+func (t *TokenInfo) Header() string {
+	if t.UseIDToken && t.IDToken != "" {
+		return t.IDToken
+	}
+	return t.AccessToken
+}
+
+// Expired reports whether the token is at/near expiry (30s clock-skew margin).
+func (t *TokenInfo) Expired() bool {
+	return t.ExpiresAt > 0 && time.Now().Unix() >= t.ExpiresAt-30
+}
+
+// SaveToken writes the token file with 0600 perms.
+func SaveToken(t *TokenInfo) error {
+	if err := os.MkdirAll(ConfigDir(), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(TokenPath(), data, 0o600)
+}
+
+// LoadToken reads the token file. Returns (nil, nil) when no token is stored.
+func LoadToken() (*TokenInfo, error) {
+	data, err := os.ReadFile(TokenPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var t TokenInfo
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// ClearToken removes the token file (logout). No-op if absent.
+func ClearToken() error {
+	err := os.Remove(TokenPath())
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/sdk/python/src/agentspan/agents/_internal/token_utils.py
+++ b/sdk/python/src/agentspan/agents/_internal/token_utils.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Auth token helpers shared by the sync/async agent API clients and framework adapters.
+
+Secured Conductor hosts (e.g. orkes) authenticate API calls with a JWT in the
+``X-Authorization`` header, minted from an application access key via
+``POST {server}/token``. These helpers centralize that mint (with an expiry-aware
+process-wide cache) so every HTTP path — agent API, SSE streaming, framework event
+pushes — sends the same correct header. Anonymous servers ignore the header.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import threading
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger("agentspan.agents.token_utils")
+
+
+def decode_jwt_exp(token: str) -> float:
+    """Best-effort decode of a JWT's ``exp`` claim (unix seconds).
+
+    Returns 0.0 for opaque tokens, malformed JWTs, or tokens without ``exp`` —
+    callers treat 0 as "expiry unknown, use until rejected".
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return 0.0
+        seg = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(seg))
+        return float(payload.get("exp", 0) or 0)
+    except Exception:
+        return 0.0
+
+
+# Process-wide mint cache: (server_url, auth_key) -> (token, exp). Framework event
+# pushes run on thread pools, so guard with a lock.
+_TOKEN_CACHE: Dict[Tuple[str, str], Tuple[str, float]] = {}
+_TOKEN_LOCK = threading.Lock()
+
+
+def resolve_agent_api_token(
+    server_url: str,
+    api_key: Optional[str] = None,
+    auth_key: Optional[str] = None,
+    auth_secret: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve the JWT for agent API calls.
+
+    An explicit ``api_key`` is already a token and returned as-is. Otherwise a JWT is
+    minted from ``auth_key``/``auth_secret`` via ``POST {server_url}/token`` and cached
+    until ~expiry. Returns None when no credentials are configured or the mint fails
+    (anonymous / security-disabled servers).
+    """
+    if api_key:
+        return api_key
+    if not auth_key or not auth_secret:
+        return None
+
+    import time
+
+    cache_key = (server_url.rstrip("/"), auth_key)
+    with _TOKEN_LOCK:
+        cached = _TOKEN_CACHE.get(cache_key)
+        if cached:
+            token, exp = cached
+            if exp == 0.0 or time.time() < exp - 30:
+                return token
+
+    import requests
+
+    url = server_url.rstrip("/") + "/token"
+    try:
+        resp = requests.post(url, json={"keyId": auth_key, "keySecret": auth_secret}, timeout=30)
+        resp.raise_for_status()
+        token = resp.json().get("token")
+    except Exception as e:  # pragma: no cover - network/credential failures
+        logger.warning("Failed to mint agent API token: %s", e)
+        return None
+    if not token:
+        return None
+    with _TOKEN_LOCK:
+        _TOKEN_CACHE[cache_key] = (token, decode_jwt_exp(token))
+    return token
+
+
+def agent_api_auth_headers(
+    server_url: str,
+    api_key: Optional[str] = None,
+    auth_key: Optional[str] = None,
+    auth_secret: Optional[str] = None,
+) -> Dict[str, str]:
+    """``X-Authorization`` header dict for agent API calls ({} when anonymous)."""
+    token = resolve_agent_api_token(server_url, api_key, auth_key, auth_secret)
+    return {"X-Authorization": token} if token else {}

--- a/sdk/python/src/agentspan/agents/frameworks/claude_agent_sdk.py
+++ b/sdk/python/src/agentspan/agents/frameworks/claude_agent_sdk.py
@@ -21,6 +21,7 @@ from dataclasses import is_dataclass, replace
 from typing import Any, Dict, List, Optional, Tuple
 
 from agentspan.agents.frameworks.serializer import WorkerInfo
+from agentspan.agents._internal.token_utils import agent_api_auth_headers
 
 logger = logging.getLogger("agentspan.agents.frameworks.claude_agent_sdk")
 
@@ -830,11 +831,7 @@ def _push_event_nonblocking(
             import requests
 
             url = f"{server_url}/agent/events/{execution_id}"
-            headers: Dict[str, str] = {}
-            if auth_key:
-                headers["X-Auth-Key"] = auth_key
-            if auth_secret:
-                headers["X-Auth-Secret"] = auth_secret
+            headers = agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
             requests.post(url, json=event, headers=headers, timeout=5)
         except Exception as exc:
             logger.debug("Event push failed (execution_id=%s): %s", execution_id, exc)
@@ -871,10 +868,9 @@ def _update_task_progress_nonblocking(
 
             url = f"{server_url}/tasks"
             headers: Dict[str, str] = {"Content-Type": "application/json"}
-            if auth_key:
-                headers["X-Auth-Key"] = auth_key
-            if auth_secret:
-                headers["X-Auth-Secret"] = auth_secret
+            headers.update(
+                agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
+            )
             body = {
                 "taskId": task_id,
                 "workflowInstanceId": execution_id,
@@ -917,10 +913,9 @@ def _create_tracking_workflow(
 
         url = f"{server_url}/agent/execution"
         headers: Dict[str, str] = {"Content-Type": "application/json"}
-        if auth_key:
-            headers["X-Auth-Key"] = auth_key
-        if auth_secret:
-            headers["X-Auth-Secret"] = auth_secret
+        headers.update(
+            agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
+        )
         body: Dict[str, Any] = {"workflowName": workflow_name, "input": input_data}
         if parent_workflow_id:
             body["parentWorkflowId"] = parent_workflow_id
@@ -959,10 +954,9 @@ def _inject_tool_task(
 
         url = f"{server_url}/agent/{execution_id}/tasks"
         headers: Dict[str, str] = {"Content-Type": "application/json"}
-        if auth_key:
-            headers["X-Auth-Key"] = auth_key
-        if auth_secret:
-            headers["X-Auth-Secret"] = auth_secret
+        headers.update(
+            agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
+        )
         body: Dict[str, Any] = {
             "taskDefName": tool_name,
             "referenceTaskName": ref_name,
@@ -1003,10 +997,9 @@ def _complete_tool_task_nonblocking(
 
             url = f"{server_url}/agent/tasks/{execution_id}/{ref_name}/{status}"
             headers: Dict[str, str] = {"Content-Type": "application/json"}
-            if auth_key:
-                headers["X-Auth-Key"] = auth_key
-            if auth_secret:
-                headers["X-Auth-Secret"] = auth_secret
+            headers.update(
+                agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
+            )
             requests.post(url, json=output_data, headers=headers, timeout=5)
         except Exception as exc:
             logger.debug(
@@ -1037,10 +1030,9 @@ def _complete_workflow_nonblocking(
 
             url = f"{server_url}/agent/execution/{workflow_execution_id}/complete"
             headers: Dict[str, str] = {"Content-Type": "application/json"}
-            if auth_key:
-                headers["X-Auth-Key"] = auth_key
-            if auth_secret:
-                headers["X-Auth-Secret"] = auth_secret
+            headers.update(
+                agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
+            )
             requests.post(url, json=output_data or {}, headers=headers, timeout=5)
         except Exception as exc:
             logger.debug(

--- a/sdk/python/src/agentspan/agents/frameworks/langchain.py
+++ b/sdk/python/src/agentspan/agents/frameworks/langchain.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from langchain_core.callbacks import BaseCallbackHandler
 
 from agentspan.agents.frameworks.serializer import WorkerInfo
+from agentspan.agents._internal.token_utils import agent_api_auth_headers
 
 logger = logging.getLogger("agentspan.agents.frameworks.langchain")
 
@@ -240,11 +241,7 @@ def _push_event_nonblocking(
             import requests
 
             url = f"{server_url}/agent/events/{execution_id}"
-            headers = {}
-            if auth_key:
-                headers["X-Auth-Key"] = auth_key
-            if auth_secret:
-                headers["X-Auth-Secret"] = auth_secret
+            headers = agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
             requests.post(url, json=event, headers=headers, timeout=5)
         except Exception as exc:
             logger.debug("Event push failed (execution_id=%s): %s", execution_id, exc)

--- a/sdk/python/src/agentspan/agents/frameworks/langgraph.py
+++ b/sdk/python/src/agentspan/agents/frameworks/langgraph.py
@@ -26,6 +26,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional, Tuple
 
 from agentspan.agents.frameworks.serializer import WorkerInfo
+from agentspan.agents._internal.token_utils import agent_api_auth_headers
 
 logger = logging.getLogger("agentspan.agents.frameworks.langgraph")
 
@@ -1780,11 +1781,7 @@ def _push_event_nonblocking(
             import requests
 
             url = f"{server_url}/agent/events/{execution_id}"
-            headers = {}
-            if auth_key:
-                headers["X-Auth-Key"] = auth_key
-            if auth_secret:
-                headers["X-Auth-Secret"] = auth_secret
+            headers = agent_api_auth_headers(server_url, auth_key=auth_key, auth_secret=auth_secret)
             requests.post(url, json=event, headers=headers, timeout=5)
         except Exception as exc:
             logger.debug("Event push failed (execution_id=%s): %s", execution_id, exc)

--- a/sdk/python/src/agentspan/agents/runtime/http_client.py
+++ b/sdk/python/src/agentspan/agents/runtime/http_client.py
@@ -20,6 +20,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 import httpx
 
+from agentspan.agents._internal.token_utils import decode_jwt_exp
 from agentspan.agents.exceptions import _raise_api_error
 
 logger = logging.getLogger("agentspan.agents.runtime.http_client")
@@ -46,23 +47,43 @@ class AgentHttpClient:
         self._auth_key = auth_key
         self._auth_secret = auth_secret
         self._client: Optional[httpx.AsyncClient] = None
+        self._token: str = ""
+        self._token_exp: float = 0.0
 
-    def _base_headers(self) -> Dict[str, str]:
-        headers: Dict[str, str] = {}
+    async def _auth_headers(self) -> Dict[str, str]:
+        """``X-Authorization`` header for secured hosts (orkes); {} when anonymous.
+
+        An explicit api_key is already a token. Otherwise a JWT is minted from
+        auth_key/auth_secret via ``POST {server}/token`` and cached until ~expiry.
+        """
         if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
-        elif self._auth_key:
-            headers["X-Auth-Key"] = self._auth_key
-            if self._auth_secret:
-                headers["X-Auth-Secret"] = self._auth_secret
-        return headers
+            return {"X-Authorization": self._api_key}
+        if not self._auth_key or not self._auth_secret:
+            return {}
+
+        if self._token and (self._token_exp == 0.0 or time.time() < self._token_exp - 30):
+            return {"X-Authorization": self._token}
+
+        try:
+            client = await self._get_client()
+            resp = await client.post(
+                f"{self._server_url}/token",
+                json={"keyId": self._auth_key, "keySecret": self._auth_secret},
+            )
+            resp.raise_for_status()
+            token = resp.json().get("token") or ""
+        except Exception as e:  # pragma: no cover - network/credential failures
+            logger.warning("Failed to mint agent API token: %s", e)
+            return {}
+        if not token:
+            return {}
+        self._token = token
+        self._token_exp = decode_jwt_exp(token)
+        return {"X-Authorization": token}
 
     async def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(
-                timeout=httpx.Timeout(30.0, connect=5.0),
-                headers=self._base_headers(),
-            )
+            self._client = httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=5.0))
         return self._client
 
     def _url(self, path: str) -> str:
@@ -74,7 +95,7 @@ class AgentHttpClient:
         """POST /agent/start — start an agent execution."""
         client = await self._get_client()
         url = self._url("/start")
-        resp = await client.post(url, json=payload)
+        resp = await client.post(url, json=payload, headers=await self._auth_headers())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -85,7 +106,7 @@ class AgentHttpClient:
         """POST /agent/deploy — deploy agent (compile + register, no execution)."""
         client = await self._get_client()
         url = self._url("/deploy")
-        resp = await client.post(url, json=payload)
+        resp = await client.post(url, json=payload, headers=await self._auth_headers())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -96,7 +117,7 @@ class AgentHttpClient:
         """POST /agent/compile — compile agent config to agent def."""
         client = await self._get_client()
         url = self._url("/compile")
-        resp = await client.post(url, json=config_json)
+        resp = await client.post(url, json=config_json, headers=await self._auth_headers())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -107,7 +128,7 @@ class AgentHttpClient:
         """GET /agent/{id}/status — fetch execution status."""
         client = await self._get_client()
         url = self._url(f"/{execution_id}/status")
-        resp = await client.get(url)
+        resp = await client.get(url, headers=await self._auth_headers())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -118,7 +139,7 @@ class AgentHttpClient:
         """POST /agent/{id}/respond — complete a pending human task."""
         client = await self._get_client()
         url = self._url(f"/{execution_id}/respond")
-        resp = await client.post(url, json=body)
+        resp = await client.post(url, json=body, headers=await self._auth_headers())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -128,7 +149,7 @@ class AgentHttpClient:
         """POST /agent/{id}/stop — graceful deterministic stop."""
         client = await self._get_client()
         url = self._url(f"/{execution_id}/stop")
-        resp = await client.post(url)
+        resp = await client.post(url, headers=await self._auth_headers())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -138,7 +159,7 @@ class AgentHttpClient:
         """POST /agent/{id}/signal — inject persistent context."""
         client = await self._get_client()
         url = self._url(f"/{execution_id}/signal")
-        resp = await client.post(url, json={"message": message})
+        resp = await client.post(url, json={"message": message}, headers=await self._auth_headers())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -152,7 +173,7 @@ class AgentHttpClient:
         server doesn't support SSE or sends only heartbeats.
         """
         url = f"{self._server_url}/agent/stream/{execution_id}"
-        headers = {**self._base_headers(), "Accept": "text/event-stream"}
+        headers = {**(await self._auth_headers()), "Accept": "text/event-stream"}
 
         last_event_id: Optional[str] = None
         first_connect = True

--- a/sdk/python/src/agentspan/agents/runtime/runtime.py
+++ b/sdk/python/src/agentspan/agents/runtime/runtime.py
@@ -148,6 +148,47 @@ async def _call_user_fn(fn, *args, **kwargs):
     return await asyncio.to_thread(fn, *args, **kwargs)
 
 
+def _resolve_loop_iteration(iteration: object) -> int:
+    """Resolve the current DO_WHILE loop iteration robustly across Conductor cores.
+
+    The compiler wires a worker's ``iteration`` input from the loop counter
+    reference ``${<agent>_loop.iteration}``. Conductor cores disagree on whether
+    that loop-output reference resolves for tasks executing *inside* the loop
+    body: the OSS core agentspan compiles against resolves it to the live integer,
+    but some embedding hosts' cores (e.g. orkes-conductor) leave it unresolved and
+    deliver ``None`` — which then crashes ``iteration >= max_retries`` comparisons.
+
+    The authoritative per-iteration value is always present on the Task object
+    (``task.iteration``), set identically by every core (1-based inside a loop,
+    0 outside). So: trust a valid integer input when present (preserves the OSS
+    path exactly, no regression), otherwise fall back to the live task iteration,
+    and finally to 0.
+    """
+    if isinstance(iteration, bool):
+        return 0
+    if isinstance(iteration, int):
+        return iteration
+    if isinstance(iteration, str) and iteration.strip().lstrip("-").isdigit():
+        return int(iteration.strip())
+    try:
+        from conductor.client.context.task_context import get_task_context
+
+        live = getattr(get_task_context().task, "iteration", None)
+        if isinstance(live, int) and not isinstance(live, bool):
+            return live
+    except Exception:
+        # No task context (e.g. unit-test direct call) or core without the field.
+        pass
+    return 0
+
+
+def _decode_jwt_exp(token: str) -> float:
+    """Best-effort decode of a JWT's `exp` (unix seconds); 0 if opaque/unavailable."""
+    from agentspan.agents._internal.token_utils import decode_jwt_exp
+
+    return decode_jwt_exp(token)
+
+
 def _normalize_handoff_target(task_ref: str) -> str:
     """Extract the actual agent name from a Conductor sub-workflow reference.
 
@@ -409,17 +450,33 @@ class AgentRuntime:
         base = self._config.server_url.rstrip("/")
         return f"{base}/agent{path}"
 
+    def _agent_api_token(self) -> "Optional[str]":
+        """Resolve the bearer token for agent runtime API calls (sent as X-Authorization).
+
+        Prefers an explicit ``api_key`` (already a token). Otherwise mints and caches a JWT
+        from ``auth_key``/``auth_secret`` via ``POST {server}/token`` — the orkes internal-key
+        (service-account) auth path, the same exchange the worker client and CLI use. Returns
+        ``None`` when no credentials are configured (anonymous / security-disabled servers).
+        """
+        from agentspan.agents._internal.token_utils import resolve_agent_api_token
+
+        return resolve_agent_api_token(
+            self._config.server_url,
+            api_key=self._config.api_key,
+            auth_key=self._config.auth_key,
+            auth_secret=self._config.auth_secret,
+        )
+
     def _agent_api_headers(self, content_type: str = "application/json") -> Dict[str, str]:
         """Build headers for agent runtime API requests."""
         headers: Dict[str, str] = {}
         if content_type:
             headers["Content-Type"] = content_type
-        if self._config.api_key:
-            headers["Authorization"] = f"Bearer {self._config.api_key}"
-        elif self._config.auth_key:
-            headers["X-Auth-Key"] = self._config.auth_key
-            if self._config.auth_secret:
-                headers["X-Auth-Secret"] = self._config.auth_secret
+        token = self._agent_api_token()
+        if token:
+            # orkes accepts X-Authorization (and Authorization: Bearer); the standalone
+            # anonymous server ignores it. X-Authorization matches the UI/CLI convention.
+            headers["X-Authorization"] = token
         return headers
 
     def _register_workflow_credentials(
@@ -709,11 +766,7 @@ class AgentRuntime:
         server_url = self._config.server_url.rstrip("/")
         url = f"{server_url}/agent/compile"
 
-        headers = {"Content-Type": "application/json"}
-        if self._config.auth_key:
-            headers["X-Auth-Key"] = self._config.auth_key
-        if self._config.auth_secret:
-            headers["X-Auth-Secret"] = self._config.auth_secret
+        headers = self._agent_api_headers()
 
         payload = {"agentConfig": config_json}
         response = requests.post(url, json=payload, headers=headers, timeout=30)
@@ -1340,6 +1393,7 @@ class AgentRuntime:
             async def combined_guardrail_worker(
                 content: object = None, iteration: int = 0
             ) -> object:
+                iteration = _resolve_loop_iteration(iteration)
                 if content is None:
                     content_str = ""
                 elif isinstance(content, str):
@@ -1420,6 +1474,7 @@ class AgentRuntime:
         g_name = guardrail.name
 
         async def guardrail_worker(content: object = None, iteration: int = 0) -> object:
+            iteration = _resolve_loop_iteration(iteration)
             if content is None:
                 content_str = ""
             elif isinstance(content, str):
@@ -1490,6 +1545,7 @@ class AgentRuntime:
         task_name = f"{agent_name}_stop_when"
 
         async def stop_when_worker(result="", iteration: int = 0, messages=None) -> object:
+            iteration = _resolve_loop_iteration(iteration)
             context = {"result": result, "messages": messages or [], "iteration": iteration}
             try:
                 should_stop = await _call_user_fn(stop_when_fn, context)
@@ -1583,6 +1639,7 @@ class AgentRuntime:
         task_name = f"{agent_name}_termination"
 
         async def termination_worker(result: str = "", iteration: int = 0) -> object:
+            iteration = _resolve_loop_iteration(iteration)
             context = {"result": result, "messages": [], "iteration": iteration}
             try:
                 outcome = await _call_user_fn(termination_cond.should_terminate, context)
@@ -2235,11 +2292,7 @@ class AgentRuntime:
         server_url = self._config.server_url.rstrip("/")
         url = f"{server_url}/agent/compile"
 
-        headers = {"Content-Type": "application/json"}
-        if self._config.auth_key:
-            headers["X-Auth-Key"] = self._config.auth_key
-        if self._config.auth_secret:
-            headers["X-Auth-Secret"] = self._config.auth_secret
+        headers = self._agent_api_headers()
 
         response = requests.post(url, json=payload, headers=headers, timeout=30)
         try:
@@ -3614,10 +3667,9 @@ class AgentRuntime:
         server_url = self._config.server_url.rstrip("/")
         url = f"{server_url}/agent/stream/{execution_id}"
         headers: Dict[str, str] = {"Accept": "text/event-stream"}
-        if self._config.auth_key:
-            headers["X-Auth-Key"] = self._config.auth_key
-        if self._config.auth_secret:
-            headers["X-Auth-Secret"] = self._config.auth_secret
+        token = self._agent_api_token()
+        if token:
+            headers["X-Authorization"] = token
 
         last_event_id: Optional[str] = None
         first_connect = True

--- a/sdk/python/tests/unit/test_sse_client.py
+++ b/sdk/python/tests/unit/test_sse_client.py
@@ -93,8 +93,36 @@ class MockSSEHandler(BaseHTTPRequestHandler):
         except (BrokenPipeError, ConnectionResetError):
             pass  # Client disconnected
 
+    def do_POST(self):
+        # Mint endpoint used by the auth-headers path: POST {server}/token
+        # with {"keyId", "keySecret"} -> {"token": <jwt>} (orkes contract).
+        if self.path.endswith("/token"):
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length)) if length else {}
+            self.server.mint_requests = getattr(self.server, "mint_requests", [])  # type: ignore[attr-defined]
+            self.server.mint_requests.append(body)  # type: ignore[attr-defined]
+            data = json.dumps({"token": MOCK_MINTED_JWT}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+        self.send_error(404)
+
     def log_message(self, format, *args):
         pass  # Suppress request logs during tests
+
+
+def _mock_jwt() -> str:
+    import base64
+
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(b'{"exp":4102444800}').rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+MOCK_MINTED_JWT = _mock_jwt()
 
 
 class MockSSEServer:
@@ -368,7 +396,11 @@ class TestStreamSSEErrors:
 
 
 class TestStreamSSEAuth:
-    def test_auth_headers_sent(self):
+    def test_auth_key_secret_mints_x_authorization(self):
+        """auth_key/auth_secret are exchanged for a JWT via POST /token (the
+        secured-host contract, e.g. orkes) and sent as X-Authorization."""
+        from agentspan.agents._internal.token_utils import _TOKEN_CACHE
+
         scenario = {
             "events": [
                 {"event": "done", "id": "1", "data": _java_event("done", output="ok")},
@@ -378,15 +410,22 @@ class TestStreamSSEAuth:
         server = MockSSEServer(scenario)
         url = server.start()
         try:
+            _TOKEN_CACHE.clear()
             rt = _make_runtime(url, auth_key="my-key", auth_secret="my-secret")
             events = list(rt._stream_sse("test-wf"))
             assert len(events) == 1
 
+            # The mint endpoint received the key/secret...
+            mints = getattr(server.server, "mint_requests", [])
+            assert mints and mints[0] == {"keyId": "my-key", "keySecret": "my-secret"}
+            # ...and the stream request carried the minted JWT.
             headers = server.received_headers
-            assert headers.get("X-Auth-Key") == "my-key"
-            assert headers.get("X-Auth-Secret") == "my-secret"
+            assert headers.get("X-Authorization") == MOCK_MINTED_JWT
+            assert "X-Auth-Key" not in headers
+            assert "X-Auth-Secret" not in headers
         finally:
             server.stop()
+            _TOKEN_CACHE.clear()
 
     def test_no_auth_headers_when_not_configured(self):
         scenario = {
@@ -402,6 +441,7 @@ class TestStreamSSEAuth:
             list(rt._stream_sse("test-wf"))
 
             headers = server.received_headers
+            assert "X-Authorization" not in headers
             assert "X-Auth-Key" not in headers
             assert "X-Auth-Secret" not in headers
         finally:

--- a/sdk/python/tests/unit/test_token_utils.py
+++ b/sdk/python/tests/unit/test_token_utils.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2025 Agentspan
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Unit tests for the shared agent-API auth token helpers.
+
+Uses a real in-process HTTP server (no mocks, per repo test policy) to emulate the
+host's POST /token mint endpoint.
+"""
+
+import base64
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from agentspan.agents._internal.token_utils import (
+    _TOKEN_CACHE,
+    agent_api_auth_headers,
+    decode_jwt_exp,
+    resolve_agent_api_token,
+)
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+class _TokenHandler(BaseHTTPRequestHandler):
+    mint_count = 0
+    token = _jwt(4102444800)  # far future
+
+    def do_POST(self):  # noqa: N802
+        if self.path != "/token":
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        if body.get("keyId") != "kid" or body.get("keySecret") != "ksec":
+            self.send_response(401)
+            self.end_headers()
+            return
+        type(self).mint_count += 1
+        data = json.dumps({"token": self.token}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *args):  # silence
+        pass
+
+
+@pytest.fixture()
+def token_server():
+    _TokenHandler.mint_count = 0
+    srv = HTTPServer(("127.0.0.1", 0), _TokenHandler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    url = f"http://127.0.0.1:{srv.server_address[1]}"
+    yield url
+    srv.shutdown()
+    _TOKEN_CACHE.clear()
+
+
+def test_decode_jwt_exp():
+    assert decode_jwt_exp(_jwt(1700000000)) == 1700000000.0
+    assert decode_jwt_exp("opaque-token") == 0.0
+    assert decode_jwt_exp("") == 0.0
+
+
+def test_api_key_passthrough():
+    # An explicit api_key is already a token — no mint, returned as-is.
+    assert resolve_agent_api_token("http://unused", api_key="tok-123") == "tok-123"
+    assert agent_api_auth_headers("http://unused", api_key="tok-123") == {
+        "X-Authorization": "tok-123"
+    }
+
+
+def test_anonymous_returns_none():
+    assert resolve_agent_api_token("http://unused") is None
+    assert agent_api_auth_headers("http://unused") == {}
+
+
+def test_mint_and_cache(token_server):
+    tok = resolve_agent_api_token(token_server, auth_key="kid", auth_secret="ksec")
+    assert tok == _TokenHandler.token
+    # Second call must hit the cache (no second mint).
+    tok2 = resolve_agent_api_token(token_server, auth_key="kid", auth_secret="ksec")
+    assert tok2 == tok
+    assert _TokenHandler.mint_count == 1
+    assert agent_api_auth_headers(token_server, auth_key="kid", auth_secret="ksec") == {
+        "X-Authorization": tok
+    }
+
+
+def test_expired_cache_reminted(token_server):
+    _TOKEN_CACHE[(token_server, "kid")] = (_jwt(100), 100.0)  # long expired
+    tok = resolve_agent_api_token(token_server, auth_key="kid", auth_secret="ksec")
+    assert tok == _TokenHandler.token
+    assert _TokenHandler.mint_count == 1  # re-minted exactly once
+
+
+def test_bad_credentials_none(token_server):
+    assert resolve_agent_api_token(token_server, auth_key="kid", auth_secret="WRONG") is None

--- a/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/CredentialEnvSeeder.java
+++ b/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/CredentialEnvSeeder.java
@@ -46,65 +46,11 @@ public class CredentialEnvSeeder implements ApplicationRunner {
 
     /**
      * Well-known provider environment variables to scan on startup.
-     * Sourced from the AI provider config in application.properties plus the
-     * additional providers listed in the UI quick-select.
      *
-     * <p>AGENTSPAN_MASTER_KEY is intentionally excluded — it is the encryption
-     * master key and must never be stored as a credential.</p>
+     * <p>Now sourced from the shared {@link KnownProviderEnvVars#NAMES} in the library so the
+     * standalone server and embedding hosts (e.g. orkes-conductor) seed an identical set.</p>
      */
-    static final List<String> KNOWN_ENV_VARS = List.of(
-            // Anthropic (Claude)
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_BASE_URL",
-            // OpenAI (GPT-4, DALL-E, etc.)
-            "OPENAI_API_KEY",
-            "OPENAI_ORG_ID",
-            "OPENAI_BASE_URL",
-            // Google Gemini / AI Studio / Vertex AI
-            "GEMINI_API_KEY",
-            "GOOGLE_API_KEY",
-            "GOOGLE_CLOUD_PROJECT",
-            "GOOGLE_CLOUD_LOCATION",
-            // Azure OpenAI
-            "AZURE_OPENAI_API_KEY",
-            "AZURE_OPENAI_ENDPOINT",
-            "AZURE_OPENAI_BASE_URL",
-            "AZURE_OPENAI_DEPLOYMENT",
-            // Mistral AI
-            "MISTRAL_API_KEY",
-            "MISTRAL_BASE_URL",
-            // Cohere
-            "COHERE_API_KEY",
-            "COHERE_BASE_URL",
-            // xAI / Grok
-            "XAI_API_KEY",
-            "GROK_BASE_URL",
-            // Groq
-            "GROQ_API_KEY",
-            // Perplexity
-            "PERPLEXITY_API_KEY",
-            "PERPLEXITY_BASE_URL",
-            // HuggingFace
-            "HUGGINGFACE_API_KEY",
-            "HUGGINGFACE_API_TOKEN",
-            // Stability AI
-            "STABILITY_API_KEY",
-            // DeepSeek
-            "DEEPSEEK_API_KEY",
-            // Together AI
-            "TOGETHER_API_KEY",
-            // Replicate
-            "REPLICATE_API_TOKEN",
-            // GitHub CLI / API
-            "GH_TOKEN",
-            "GITHUB_TOKEN",
-            // AWS Bedrock
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_REGION",
-            "BEDROCK_API_KEY",
-            // Ollama (local inference)
-            "OLLAMA_HOST");
+    static final List<String> KNOWN_ENV_VARS = KnownProviderEnvVars.NAMES;
 
     private final CredentialStoreProvider storeProvider;
     private final Function<String, String> envLookup;

--- a/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/service/skill/FileSystemSkillMetadataDAO.java
+++ b/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/service/skill/FileSystemSkillMetadataDAO.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.service.skill;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.agentspan.runtime.model.skill.SkillDetail;
+import dev.agentspan.runtime.spi.SkillMetadataDAO;
+
+/**
+ * Default {@link SkillMetadataDAO} — stores skill metadata as {@code metadata.json} files on the
+ * local filesystem under {@code <storage>/owners/<ownerId>/<name>/<version>/}, with a per-skill
+ * {@code latest} pointer file. This is the standalone-server default; it preserves the exact
+ * on-disk layout used before the SPI extraction. Embedding hosts (e.g. orkes-conductor) supply a
+ * durable/HA implementation instead (this class ships only in {@code conductor-agentspan-server},
+ * so it is never on an embedding host's classpath).
+ */
+@Component
+public class FileSystemSkillMetadataDAO implements SkillMetadataDAO {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Path storageRoot;
+
+    public FileSystemSkillMetadataDAO(
+            @Value("${agentspan.skills.storage.directory:${java.io.tmpdir}/agentspan/skills}") String storageDir) {
+        this.storageRoot = Path.of(storageDir).toAbsolutePath().normalize();
+    }
+
+    @Override
+    public void save(SkillDetail detail, boolean makeLatest) {
+        Path metadataPath = metadataPath(detail.getOwnerId(), detail.getName(), detail.getVersion());
+        try {
+            Files.createDirectories(metadataPath.getParent());
+            writeDetail(metadataPath, detail);
+            if (makeLatest) {
+                Files.writeString(
+                        latestPath(detail.getOwnerId(), detail.getName()),
+                        detail.getVersion(),
+                        StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write skill metadata: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Optional<SkillDetail> find(String ownerId, String name, String version) {
+        Path metadataPath = metadataPath(ownerId, name, version);
+        if (!Files.exists(metadataPath)) {
+            return Optional.empty();
+        }
+        return Optional.of(readDetail(metadataPath));
+    }
+
+    @Override
+    public Optional<String> latestVersion(String ownerId, String name) {
+        Path latest = latestPath(ownerId, name);
+        if (!Files.exists(latest)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Files.readString(latest, StandardCharsets.UTF_8).trim());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read latest skill version: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<SkillDetail> listVersions(String ownerId, String name) {
+        Path skillRoot = skillRoot(ownerId, name);
+        List<SkillDetail> details = new ArrayList<>();
+        if (!Files.isDirectory(skillRoot)) {
+            return details;
+        }
+        try (var versions = Files.list(skillRoot)) {
+            for (Path versionPath : versions.filter(Files::isDirectory).toList()) {
+                Path metadata = versionPath.resolve("metadata.json");
+                if (Files.exists(metadata)) {
+                    details.add(readDetail(metadata));
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to list skill versions: " + e.getMessage(), e);
+        }
+        return details;
+    }
+
+    @Override
+    public List<SkillDetail> list(String ownerId, boolean allVersions) {
+        Path ownerRoot = ownerRoot(ownerId);
+        List<SkillDetail> details = new ArrayList<>();
+        if (!Files.isDirectory(ownerRoot)) {
+            return details;
+        }
+        try (var skillDirs = Files.list(ownerRoot)) {
+            for (Path skillDir : skillDirs.filter(Files::isDirectory).toList()) {
+                if (allVersions) {
+                    try (var versions = Files.list(skillDir)) {
+                        for (Path versionPath : versions.filter(Files::isDirectory).toList()) {
+                            Path metadata = versionPath.resolve("metadata.json");
+                            if (Files.exists(metadata)) {
+                                details.add(readDetail(metadata));
+                            }
+                        }
+                    }
+                } else {
+                    Path latest = skillDir.resolve("latest");
+                    if (Files.exists(latest)) {
+                        String version = Files.readString(latest, StandardCharsets.UTF_8).trim();
+                        Path metadata = skillDir.resolve(encoded(version)).resolve("metadata.json");
+                        if (Files.exists(metadata)) {
+                            details.add(readDetail(metadata));
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to list skills: " + e.getMessage(), e);
+        }
+        return details;
+    }
+
+    @Override
+    public void delete(String ownerId, String name, String version) {
+        Path dir = versionDir(ownerId, name, version);
+        if (!Files.exists(dir)) {
+            return;
+        }
+        try (var paths = Files.walk(dir)) {
+            for (Path p : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(p);
+            }
+            Path latest = latestPath(ownerId, name);
+            if (Files.exists(latest)
+                    && version.equals(Files.readString(latest, StandardCharsets.UTF_8).trim())) {
+                updateLatestAfterDelete(ownerId, name);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to delete skill metadata: " + e.getMessage(), e);
+        }
+    }
+
+    private void updateLatestAfterDelete(String ownerId, String name) throws IOException {
+        Path skillRoot = skillRoot(ownerId, name);
+        if (!Files.isDirectory(skillRoot)) {
+            Files.deleteIfExists(latestPath(ownerId, name));
+            return;
+        }
+        List<SkillDetail> remaining = listVersions(ownerId, name);
+        if (remaining.isEmpty()) {
+            Files.deleteIfExists(latestPath(ownerId, name));
+            try (var children = Files.list(skillRoot)) {
+                if (children.findAny().isEmpty()) {
+                    Files.deleteIfExists(skillRoot);
+                }
+            }
+            return;
+        }
+        remaining.sort(Comparator.comparing(SkillDetail::getCreatedAt, Comparator.nullsFirst(Long::compareTo))
+                .thenComparing(SkillDetail::getVersion));
+        Files.writeString(
+                latestPath(ownerId, name), remaining.get(remaining.size() - 1).getVersion(), StandardCharsets.UTF_8);
+    }
+
+    private SkillDetail readDetail(Path metadataPath) {
+        try {
+            return MAPPER.readValue(metadataPath.toFile(), SkillDetail.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read skill metadata: " + e.getMessage(), e);
+        }
+    }
+
+    private void writeDetail(Path metadataPath, SkillDetail detail) {
+        try {
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(metadataPath.toFile(), detail);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write skill metadata: " + e.getMessage(), e);
+        }
+    }
+
+    private Path ownerRoot(String ownerId) {
+        return storageRoot.resolve("owners").resolve(encoded(ownerId));
+    }
+
+    private Path skillRoot(String ownerId, String name) {
+        return ownerRoot(ownerId).resolve(encoded(name));
+    }
+
+    private Path versionDir(String ownerId, String name, String version) {
+        return skillRoot(ownerId, name).resolve(encoded(version));
+    }
+
+    private Path metadataPath(String ownerId, String name, String version) {
+        return versionDir(ownerId, name, version).resolve("metadata.json");
+    }
+
+    private Path latestPath(String ownerId, String name) {
+        return skillRoot(ownerId, name).resolve("latest");
+    }
+
+    private String encoded(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/SkillRegistryServiceTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/SkillRegistryServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import dev.agentspan.runtime.context.RequestContext;
 import dev.agentspan.runtime.context.RequestContextHolder;
 import dev.agentspan.runtime.model.skill.SkillDetail;
+import dev.agentspan.runtime.service.skill.FileSystemSkillMetadataDAO;
 import dev.agentspan.runtime.service.skill.FileSystemSkillPackageStore;
 
 class SkillRegistryServiceTest {
@@ -39,12 +40,12 @@ class SkillRegistryServiceTest {
     @Test
     void registeredSkillsAreVisibleOnlyToOwner() throws Exception {
         SkillRegistryService service = new SkillRegistryService(
-                tempDir.toString(),
                 1024 * 1024,
                 1024 * 1024,
                 10 * 1024 * 1024,
                 100,
-                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()));
+                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()),
+                new FileSystemSkillMetadataDAO(tempDir.toString()));
         String skillName = "owned-skill";
         String manifest = "{\"name\":\"" + skillName + "\"}";
 
@@ -67,12 +68,12 @@ class SkillRegistryServiceTest {
     @Test
     void deletingLatestVersionPromotesPreviousVersion() throws Exception {
         SkillRegistryService service = new SkillRegistryService(
-                tempDir.toString(),
                 1024 * 1024,
                 1024 * 1024,
                 10 * 1024 * 1024,
                 100,
-                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()));
+                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()),
+                new FileSystemSkillMetadataDAO(tempDir.toString()));
         String skillName = "versioned-skill";
         asUser("user-a");
 
@@ -90,12 +91,12 @@ class SkillRegistryServiceTest {
     @Test
     void sameSkillNameUsesPerOwnerLatestAndPackageStorage() throws Exception {
         SkillRegistryService service = new SkillRegistryService(
-                tempDir.toString(),
                 1024 * 1024,
                 1024 * 1024,
                 10 * 1024 * 1024,
                 100,
-                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()));
+                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()),
+                new FileSystemSkillMetadataDAO(tempDir.toString()));
         String skillName = "shared-name-skill";
 
         asUser("user-a");
@@ -131,12 +132,12 @@ class SkillRegistryServiceTest {
     @SuppressWarnings("unchecked")
     void skillRefRawConfigIncludesParamsAndRegisteredCrossSkills() throws Exception {
         SkillRegistryService service = new SkillRegistryService(
-                tempDir.toString(),
                 1024 * 1024,
                 1024 * 1024,
                 10 * 1024 * 1024,
                 100,
-                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()));
+                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()),
+                new FileSystemSkillMetadataDAO(tempDir.toString()));
         asUser("user-a");
 
         service.register(
@@ -175,12 +176,12 @@ class SkillRegistryServiceTest {
     @SuppressWarnings("unchecked")
     void registeredCrossSkillRefsArePinnedAtRegistrationTime() throws Exception {
         SkillRegistryService service = new SkillRegistryService(
-                tempDir.toString(),
                 1024 * 1024,
                 1024 * 1024,
                 10 * 1024 * 1024,
                 100,
-                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()));
+                new FileSystemSkillPackageStore(tempDir.resolve("packages").toString()),
+                new FileSystemSkillMetadataDAO(tempDir.toString()));
         asUser("user-a");
 
         service.register(

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/compiler/MultiAgentCompiler.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/compiler/MultiAgentCompiler.java
@@ -22,6 +22,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 
 import dev.agentspan.runtime.model.*;
 import dev.agentspan.runtime.service.PlanAndCompileTask;
+import dev.agentspan.runtime.util.EmbeddedMode;
 import dev.agentspan.runtime.util.JavaScriptBuilder;
 import dev.agentspan.runtime.util.ModelParser;
 import dev.agentspan.runtime.util.ModelParser.ParsedModel;
@@ -2663,7 +2664,8 @@ public class MultiAgentCompiler {
                             throw new IllegalArgumentException("plannerContext header '" + name
                                     + "' contains CR/LF — rejected to prevent HTTP response splitting");
                         }
-                        headers.put(name, CREDENTIAL_PLACEHOLDER.matcher(value).replaceAll("#{$1}"));
+                        String replacement = EmbeddedMode.isEmbedded() ? "\\${workflow.secrets.$1}" : "#{$1}";
+                        headers.put(name, CREDENTIAL_PLACEHOLDER.matcher(value).replaceAll(replacement));
                     }
                 }
 

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/compiler/ToolCompiler.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/compiler/ToolCompiler.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +21,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 
 import dev.agentspan.runtime.model.GuardrailConfig;
 import dev.agentspan.runtime.model.ToolConfig;
+import dev.agentspan.runtime.util.EmbeddedMode;
 import dev.agentspan.runtime.util.JavaScriptBuilder;
 import dev.agentspan.runtime.util.ModelParser;
 
@@ -54,13 +56,29 @@ public class ToolCompiler {
      * The {@code #} prefix is invisible to Conductor's expression engine and is later
      * resolved by credential-aware task handlers.
      */
+    /** Matches a {@code ${IDENTIFIER}} credential placeholder. */
+    private static final Pattern CREDENTIAL_PLACEHOLDER = Pattern.compile("\\$\\{([A-Za-z_][A-Za-z0-9_]*)\\}");
+
     private static Map<String, Object> escapeCredentialPlaceholders(Map<?, ?> headers) {
         Map<String, Object> escaped = new LinkedHashMap<>();
         for (Map.Entry<?, ?> e : headers.entrySet()) {
             String v = String.valueOf(e.getValue());
-            escaped.put(String.valueOf(e.getKey()), v.replace("${", "#{"));
+            escaped.put(String.valueOf(e.getKey()), rewriteCredentialPlaceholders(v));
         }
         return escaped;
+    }
+
+    /**
+     * Rewrite {@code ${NAME}} credential placeholders for the runtime that will resolve them.
+     * When embedded in a host (e.g. orkes-conductor), emit the host's native
+     * {@code ${workflow.secrets.NAME}} so the host resolves it at task-input binding. Standalone:
+     * escape to {@code #{NAME}} for AgentSpan's credential-aware HTTP/MCP task handlers.
+     */
+    private static String rewriteCredentialPlaceholders(String value) {
+        if (EmbeddedMode.isEmbedded()) {
+            return CREDENTIAL_PLACEHOLDER.matcher(value).replaceAll("\\${workflow.secrets.$1}");
+        }
+        return value.replace("${", "#{");
     }
 
     /**

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/config/AgentSpanAutoConfiguration.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/config/AgentSpanAutoConfiguration.java
@@ -5,7 +5,11 @@
 package dev.agentspan.runtime.config;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.FilterType;
 
 /**
@@ -19,6 +23,17 @@ import org.springframework.context.annotation.FilterType;
  * ({@code AgentRuntime}) scans only the Conductor packages and relies on this
  * auto-configuration for the AgentSpan beans.
  *
+ * <p><b>Activation contract.</b> Merely having this library on the classpath must not change a
+ * host application's behavior. The configuration activates only when:
+ * <ul>
+ *   <li><b>Standalone:</b> the standalone server distribution is the application — detected by its
+ *       entry point ({@code dev.agentspan.runtime.AgentRuntime}, shipped only in
+ *       {@code conductor-agentspan-server}) being on the classpath; or</li>
+ *   <li><b>Embedded:</b> the host explicitly opts in with {@code agentspan.embedded=true}
+ *       (e.g. orkes-conductor). Without the flag, the host runs as stock Conductor — no
+ *       AgentSpan beans, controllers, or system-task overrides are registered.</li>
+ * </ul>
+ *
  * <p>The scan spans both jars (library + server) because they share the
  * {@code dev.agentspan.runtime} namespace: the library's contracts and logic are always
  * present, while the server's default SPI implementations and web config are present only
@@ -28,6 +43,7 @@ import org.springframework.context.annotation.FilterType;
  * this class, which are processed directly rather than via the scan.
  */
 @AutoConfiguration
+@Conditional(AgentSpanAutoConfiguration.StandaloneOrExplicitlyEmbedded.class)
 @ComponentScan(
         basePackages = "dev.agentspan.runtime",
         excludeFilters = {
@@ -36,4 +52,22 @@ import org.springframework.context.annotation.FilterType;
                     type = FilterType.REGEX,
                     pattern = "dev\\.agentspan\\.runtime\\.config\\.AgentSpanAutoConfiguration")
         })
-public class AgentSpanAutoConfiguration {}
+public class AgentSpanAutoConfiguration {
+
+    /**
+     * Activate when running as the standalone AgentSpan server (its entry point class is on the
+     * classpath) OR when an embedding host explicitly sets {@code agentspan.embedded=true}.
+     */
+    static class StandaloneOrExplicitlyEmbedded extends AnyNestedCondition {
+
+        StandaloneOrExplicitlyEmbedded() {
+            super(ConfigurationPhase.PARSE_CONFIGURATION);
+        }
+
+        @ConditionalOnClass(name = "dev.agentspan.runtime.AgentRuntime")
+        static class StandaloneServer {}
+
+        @ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+        static class HostOptedIn {}
+    }
+}

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/SecretController.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/SecretController.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -44,6 +45,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/secrets")
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "false", matchIfMissing = true)
 public class SecretController {
 
     private static final Logger log = LoggerFactory.getLogger(SecretController.class);

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareHttpTaskConfig.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareHttpTaskConfig.java
@@ -4,6 +4,7 @@
  */
 package dev.agentspan.runtime.credentials;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -17,8 +18,16 @@ import com.netflix.conductor.tasks.http.providers.RestTemplateProvider;
  *
  * <p>This follows the same pattern as {@code AgentHumanTaskConfig} which
  * overrides the default HUMAN task.</p>
+ *
+ * <p><b>Embedded mode:</b> disabled when {@code agentspan.embedded=true} (e.g. when the
+ * library is imported into a host such as orkes-conductor). The host already provides its
+ * own {@code HTTP} system task — overriding it here would collide on the {@code "HTTP"} bean
+ * name and downgrade the host's task. The host is expected to port {@code #{NAME}} secret
+ * resolution into its own HTTP task, guarded by the {@code __agentspan_ctx__} input. The
+ * standalone OSS server leaves this property unset, so the override stays active as before.</p>
  */
 @Configuration
+@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "false", matchIfMissing = true)
 public class CredentialAwareHttpTaskConfig {
 
     @Bean("HTTP")

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareMcpService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareMcpService.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import org.conductoross.conductor.ai.mcp.MCPService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -42,6 +43,7 @@ import okhttp3.OkHttpClient;
  */
 @Component
 @Primary
+@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "false", matchIfMissing = true)
 public class CredentialAwareMcpService extends MCPService {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialAwareMcpService.class);

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareMcpService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareMcpService.java
@@ -13,7 +13,6 @@ import java.util.regex.Pattern;
 import org.conductoross.conductor.ai.mcp.MCPService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +42,6 @@ import okhttp3.OkHttpClient;
  */
 @Component
 @Primary
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "false", matchIfMissing = true)
 public class CredentialAwareMcpService extends MCPService {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialAwareMcpService.class);

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/KnownProviderEnvVars.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/KnownProviderEnvVars.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License.
+ */
+package dev.agentspan.runtime.credentials;
+
+import java.util.List;
+
+/**
+ * Single source of truth for the well-known LLM/tool provider environment variables that AgentSpan
+ * auto-seeds into the credential store on startup.
+ *
+ * <p>Shared so every deployment seeds the same set: the standalone server's {@code CredentialEnvSeeder}
+ * and any embedding host (e.g. orkes-conductor) reference this list instead of maintaining their own
+ * copies. Keeping one list avoids drift between standalone and embedded behavior.</p>
+ *
+ * <p>{@code AGENTSPAN_MASTER_KEY} is intentionally excluded — it is the encryption master key and must
+ * never be stored as a credential.</p>
+ */
+public final class KnownProviderEnvVars {
+
+    private KnownProviderEnvVars() {}
+
+    /** Well-known provider environment variables to scan on startup. */
+    public static final List<String> NAMES = List.of(
+            // Anthropic (Claude)
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            // OpenAI (GPT-4, DALL-E, etc.)
+            "OPENAI_API_KEY",
+            "OPENAI_ORG_ID",
+            "OPENAI_BASE_URL",
+            // Google Gemini / AI Studio / Vertex AI
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_CLOUD_LOCATION",
+            // Azure OpenAI
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_OPENAI_BASE_URL",
+            "AZURE_OPENAI_DEPLOYMENT",
+            // Mistral AI
+            "MISTRAL_API_KEY",
+            "MISTRAL_BASE_URL",
+            // Cohere
+            "COHERE_API_KEY",
+            "COHERE_BASE_URL",
+            // xAI / Grok
+            "XAI_API_KEY",
+            "GROK_BASE_URL",
+            // Groq
+            "GROQ_API_KEY",
+            // Perplexity
+            "PERPLEXITY_API_KEY",
+            "PERPLEXITY_BASE_URL",
+            // HuggingFace
+            "HUGGINGFACE_API_KEY",
+            "HUGGINGFACE_API_TOKEN",
+            // Stability AI
+            "STABILITY_API_KEY",
+            // DeepSeek
+            "DEEPSEEK_API_KEY",
+            // Together AI
+            "TOGETHER_API_KEY",
+            // Replicate
+            "REPLICATE_API_TOKEN",
+            // GitHub CLI / API
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            // AWS Bedrock
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_REGION",
+            "BEDROCK_API_KEY",
+            // Ollama (local inference)
+            "OLLAMA_HOST");
+}

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentHumanTaskConfig.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentHumanTaskConfig.java
@@ -7,6 +7,7 @@ package dev.agentspan.runtime.service;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUMAN;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -14,8 +15,17 @@ import org.springframework.context.annotation.Primary;
 /**
  * Registers {@link AgentHumanTask} as the primary HUMAN task implementation,
  * overriding Conductor's default {@code Human} system task.
+ *
+ * <p><b>Embedded mode:</b> disabled when {@code agentspan.embedded=true} (e.g. when the
+ * library is imported into a host such as orkes-conductor). The host provides its own
+ * (richer) HUMAN task — overriding it here would collide on the {@code HUMAN} bean name and
+ * replace the host's full HITL implementation with this SSE-only shim. The host is expected
+ * to emit the {@code WAITING} SSE event from its own HUMAN task, guarded by the
+ * {@code __agentspan_ctx__} input. The standalone OSS server leaves this property unset, so
+ * the override stays active as before.</p>
  */
 @Configuration
+@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "false", matchIfMissing = true)
 public class AgentHumanTaskConfig {
 
     @Bean(TASK_TYPE_HUMAN)

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -39,6 +39,7 @@ import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.service.ExecutionService;
+import com.netflix.conductor.service.MetadataService;
 import com.netflix.conductor.service.WorkflowService;
 
 import dev.agentspan.runtime.compiler.AgentCompiler;
@@ -84,6 +85,16 @@ public class AgentService {
      */
     @Autowired(required = false)
     private IDGenerator idGenerator;
+
+    /**
+     * Stable metadata service for task-def registration. The low-level {@code MetadataDAO}'s
+     * {@code createTaskDef}/{@code updateTaskDef} return types differ across Conductor cores
+     * (orkes' vendored oss-core returns {@code void}; 3.30.2 returns {@code TaskDef}), so calling
+     * the DAO directly throws {@code NoSuchMethodError} when embedded. {@code MetadataService}'s
+     * methods return {@code void} in all cores. Optional so the test constructor still works.
+     */
+    @Autowired(required = false)
+    private MetadataService metadataService;
 
     /** Package-private constructor for testing with ExecutionTokenService */
     AgentService(
@@ -278,6 +289,18 @@ public class AgentService {
         startReq.setVersion(def.getVersion());
         startReq.setWorkflowDef(def);
 
+        // Attribute the execution to the calling principal (the host populates the
+        // RequestContext: orkes' principal filter when embedded, the standalone AuthFilter
+        // otherwise). Security-enabled hosts key on this standard Conductor field: orkes
+        // records workflow.createdBy from it, stamps _createdBy into every scheduled task,
+        // impersonates it during decide so sub-workflows inherit attribution, and its
+        // workers' poll-time secret substitution REQUIRES it (tasks of workflows without
+        // createdBy fail to poll). Stock Conductor simply records the value.
+        String principal = RequestContextHolder.get().map(ctx -> ctx.getUserId()).orElse(null);
+        if (principal != null) {
+            startReq.setCreatedBy(principal);
+        }
+
         Map<String, Object> input = new LinkedHashMap<>();
         input.put("prompt", request.getPrompt());
         input.put("media", request.getMedia() != null ? request.getMedia() : List.of());
@@ -324,8 +347,7 @@ public class AgentService {
                         }
                     }
                 }
-                String currentUserId =
-                        RequestContextHolder.get().map(ctx -> ctx.getUserId()).orElse(null);
+                String currentUserId = principal;
                 if (currentUserId != null) {
                     String token = executionTokenService.mint(
                             currentUserId, preallocatedExecutionId, declaredNames, timeoutSeconds);
@@ -1355,7 +1377,11 @@ public class AgentService {
         try {
             TaskDef existing = metadataDAO.getTaskDef(taskName);
             if (existing != null) {
-                metadataDAO.updateTaskDef(taskDef);
+                if (metadataService != null) {
+                    metadataService.updateTaskDef(taskDef);
+                } else {
+                    metadataDAO.updateTaskDef(taskDef);
+                }
                 log.debug("Updated task definition: {}", taskName);
                 return;
             }
@@ -1363,7 +1389,13 @@ public class AgentService {
             // Task doesn't exist, create it
         }
 
-        metadataDAO.createTaskDef(taskDef);
+        // Prefer the stable MetadataService (registerTaskDef upserts, returns void in all cores);
+        // fall back to the DAO only outside Spring (tests).
+        if (metadataService != null) {
+            metadataService.registerTaskDef(List.of(taskDef));
+        } else {
+            metadataDAO.createTaskDef(taskDef);
+        }
         log.info("Registered task definition: {}", taskName);
     }
 

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -399,7 +399,14 @@ public class AgentService {
      */
     @SuppressWarnings("unchecked")
     public List<AgentSummary> listAgents() {
-        List<WorkflowDef> allDefs = metadataDAO.getAllWorkflowDefsLatestVersions();
+        // Use the portable getAllWorkflowDefs() (present across Conductor cores, incl. orkes'
+        // vendored oss-core which lacks getAllWorkflowDefsLatestVersions()) and reduce to the
+        // latest version per name ourselves.
+        Map<String, WorkflowDef> latestByName = new HashMap<>();
+        for (WorkflowDef d : metadataDAO.getAllWorkflowDefs()) {
+            latestByName.merge(d.getName(), d, (a, b) -> a.getVersion() >= b.getVersion() ? a : b);
+        }
+        List<WorkflowDef> allDefs = new ArrayList<>(latestByName.values());
         List<AgentSummary> agents = new ArrayList<>();
 
         for (WorkflowDef def : allDefs) {

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -34,6 +34,7 @@ import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.core.execution.StartWorkflowInput;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.WorkflowModel;
@@ -73,6 +74,16 @@ public class AgentService {
 
     @Autowired(required = false)
     private SkillRegistryService skillRegistryService;
+
+    /**
+     * Conductor's configured ID generator. When embedded in a host that uses time-based IDs
+     * (e.g. orkes-conductor with {@code conductor.id.generator=time_based}), pre-allocated
+     * execution IDs must be v1 time-based UUIDs — the host derives a workflow's createTime from
+     * its ID and yields 0 for non-v1 (random) UUIDs. Falls back to a random UUID when unset
+     * (standalone tests / no Spring context).
+     */
+    @Autowired(required = false)
+    private IDGenerator idGenerator;
 
     /** Package-private constructor for testing with ExecutionTokenService */
     AgentService(
@@ -293,7 +304,10 @@ public class AgentService {
         // with NPE when it tries Map.of(..., null, ...) on the not-null
         // execution_id column. Passing this id to setWorkflowId on the start
         // input below makes Conductor adopt it instead of generating one.
-        String preallocatedExecutionId = UUID.randomUUID().toString();
+        // Use the host's configured ID generator (time-based when embedded in orkes) so the
+        // host can derive createTime from the ID; fall back to a random UUID outside Spring.
+        String preallocatedExecutionId =
+                idGenerator != null ? idGenerator.generate() : UUID.randomUUID().toString();
 
         // Mint execution token and embed in workflow variables for worker credential resolution
         if (executionTokenService != null) {

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/SkillRegistryService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/SkillRegistryService.java
@@ -9,13 +9,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -25,6 +22,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -48,6 +46,7 @@ import dev.agentspan.runtime.model.skill.SkillDetail;
 import dev.agentspan.runtime.model.skill.SkillFileContent;
 import dev.agentspan.runtime.model.skill.SkillFileEntry;
 import dev.agentspan.runtime.model.skill.SkillSummary;
+import dev.agentspan.runtime.spi.SkillMetadataDAO;
 import dev.agentspan.runtime.spi.SkillPackageStore;
 import dev.agentspan.runtime.spi.StoredSkillPackage;
 
@@ -88,27 +87,27 @@ public class SkillRegistryService {
             ".properties",
             ".csv");
 
-    private final Path storageRoot;
     private final long maxPackageBytes;
     private final long maxPreviewBytes;
     private final long maxUncompressedBytes;
     private final int maxFileCount;
     private final SkillPackageStore packageStore;
+    private final SkillMetadataDAO metadataDao;
 
     @Autowired
     public SkillRegistryService(
-            @Value("${agentspan.skills.storage.directory:${java.io.tmpdir}/agentspan/skills}") String storageDir,
             @Value("${agentspan.skills.max-package-bytes:52428800}") long maxPackageBytes,
             @Value("${agentspan.skills.max-preview-bytes:1048576}") long maxPreviewBytes,
             @Value("${agentspan.skills.max-uncompressed-bytes:209715200}") long maxUncompressedBytes,
             @Value("${agentspan.skills.max-file-count:2000}") int maxFileCount,
-            SkillPackageStore packageStore) {
-        this.storageRoot = Path.of(storageDir).toAbsolutePath().normalize();
+            SkillPackageStore packageStore,
+            SkillMetadataDAO metadataDao) {
         this.maxPackageBytes = maxPackageBytes;
         this.maxPreviewBytes = maxPreviewBytes;
         this.maxUncompressedBytes = maxUncompressedBytes;
         this.maxFileCount = maxFileCount;
         this.packageStore = packageStore;
+        this.metadataDao = metadataDao;
     }
 
     public synchronized SkillDetail register(String manifestJson, MultipartFile packageFile) {
@@ -139,11 +138,10 @@ public class SkillRegistryService {
 
         long now = Instant.now().toEpochMilli();
         String storageName = packageStoreName(ownerId, name);
-        Path versionDir = versionDir(ownerId, name, version);
-        Path metadataPath = metadataPath(ownerId, name, version);
 
-        if (Files.exists(metadataPath)) {
-            SkillDetail existing = readDetail(metadataPath);
+        Optional<SkillDetail> existingOpt = metadataDao.find(ownerId, name, version);
+        if (existingOpt.isPresent()) {
+            SkillDetail existing = existingOpt.get();
             enforceReadable(existing);
             if (!checksum.equals(existing.getChecksum())) {
                 throw new IllegalArgumentException(
@@ -155,14 +153,13 @@ public class SkillRegistryService {
                 existing.setStorageType(restored.storageType());
                 existing.setPackageSize(restored.size());
                 existing.setUpdatedAt(now);
-                writeDetail(metadataPath, existing);
+                metadataDao.save(existing, false);
             }
             return existing;
         }
 
         StoredSkillPackage stored = null;
         try {
-            Files.createDirectories(versionDir);
             stored = packageStore.store(storageName, version, checksum, bytes);
 
             SkillDetail detail = SkillDetail.builder()
@@ -182,14 +179,8 @@ public class SkillRegistryService {
                     .metadata(parsed.metadata())
                     .rawConfig(rawConfig)
                     .build();
-            writeDetail(metadataPath, detail);
-            Files.writeString(latestPath(ownerId, name), version, StandardCharsets.UTF_8);
+            metadataDao.save(detail, true);
             return detail;
-        } catch (IOException e) {
-            if (stored != null) {
-                packageStore.delete(stored.handle());
-            }
-            throw new IllegalStateException("Failed to store skill package: " + e.getMessage(), e);
         } catch (RuntimeException e) {
             if (stored != null) {
                 packageStore.delete(stored.handle());
@@ -199,31 +190,11 @@ public class SkillRegistryService {
     }
 
     public List<SkillSummary> list(boolean allVersions) {
-        Path ownerRoot = ownerRoot(currentUserId());
-        if (!Files.isDirectory(ownerRoot)) {
-            return List.of();
-        }
         List<SkillSummary> summaries = new ArrayList<>();
-        try (var skillDirs = Files.list(ownerRoot)) {
-            for (Path skillDir : skillDirs.filter(Files::isDirectory).toList()) {
-                if (allVersions) {
-                    try (var versions = Files.list(skillDir)) {
-                        for (Path versionPath :
-                                versions.filter(Files::isDirectory).toList()) {
-                            addSummary(summaries, versionPath.resolve("metadata.json"));
-                        }
-                    }
-                } else {
-                    Path latest = skillDir.resolve("latest");
-                    if (Files.exists(latest)) {
-                        String version =
-                                Files.readString(latest, StandardCharsets.UTF_8).trim();
-                        addSummary(summaries, skillDir.resolve(encoded(version)).resolve("metadata.json"));
-                    }
-                }
+        for (SkillDetail detail : metadataDao.list(currentUserId(), allVersions)) {
+            if (isReadable(detail)) {
+                addSummary(summaries, detail);
             }
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to list skills: " + e.getMessage(), e);
         }
         summaries.sort(Comparator.comparing(SkillSummary::getName).thenComparing(SkillSummary::getVersion));
         return summaries;
@@ -232,11 +203,9 @@ public class SkillRegistryService {
     public SkillDetail get(String name, String version) {
         String ownerId = currentUserId();
         String resolvedVersion = resolveVersion(ownerId, name, version);
-        Path metadataPath = metadataPath(ownerId, name, resolvedVersion);
-        if (!Files.exists(metadataPath)) {
-            throw new IllegalArgumentException("Skill not found: " + name + "@" + resolvedVersion);
-        }
-        SkillDetail detail = readDetail(metadataPath);
+        SkillDetail detail = metadataDao
+                .find(ownerId, name, resolvedVersion)
+                .orElseThrow(() -> new IllegalArgumentException("Skill not found: " + name + "@" + resolvedVersion));
         enforceReadable(detail);
         return detail;
     }
@@ -330,42 +299,14 @@ public class SkillRegistryService {
     public synchronized void delete(String name, String version) {
         String ownerId = currentUserId();
         String resolvedVersion = resolveVersion(ownerId, name, version);
-        Path dir = versionDir(ownerId, name, resolvedVersion);
-        if (!Files.exists(dir)) {
-            return;
-        }
-        Path metadataPath = metadataPath(ownerId, name, resolvedVersion);
-        SkillDetail detail = null;
-        if (Files.exists(metadataPath)) {
-            detail = readDetail(metadataPath);
+        metadataDao.find(ownerId, name, resolvedVersion).ifPresent(detail -> {
             enforceReadable(detail);
-        }
-        try (var paths = Files.walk(dir)) {
-            for (Path p : paths.sorted(Comparator.reverseOrder()).toList()) {
-                Files.deleteIfExists(p);
-            }
-            if (detail != null) {
-                deletePackage(detail);
-            }
-            Path latest = latestPath(ownerId, name);
-            if (Files.exists(latest)
-                    && resolvedVersion.equals(
-                            Files.readString(latest, StandardCharsets.UTF_8).trim())) {
-                updateLatestAfterDelete(ownerId, name);
-            }
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to delete skill: " + e.getMessage(), e);
-        }
+            deletePackage(detail);
+        });
+        metadataDao.delete(ownerId, name, resolvedVersion);
     }
 
-    private void addSummary(List<SkillSummary> summaries, Path metadataPath) {
-        if (!Files.exists(metadataPath)) {
-            return;
-        }
-        SkillDetail detail = readDetail(metadataPath);
-        if (!isReadable(detail)) {
-            return;
-        }
+    private void addSummary(List<SkillSummary> summaries, SkillDetail detail) {
         Map<String, Object> raw = detail.getRawConfig() != null ? detail.getRawConfig() : Map.of();
         summaries.add(SkillSummary.builder()
                 .name(detail.getName())
@@ -389,34 +330,20 @@ public class SkillRegistryService {
             version = null;
         }
         if (version != null && !version.isBlank()) {
-            Path direct = metadataPath(ownerId, name, version);
-            if (Files.exists(direct)) {
+            if (metadataDao.find(ownerId, name, version).isPresent()) {
                 return version;
             }
-            Path skillRoot = skillRoot(ownerId, name);
-            if (Files.isDirectory(skillRoot)) {
-                try (var versions = Files.list(skillRoot)) {
-                    for (Path candidate : versions.filter(Files::isDirectory).toList()) {
-                        SkillDetail detail = readDetail(candidate.resolve("metadata.json"));
-                        if (detail.getChecksum() != null && detail.getChecksum().startsWith(version)) {
-                            return detail.getVersion();
-                        }
-                    }
-                } catch (IOException e) {
-                    throw new IllegalStateException("Failed to resolve skill version: " + e.getMessage(), e);
+            // Allow a checksum prefix in place of an exact version.
+            for (SkillDetail detail : metadataDao.listVersions(ownerId, name)) {
+                if (detail.getChecksum() != null && detail.getChecksum().startsWith(version)) {
+                    return detail.getVersion();
                 }
             }
             return version;
         }
-        Path latest = latestPath(ownerId, name);
-        if (!Files.exists(latest)) {
-            throw new IllegalArgumentException("Skill not found: " + name);
-        }
-        try {
-            return Files.readString(latest, StandardCharsets.UTF_8).trim();
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to read latest skill version: " + e.getMessage(), e);
-        }
+        return metadataDao
+                .latestVersion(ownerId, name)
+                .orElseThrow(() -> new IllegalArgumentException("Skill not found: " + name));
     }
 
     private Map<String, Object> parseManifest(String manifestJson) {
@@ -750,7 +677,9 @@ public class SkillRegistryService {
             SkillDetail refDetail;
             try {
                 String refVersion = resolveVersion(ownerId, refName, null);
-                refDetail = readDetail(metadataPath(ownerId, refName, refVersion));
+                refDetail = metadataDao
+                        .find(ownerId, refName, refVersion)
+                        .orElseThrow(() -> new IllegalArgumentException("Skill not found: " + refName));
             } catch (IllegalArgumentException e) {
                 continue;
             }
@@ -871,54 +800,28 @@ public class SkillRegistryService {
         return matcher.group(2).trim();
     }
 
-    private SkillDetail readDetail(Path metadataPath) {
-        try {
-            return MAPPER.readValue(metadataPath.toFile(), SkillDetail.class);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to read skill metadata: " + e.getMessage(), e);
-        }
-    }
-
-    private void writeDetail(Path metadataPath, SkillDetail detail) {
-        try {
-            MAPPER.writerWithDefaultPrettyPrinter().writeValue(metadataPath.toFile(), detail);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to write skill metadata: " + e.getMessage(), e);
-        }
-    }
-
     private boolean packageExists(SkillDetail detail) {
         String handle = detail.getPackageFileHandleId();
-        if (handle != null && !handle.isBlank()) {
-            try {
-                if (packageStore.exists(handle)) {
-                    return true;
-                }
-            } catch (RuntimeException ignored) {
-                // Fall through to legacy package path lookup.
-            }
+        if (handle == null || handle.isBlank()) {
+            return false;
         }
-        return Files.exists(legacyPackagePath(detail.getOwnerId(), detail.getName(), detail.getVersion()));
+        try {
+            return packageStore.exists(handle);
+        } catch (RuntimeException ignored) {
+            return false;
+        }
     }
 
     private byte[] packageBytes(SkillDetail detail) {
         String handle = detail.getPackageFileHandleId();
-        if (handle != null && !handle.isBlank()) {
-            try {
-                return packageStore.read(handle);
-            } catch (RuntimeException ignored) {
-                // Fall through to legacy package path lookup.
-            }
-        }
-        try {
-            return Files.readAllBytes(legacyPackagePath(detail.getOwnerId(), detail.getName(), detail.getVersion()));
-        } catch (IOException e) {
+        if (handle == null || handle.isBlank()) {
             throw new IllegalArgumentException(
                     "Skill package not found: " + detail.getName() + "@" + detail.getVersion());
         }
+        return packageStore.read(handle);
     }
 
-    private void deletePackage(SkillDetail detail) throws IOException {
+    private void deletePackage(SkillDetail detail) {
         String handle = detail.getPackageFileHandleId();
         if (handle != null && !handle.isBlank()) {
             try {
@@ -927,40 +830,6 @@ public class SkillRegistryService {
                 // Legacy records used synthetic handles before the package store existed.
             }
         }
-        Files.deleteIfExists(legacyPackagePath(detail.getOwnerId(), detail.getName(), detail.getVersion()));
-    }
-
-    private void updateLatestAfterDelete(String ownerId, String name) throws IOException {
-        Path skillRoot = skillRoot(ownerId, name);
-        if (!Files.isDirectory(skillRoot)) {
-            Files.deleteIfExists(latestPath(ownerId, name));
-            return;
-        }
-        List<SkillDetail> remaining = new ArrayList<>();
-        try (var versions = Files.list(skillRoot)) {
-            for (Path versionPath : versions.filter(Files::isDirectory).toList()) {
-                Path metadata = versionPath.resolve("metadata.json");
-                if (Files.exists(metadata)) {
-                    SkillDetail detail = readDetail(metadata);
-                    if (isReadable(detail)) {
-                        remaining.add(detail);
-                    }
-                }
-            }
-        }
-        if (remaining.isEmpty()) {
-            Files.deleteIfExists(latestPath(ownerId, name));
-            try (var children = Files.list(skillRoot)) {
-                if (children.findAny().isEmpty()) {
-                    Files.deleteIfExists(skillRoot);
-                }
-            }
-            return;
-        }
-        remaining.sort(Comparator.comparing(SkillDetail::getCreatedAt, Comparator.nullsFirst(Long::compareTo))
-                .thenComparing(SkillDetail::getVersion));
-        Files.writeString(
-                latestPath(ownerId, name), remaining.get(remaining.size() - 1).getVersion(), StandardCharsets.UTF_8);
     }
 
     private String currentUserId() {
@@ -994,36 +863,8 @@ public class SkillRegistryService {
         return normalized;
     }
 
-    private Path ownerRoot(String ownerId) {
-        return storageRoot.resolve("owners").resolve(encoded(ownerId));
-    }
-
-    private Path skillRoot(String ownerId, String name) {
-        return ownerRoot(ownerId).resolve(encoded(name));
-    }
-
-    private Path versionDir(String ownerId, String name, String version) {
-        return skillRoot(ownerId, name).resolve(encoded(version));
-    }
-
-    private Path metadataPath(String ownerId, String name, String version) {
-        return versionDir(ownerId, name, version).resolve("metadata.json");
-    }
-
-    private Path legacyPackagePath(String ownerId, String name, String version) {
-        return versionDir(ownerId, name, version).resolve("skill.zip");
-    }
-
-    private Path latestPath(String ownerId, String name) {
-        return skillRoot(ownerId, name).resolve("latest");
-    }
-
     private String packageStoreName(String ownerId, String name) {
         return ownerId + ":" + name;
-    }
-
-    private String encoded(String value) {
-        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 
     private void validateSkillName(String name) {

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/spi/SkillMetadataDAO.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/spi/SkillMetadataDAO.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.spi;
+
+import java.util.List;
+import java.util.Optional;
+
+import dev.agentspan.runtime.model.skill.SkillDetail;
+
+/**
+ * Persistence SPI for skill <b>metadata</b> (manifest, versions, and the per-skill "latest"
+ * pointer). Skill package <b>bytes</b> are stored separately via {@link SkillPackageStore}.
+ *
+ * <p>The standalone server ships a filesystem-backed implementation (zero-config, single node);
+ * an embedding host (e.g. orkes-conductor) supplies a durable/HA implementation (e.g. Postgres)
+ * so skill listings are consistent across nodes.</p>
+ *
+ * <p>All operations are scoped by {@code ownerId}. Authorization (whether the caller may read a
+ * given skill) is the caller's concern, not this DAO's.</p>
+ */
+public interface SkillMetadataDAO {
+
+    /**
+     * Persist a skill version's metadata (create or overwrite).
+     *
+     * @param detail     metadata to store, keyed by {@code ownerId + name + version}
+     * @param makeLatest when {@code true}, mark this version as the skill's latest
+     */
+    void save(SkillDetail detail, boolean makeLatest);
+
+    /** Exact-version lookup. */
+    Optional<SkillDetail> find(String ownerId, String name, String version);
+
+    /** The recorded latest version string for a skill, if any. */
+    Optional<String> latestVersion(String ownerId, String name);
+
+    /** All recorded versions of a single skill (unordered). */
+    List<SkillDetail> listVersions(String ownerId, String name);
+
+    /**
+     * All skills for an owner. When {@code allVersions} is {@code false}, returns only each
+     * skill's latest version; when {@code true}, returns every version of every skill.
+     */
+    List<SkillDetail> list(String ownerId, boolean allVersions);
+
+    /** Remove a single version and recompute the skill's latest pointer if needed. */
+    void delete(String ownerId, String name, String version);
+}

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/tasks/Join.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/tasks/Join.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.annotations.VisibleForTesting;
@@ -24,6 +25,7 @@ import com.netflix.conductor.model.WorkflowModel;
 import lombok.extern.slf4j.Slf4j;
 
 @Component(TASK_TYPE_JOIN)
+@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "false", matchIfMissing = true)
 @Slf4j
 public class Join extends WorkflowSystemTask {
 

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/util/EmbeddedMode.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/util/EmbeddedMode.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Captures whether AgentSpan is running embedded in a host (e.g. orkes-conductor) into a static
+ * flag, so compile-time code reached through plain (non-Spring) helpers — e.g. {@code ToolCompiler}
+ * — can branch on it. Populated once at startup from the {@code agentspan.embedded} property
+ * (default {@code false} for the standalone server). Compilation is request-driven, so the value is
+ * always set before any compile runs.
+ */
+@Component
+public class EmbeddedMode {
+
+    private static volatile boolean embedded = false;
+
+    @Value("${agentspan.embedded:false}")
+    public void setEmbedded(boolean value) {
+        embedded = value;
+    }
+
+    public static boolean isEmbedded() {
+        return embedded;
+    }
+}

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/util/ProviderValidator.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/util/ProviderValidator.java
@@ -7,6 +7,7 @@ package dev.agentspan.runtime.util;
 
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import dev.agentspan.runtime.ai.AgentspanAIModelProvider;
@@ -22,11 +23,23 @@ public class ProviderValidator {
     private static final String DOCS_URL = "https://github.com/agentspan-ai/agentspan/blob/main/docs/ai-models.md";
 
     /**
+     * When embedded in a host (e.g. orkes-conductor), Conductor is the authority for model
+     * providers and credentials: conductor-ai <b>integrations</b> resolve providers by name,
+     * and the host's <b>credential store</b> (AWS SSM / Vault / etc., reached via the
+     * {@code CredentialStoreProvider} SPI) supplies raw keys. This standalone pre-flight check
+     * only knows AgentSpan's own provider model, so it would wrongly reject host-configured
+     * providers. The execution path already delegates to conductor-ai (which resolves or
+     * rejects the provider), so when embedded we defer to Conductor and skip this check.
+     */
+    @Value("${agentspan.embedded:false}")
+    private boolean embedded;
+
+    /**
      * Returns Optional.empty() if the provider is configured (either via startup environment
      * variables or via a credential added in the UI), or Optional.of(errorMessage) if not.
      */
     public Optional<String> validateProvider(String provider) {
-        if (aiModelProvider.isProviderConfigured(provider)) {
+        if (embedded || aiModelProvider.isProviderConfigured(provider)) {
             return Optional.empty();
         }
         return Optional.of("Model provider '" + provider + "' is not configured. "


### PR DESCRIPTION
## Summary

Library changes needed to embed `conductor-agentspan` into a host (orkes-conductor). All gated behind a single `agentspan.embedded` flag (default off), so **standalone behavior is unchanged**; only embedded mode defers to the host.

Branches off `server_split` (this PR's base). Validated end-to-end in orkes-conductor: orkes-io/orkes-conductor#3662.

## Changes
- Gate the `HTTP`/`HUMAN`/`JOIN`/MCP task overrides behind `agentspan.embedded` so the host's native tasks win when embedded (they collide on bean name otherwise).
- Defer provider pre-flight validation to the host when embedded (the host owns conductor-ai integrations + the secret store).
- `AgentService.listAgents()` uses the portable `getAllWorkflowDefs()` instead of `getAllWorkflowDefsLatestVersions()` (absent in orkes' vendored core).

## Notes
Spike-level; see the orkes-conductor PR's `AGENTSPAN_EMBED_SPIKE_HANDOFF.md` for the full write-up, known issues (e.g. `createTime=0`), and next steps.