### PR TITLE
test(e2e): make secrets guardrail case-insensitive (fix python-e2e flake)

### DIFF
--- a/sdk/python/e2e/test_suite8_guardrails.py
+++ b/sdk/python/e2e/test_suite8_guardrails.py
@@ -50,8 +50,12 @@ G1_BLOCK_INPUT = RegexGuardrail(
 )
 
 # G3: Agent output regex (block, multi-pattern) — blocks secrets
+# Case-insensitive: a secrets filter must catch "Password"/"TOKEN" etc., not
+# just the lowercase forms. Without (?i) the guardrail misses capitalised
+# words the LLM nondeterministically produces (e.g. "Password" at a sentence
+# start), letting them slip into output and flaking this suite.
 G3_NO_SECRETS = RegexGuardrail(
-    patterns=[r"\bpassword\b", r"\bsecret\b", r"\btoken\b"],
+    patterns=[r"(?i)\bpassword\b", r"(?i)\bsecret\b", r"(?i)\btoken\b"],
     mode="block",
     name="no_secrets",
     message="Do not include passwords, secrets, or tokens.",

--- a/sdk/python/e2e/test_suite8_guardrails.py
+++ b/sdk/python/e2e/test_suite8_guardrails.py
@@ -363,7 +363,7 @@ class TestSuite8Guardrails:
         assert g3["position"] == "output"
         assert g3["onFail"] == "retry"
         patterns = g3.get("patterns", [])
-        for pat in [r"\bpassword\b", r"\bsecret\b", r"\btoken\b"]:
+        for pat in [r"(?i)\bpassword\b", r"(?i)\bsecret\b", r"(?i)\btoken\b"]:
             assert pat in patterns, f"G3 missing pattern '{pat}'. Got: {patterns}"
 
         # ── Tool-level guardrails ─────────────────────────────────────


### PR DESCRIPTION
## Summary

`python-e2e` → `test_suite8_guardrails::test_agent_output_secrets_blocked` was failing intermittently:

```
AssertionError: [Secrets] Secret word in output.
output=Understood! Password security is crucial for protecting your accounts...
assert not <re.Match ... match='Password'>
```

## Root cause

The test asks the agent to include "password" in its reply and expects the `G3_NO_SECRETS` **output** guardrail to either escalate or scrub it. But the guardrail's patterns were **case-sensitive**:

```python
patterns=[r"\bpassword\b", r"\bsecret\b", r"\btoken\b"]
```

The LLM nondeterministically replied "**P**assword security is crucial…" (capitalised, sentence-start). `\bpassword\b` doesn't match "Password", so the guardrail passed it through → the word reached the output → the test's own case-insensitive assertion failed. Whether it flaked depended purely on how the model capitalised the word.

## Fix

Make the patterns case-insensitive with an inline `(?i)` flag. A secrets filter *should* catch any casing, so this is also the correct behaviour. `RegexGuardrail` evaluates locally via Python `re.compile`, so the inline flag is portable.

## Verification (CLAUDE.md make-it-fail)

Checked against the exact CI failure string:

```
OLD (case-sensitive) blocks it? False   <- reproduces the flake
NEW (case-insensitive) blocks it? True  <- fixed
```

The assertion path uses a deterministic regex (no LLM judging) — the flake was the guardrail config, not the check.