### PR TITLE
fix(ts): dedupe overrides block in package.json (restore undici pin)

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -46,10 +46,6 @@
     "@io-orkes/conductor-javascript": "^3.0.3",
     "dotenv": "^16.0.0"
   },
-  "overrides": {
-    "undici": "^7.28.0",
-    "ws": "^8.21.0"
-  },
   "peerDependencies": {
     "@langchain/core": ">=0.2.0",
     "@langchain/langgraph": ">=0.2.0",
@@ -101,6 +97,7 @@
     "typecheck": "tsc --noEmit"
   },
   "overrides": {
+    "undici": "^7.28.0",
     "esbuild": "^0.28.1",
     "ws": "^8.21.0",
     "@langchain/langgraph": {


### PR DESCRIPTION
## Summary

Follow-up to #270. The merge of #270 left **two `"overrides"` keys** in `sdk/typescript/package.json` (lines 49 and 103) — one from the HITL/audit branch, one from main. JSON keeps only the last duplicate key, so the **`undici` pin was silently shadowed**.

The high-severity `undici` audit fix from #270 is currently surviving only because the transitive `^7.x` range happens to resolve to the patched `7.28.0` — there is no actual pin guarding it. A future `undici` 7.x release with a new advisory would re-break the `npm audit --omit=dev --audit-level=high` gate with nothing to hold it.

## Fix

Consolidate into a **single valid `overrides` block** that includes `undici` alongside the existing `esbuild` / `ws` / `uuid` overrides. No resolved-version changes — the lockfile is unchanged.

## Verification

- `grep -c '"overrides"'` → 1 (was 2); valid JSON; `undici` pin present
- `npm ci` + `npm run build` + `npx vitest run tests/unit/` (823 tests) — pass
- `npm audit --workspaces=false --omit=dev --audit-level=high` — exit 0
- Resolved: undici 7.28.0, esbuild 0.28.1, ws 8.21.0