### PR TITLE
fix(python-sdk): Windows/cross-platform developer experience (install, CLI, python -m)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -99,6 +99,18 @@ uv venv && source .venv/bin/activate
 uv pip install agentspan
 ```
 
+On **Windows** (PowerShell), activate the venv with the Windows path:
+
+```powershell
+uv venv
+.venv\Scripts\Activate.ps1
+uv pip install agentspan
+```
+
+Use **Python 3.10–3.13** (not 3.14 yet — some native dependencies don't ship 3.14
+wheels). The CLI works as both `agentspan <command>` and, if the Scripts directory
+isn't on `PATH`, `python -m agentspan <command>` (e.g. `python -m agentspan doctor`).
+
 ### Start the Server
 
 The SDK auto-starts the server when needed, but you can also start it manually (recommended):

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -8,7 +8,10 @@ version = "0.1.0"
 description = "Agentspan SDK — durable, scalable, observable AI agents"
 readme = "README.md"
 license = {text = "MIT License"}
-requires-python = ">=3.10"
+# Upper bound: native deps (grpc via conductor-python, pydantic-core) often lack
+# wheels for the newest Python until well after release, so installs on e.g. 3.14
+# fall back to source builds and fail. Bump the ceiling once those wheels exist.
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "conductor-python>=1.3.11",
     "httpx>=0.24",
@@ -21,7 +24,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/sdk/python/src/agentspan/__main__.py
+++ b/sdk/python/src/agentspan/__main__.py
@@ -1,0 +1,11 @@
+"""Allow running the CLI as ``python -m agentspan ...``.
+
+Mirrors the ``agentspan`` console script (entry point ``agentspan.cli:main``) so the
+CLI is reachable even when the install's Scripts/bin directory is not on ``PATH`` —
+a common situation on Windows. ``python -m agentspan doctor`` is then equivalent to
+``agentspan doctor``.
+"""
+from agentspan.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/src/agentspan/cli/__init__.py
+++ b/sdk/python/src/agentspan/cli/__init__.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 
 import os
 import platform
+import socket
 import stat
 import subprocess
 import sys
+import tempfile
+import urllib.error
 import urllib.request
 
 _S3_BUCKET = "https://agentspan.s3.us-east-2.amazonaws.com"
@@ -39,34 +42,69 @@ def _detect_arch() -> str:
 
 
 def _download_with_progress(url: str, dest: str) -> None:
-    """Download *url* to *dest* showing a progress bar on stderr."""
-    response = urllib.request.urlopen(url)
+    """Download *url* to *dest* atomically, with a progress bar and friendly errors.
+
+    Writes to a temp file in the destination directory and atomically renames on
+    success, so an interrupted/partial download never leaves a corrupt binary at
+    *dest* (which would otherwise be cached and executed forever). HTTP/network
+    failures are surfaced as clear, actionable messages instead of raw tracebacks.
+    """
+    try:
+        response = urllib.request.urlopen(url, timeout=60)  # noqa: S310
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise RuntimeError(
+                f"No Agentspan CLI binary is published for {_detect_os()}/{_detect_arch()} "
+                f"(looked at {url}). Your OS/architecture may be unsupported or the release "
+                f"may not be available yet."
+            ) from exc
+        raise RuntimeError(
+            f"Failed to download the Agentspan CLI (HTTP {exc.code}) from {url}."
+        ) from exc
+    except (urllib.error.URLError, socket.timeout) as exc:
+        reason = getattr(exc, "reason", exc)
+        raise RuntimeError(
+            f"Could not reach the Agentspan CLI download server ({url}): {reason}. "
+            f"Check your network connection, proxy, or firewall settings."
+        ) from exc
+
     total = int(response.headers.get("Content-Length", 0))
     block_size = 64 * 1024
     downloaded = 0
     bar_width = 40
 
-    with open(dest, "wb") as f:
-        while True:
-            chunk = response.read(block_size)
-            if not chunk:
-                break
-            f.write(chunk)
-            downloaded += len(chunk)
-            if total > 0:
-                pct = downloaded / total
-                filled = int(bar_width * pct)
-                bar = "\u2588" * filled + "\u2591" * (bar_width - filled)
-                mb_done = downloaded / (1024 * 1024)
-                mb_total = total / (1024 * 1024)
-                print(
-                    f"\r  [{bar}] {pct:5.1%}  {mb_done:.1f}/{mb_total:.1f} MB",
-                    end="",
-                    file=sys.stderr,
-                    flush=True,
-                )
-    if total > 0:
-        print(file=sys.stderr)  # newline after progress bar
+    dest_dir = os.path.dirname(dest) or "."
+    os.makedirs(dest_dir, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dest_dir, prefix=".agentspan-dl-")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            while True:
+                chunk = response.read(block_size)
+                if not chunk:
+                    break
+                f.write(chunk)
+                downloaded += len(chunk)
+                if total > 0:
+                    pct = downloaded / total
+                    filled = int(bar_width * pct)
+                    bar = "\u2588" * filled + "\u2591" * (bar_width - filled)
+                    print(
+                        f"\r  [{bar}] {pct:5.1%}  "
+                        f"{downloaded / 1048576:.1f}/{total / 1048576:.1f} MB",
+                        end="",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+        if total > 0:
+            print(file=sys.stderr)  # newline after progress bar
+        os.replace(tmp_path, dest)  # atomic on POSIX and Windows
+    except BaseException:
+        # Any failure (incl. KeyboardInterrupt) \u2014 drop the partial file.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _binary_path() -> str:
@@ -76,10 +114,21 @@ def _binary_path() -> str:
 
 
 def _ensure_binary() -> str:
-    """Download the CLI binary if it is not already cached and return its path."""
+    """Download the CLI binary if it is not already cached and return its path.
+
+    Set ``AGENTSPAN_FORCE_DOWNLOAD=1`` to force a re-download (e.g. to recover from
+    a corrupt cache). A zero-byte cached file is treated as missing.
+    """
     path = _binary_path()
-    if os.path.isfile(path):
+    force = os.environ.get("AGENTSPAN_FORCE_DOWNLOAD") == "1"
+    if not force and os.path.isfile(path) and os.path.getsize(path) > 0:
         return path
+    # Drop any stale / zero-byte / corrupt cached binary before re-downloading.
+    if os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
 
     os.makedirs(_CACHE_DIR, exist_ok=True)
     os_name = _detect_os()
@@ -90,15 +139,22 @@ def _ensure_binary() -> str:
 
     print("Downloading Agentspan CLI ...", file=sys.stderr, flush=True)
     _download_with_progress(url, path)
-    st = os.stat(path)
-    os.chmod(path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    # Execute bits are POSIX-only; on Windows .exe is executable by extension.
+    if os_name != "windows":
+        st = os.stat(path)
+        os.chmod(path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     print("Agentspan CLI installed.", file=sys.stderr, flush=True)
     return path
 
 
 def main() -> None:
     """Entry point for the ``agentspan`` console script."""
-    binary = _ensure_binary()
+    try:
+        binary = _ensure_binary()
+    except RuntimeError as exc:
+        # Friendly, actionable message instead of a raw traceback.
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
     result = subprocess.run([binary] + sys.argv[1:])
     sys.exit(result.returncode)
 

--- a/sdk/python/tests/unit/test_cli_binary.py
+++ b/sdk/python/tests/unit/test_cli_binary.py
@@ -1,0 +1,62 @@
+"""CLI binary download robustness (cross-platform, esp. Windows): atomic writes,
+friendly errors, and corrupt-cache recovery. No network — `urlopen` is stubbed.
+"""
+import urllib.error
+
+import pytest
+
+import agentspan.cli as cli
+
+
+class _FakeResp:
+    def __init__(self, chunks, total):
+        self._chunks = list(chunks)
+        self.headers = {"Content-Length": str(total)}
+
+    def read(self, _n):
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+def test_http_404_gives_friendly_error(monkeypatch, tmp_path):
+    def boom(url, timeout=0):
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", boom)
+    dest = tmp_path / "bin" / "agentspan.exe"
+    with pytest.raises(RuntimeError, match="No Agentspan CLI binary"):
+        cli._download_with_progress("http://x/agentspan_windows_amd64.exe", str(dest))
+    assert not dest.exists()
+
+
+def test_network_error_gives_friendly_error(monkeypatch, tmp_path):
+    def boom(url, timeout=0):
+        raise urllib.error.URLError("proxy refused")
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", boom)
+    with pytest.raises(RuntimeError, match="Could not reach"):
+        cli._download_with_progress("http://x/b", str(tmp_path / "bin" / "b"))
+
+
+def test_successful_download_is_atomic_and_leaves_no_temp(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        cli.urllib.request, "urlopen", lambda url, timeout=0: _FakeResp([b"hello"], 5)
+    )
+    dest = tmp_path / "bin" / "agentspan"
+    cli._download_with_progress("http://x/b", str(dest))
+    assert dest.read_bytes() == b"hello"
+    assert list((tmp_path / "bin").glob(".agentspan-dl-*")) == []  # temp cleaned up
+
+
+def test_partial_download_is_cleaned_up(monkeypatch, tmp_path):
+    class _Broken:
+        headers = {"Content-Length": "100"}
+
+        def read(self, _n):
+            raise OSError("connection reset")
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", lambda url, timeout=0: _Broken())
+    dest = tmp_path / "bin" / "agentspan"
+    with pytest.raises(OSError, match="connection reset"):
+        cli._download_with_progress("http://x/b", str(dest))
+    assert not dest.exists()  # no corrupt binary left at the final path
+    assert list((tmp_path / "bin").glob(".agentspan-dl-*")) == []

--- a/sdk/python/tests/unit/test_main_entrypoint.py
+++ b/sdk/python/tests/unit/test_main_entrypoint.py
@@ -1,0 +1,24 @@
+"""`python -m agentspan` must invoke the same entry point as the `agentspan` console
+script (the `agentspan.cli:main` entry point). This guards the Windows-friendly
+module-execution path so it can't silently regress.
+"""
+import importlib
+
+
+def test_main_module_reexports_cli_main():
+    main_mod = importlib.import_module("agentspan.__main__")
+    from agentspan.cli import main as cli_main
+
+    assert main_mod.main is cli_main
+
+
+def test_importing_main_module_does_not_run_cli(monkeypatch):
+    # Importing the module must NOT execute the CLI — only `python -m agentspan`
+    # (running it as __main__) should. Importing it here must stay side-effect free.
+    import agentspan.cli as cli
+
+    called = []
+    monkeypatch.setattr(cli, "main", lambda *a, **k: called.append(True))
+    importlib.reload(importlib.import_module("agentspan.__main__"))
+
+    assert called == []


### PR DESCRIPTION
Fixes the Windows/Python-3.14 CLI install failure. Caps `requires-python` to `>=3.10,<3.14` (native deps lack 3.14 wheels); adds `__main__.py` so `python -m agentspan doctor` works when Scripts isn't on PATH; hardens the CLI binary download (atomic write, friendly 404/network errors, Windows-safe chmod, `AGENTSPAN_FORCE_DOWNLOAD=1` recovery); README Windows notes.
Tests: deterministic, no network, validated fail-then-pass.
Out of scope: the 13 deprecated `asyncio.get_event_loop()` sites (separate PR).