### PR TITLE
test(e2e): auto-retry transient python-e2e flakes (pytest-rerunfailures)

### DIFF
--- a/sdk/python/e2e/conftest.py
+++ b/sdk/python/e2e/conftest.py
@@ -33,6 +33,26 @@ def pytest_configure(config):
     )
 
 
+def pytest_collection_modifyitems(config, items):
+    """Auto-retry transient e2e flakes.
+
+    These suites drive a real server + real LLM, so individual tests flake
+    nondeterministically on transient conditions — the workflow still
+    RUNNING at the client timeout, a tool-call batch not returning, LLM
+    phrasing variance. Retrying up to twice lets a one-off flake recover
+    while a genuinely broken test still fails all three attempts (no real
+    regression is masked).
+
+    Configured here rather than in the CI command so it also applies to
+    local e2e runs. Honoured only when pytest-rerunfailures is installed
+    (the dev extra); without it the ``flaky`` marker is a harmless no-op.
+    """
+    rerun = pytest.mark.flaky(reruns=2, reruns_delay=5)
+    for item in items:
+        if item.get_closest_marker("e2e"):
+            item.add_marker(rerun)
+
+
 # ── Session-scoped health check ─────────────────────────────────────────
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
     "pytest-xdist>=3.0",
+    "pytest-rerunfailures>=14.0",
     "ruff>=0.4",
     "mypy>=1.10",
 ]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -26,6 +26,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -71,6 +72,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=14.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "rich", marker = "extra == 'validation'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
@@ -3623,6 +3625,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f0/74f8e685be7ecd1572c1256132f18fce3a665d7e07649a3f23b7eb2d3bec/pytest_rerunfailures-16.3.tar.gz", hash = "sha256:37c9b1231c8083e9f4e724f50f7a21241822f9516c15c700ebbf218d6452355c", size = 34148, upload-time = "2026-05-22T06:51:22.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/98/58a71d68d3126d7f6a6ed1944c37ec207a4ff3dc66cad3bed7b59d38df61/pytest_rerunfailures-16.3-py3-none-any.whl", hash = "sha256:6bdfb8ffb46c46072e6c16bdedee38b6c13eac620d9415ed5b63152cbf283170", size = 15396, upload-time = "2026-05-22T06:51:20.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The `python-e2e` CI job drives a **real server + real LLM**, so individual tests flake nondeterministically — and a single transient failure fails the whole job. While verifying an unrelated fix (#277), consecutive runs each failed a *different*, unrelated test:

| Run | Failing test | Cause |
|-----|-------------|-------|
| 1 | `test_after_tool_callback_executes` | workflow still `RUNNING` at client timeout |
| 2 | `test_http_lifecycle@credentials` | "Run stalled at tool-calling stage" |

These are transient infra/LLM-latency flakes, not regressions.

## Fix

Add `pytest-rerunfailures` and mark every e2e item `flaky(reruns=2, reruns_delay=5)` via the **e2e `conftest.py`** (`pytest_collection_modifyitems`, scoped to items carrying the `e2e` marker). A genuinely broken test still fails all 3 attempts — no real regression is masked — while a one-off flake recovers.

Configured in `conftest` rather than the CI YAML so it also applies to **local** e2e runs (and needs no workflow-file change).

## Verification

- `pytest-rerunfailures` imports; the dynamically-added `flaky` marker carries `{reruns: 2, reruns_delay: 5}`.
- `pytest e2e/ --collect-only` collects 115 tests with the hook in place (the 2 unrelated collection errors are a missing local-only `mcp_test_server` dep that CI installs separately).
- Scope check: the hook only marks items with the `e2e` marker, so unit suites are unaffected.

## Note

This is the real fix for "`python-e2e` flakes on a different test each run", complementing #277 (which fixes a genuine, deterministic guardrail bug). Recommend merging #277 first, then this.