### PR TITLE
docs: fix Jekyll Liquid build error in plan-execute.md

### DIFF
--- a/docs/concepts/plan-execute.md
+++ b/docs/concepts/plan-execute.md
@@ -350,6 +350,7 @@ result = runtime.run(harness, "ingest job", plan=plan)
 
 ### Parallel work + validation
 
+{% raw %}
 ```python
 plan = Plan(
     steps=[
@@ -368,6 +369,7 @@ plan = Plan(
     validation=[Validation("check_word_count", args={"path": "report.md", "min_words": 1000})],
 )
 ```
+{% endraw %}
 
 ## Planner context — ground the planner in your domain rules
 


### PR DESCRIPTION
## Summary

The `pages-build-deployment` (GitHub Pages / Jekyll) workflow is failing on `main`:

```
Error: Liquid syntax error (line 355): Variable '{{"path": "out/{i}' was not properly terminated
```

The parallel-work code sample in `docs/concepts/plan-execute.md` contains a Python f-string `f'{{"path": "out/{i}.md", ...}}'`. Jekyll runs Liquid over fenced code blocks too, so the `{{` is parsed as an (unterminated) Liquid variable and the whole site build aborts.

## Fix

Wrap that code block in `{% raw %}` / `{% endraw %}` so Jekyll emits it verbatim. Two-line change.

## Scope check

This is the only Liquid-breaking `{{`/`{%` token in the **rendered** docs set (top-level `*.md` + `concepts/` + `examples/` — the dirs Jekyll actually renders, per the build log). The `{{...}}` tokens in `docs/sdk-design/` and `docs/design/plans/` are harmless: those files have no YAML front matter, so Jekyll copies them without Liquid processing. The mermaid `{{"text"}}` diagrams render fine (valid Liquid string output).