### PR TITLE
refactor(server): Phase 1 — extract credential SPI interfaces to lib, push impls to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 .DS_Store
 .idea/
+.vscode/
+.claude/
 __pycache__/
 sdk/python/.coverage
 sdk/python/.env

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,6 +24,7 @@ ext {
     junitVersion       = '5.10.2'
     assertjVersion     = '3.25.1'
     mockitoVersion     = '5.10.0'
+    archunitVersion    = '1.3.0'
 }
 
 subprojects {

--- a/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/EncryptedDbCredentialStoreProvider.java
+++ b/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/EncryptedDbCredentialStoreProvider.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 import dev.agentspan.runtime.model.credentials.CredentialMeta;
 import dev.agentspan.runtime.spi.CredentialStoreProvider;
+import dev.agentspan.runtime.spi.MasterKeyProvider;
 
 /**
  * AES-256-GCM encrypted credential store backed by the credential SQLite/Postgres DB.
@@ -31,7 +32,7 @@ import dev.agentspan.runtime.spi.CredentialStoreProvider;
  * <p>Encryption format: [12-byte IV][ciphertext+16-byte GCM tag]
  * All concatenated into a single BLOB stored in credentials_store.encrypted_value.</p>
  *
- * <p>The master key is the 32-byte key from {@code MasterKeyConfig#credentialMasterKey()}.</p>
+ * <p>The 32-byte master key is sourced from the active {@link MasterKeyProvider}.</p>
  */
 @Component
 public class EncryptedDbCredentialStoreProvider implements CredentialStoreProvider {
@@ -46,10 +47,9 @@ public class EncryptedDbCredentialStoreProvider implements CredentialStoreProvid
     private final byte[] masterKey;
 
     public EncryptedDbCredentialStoreProvider(
-            @Qualifier("credentialJdbc") NamedParameterJdbcTemplate jdbc,
-            @Qualifier("credentialMasterKey") byte[] masterKey) {
+            @Qualifier("credentialJdbc") NamedParameterJdbcTemplate jdbc, MasterKeyProvider masterKeyProvider) {
         this.jdbc = jdbc;
-        this.masterKey = masterKey;
+        this.masterKey = masterKeyProvider.getMasterKey();
     }
 
     @Override

--- a/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/FileEnvMasterKeyProvider.java
+++ b/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/FileEnvMasterKeyProvider.java
@@ -15,31 +15,49 @@ import java.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import dev.agentspan.runtime.spi.MasterKeyProvider;
 
 /**
- * Loads or generates the AES-256-GCM master key used by EncryptedDbCredentialStoreProvider.
+ * OSS file/env implementation of {@link MasterKeyProvider}.
  *
  * <p>Key sourcing rules:</p>
  * <ul>
  *   <li>If {@code AGENTSPAN_MASTER_KEY} env var is set → decode and use it</li>
  *   <li>If unset → auto-generate, persist to ~/.agentspan/master.key, warn</li>
  * </ul>
+ *
+ * <p>This is the standalone-server default. An embedding host (e.g. orkes-conductor) can source
+ * the key from AWS KMS, HashiCorp Vault, Azure Key Vault or GCP KMS by contributing its own
+ * {@link MasterKeyProvider} bean in place of this one.</p>
  */
-@Configuration
-public class MasterKeyConfig {
+@Component
+public class FileEnvMasterKeyProvider implements MasterKeyProvider {
 
-    private static final Logger log = LoggerFactory.getLogger(MasterKeyConfig.class);
+    private static final Logger log = LoggerFactory.getLogger(FileEnvMasterKeyProvider.class);
     private static final int KEY_BYTES = 32; // 256-bit
 
-    @Value("${AGENTSPAN_MASTER_KEY:#{null}}")
-    private String masterKeyBase64;
+    private final String masterKeyBase64;
+    private volatile byte[] cached;
 
-    @Bean("credentialMasterKey")
-    public byte[] credentialMasterKey() {
-        Path homeDir = Paths.get(System.getProperty("user.home"));
-        return loadOrGenerate(masterKeyBase64, homeDir);
+    public FileEnvMasterKeyProvider(@Value("${AGENTSPAN_MASTER_KEY:#{null}}") String masterKeyBase64) {
+        this.masterKeyBase64 = masterKeyBase64;
+    }
+
+    @Override
+    public byte[] getMasterKey() {
+        byte[] result = cached;
+        if (result == null) {
+            synchronized (this) {
+                result = cached;
+                if (result == null) {
+                    result = loadOrGenerate(masterKeyBase64, Paths.get(System.getProperty("user.home")));
+                    cached = result;
+                }
+            }
+        }
+        return result;
     }
 
     /**

--- a/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/HmacExecutionTokenIssuer.java
+++ b/server/conductor-agentspan-server/src/main/java/dev/agentspan/runtime/credentials/HmacExecutionTokenIssuer.java
@@ -14,26 +14,29 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
+import dev.agentspan.runtime.spi.MasterKeyProvider;
+
 /**
- * Mints and validates execution tokens for worker credential resolution.
+ * OSS HMAC-SHA256 implementation of {@link ExecutionTokenIssuer}.
  *
  * <p>Token format: base64url(header).base64url(payload).base64url(hmacSignature)
  * Signed with HMAC-SHA256 using the server master key.</p>
  *
  * <p>jti deny-list: in-memory ConcurrentHashMap (jti → expiryEpochSecond).
  * Self-pruning via scheduled cleanup. In OSS, the deny-list is lost on restart
- * (bounded risk: tokens expire with workflow TTL).</p>
+ * (bounded risk: tokens expire with workflow TTL). An embedding host can supply a durable
+ * revocation store by contributing its own {@link ExecutionTokenIssuer} bean.</p>
  */
 @Service
-public class ExecutionTokenService {
+public class HmacExecutionTokenIssuer implements ExecutionTokenIssuer {
 
-    private static final Logger log = LoggerFactory.getLogger(ExecutionTokenService.class);
+    private static final Logger log = LoggerFactory.getLogger(HmacExecutionTokenIssuer.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final long ONE_HOUR_SECONDS = 3600;
     private static final String SCOPE = "credentials";
@@ -44,19 +47,11 @@ public class ExecutionTokenService {
     private final byte[] masterKey;
     private final ConcurrentHashMap<String, Long> denyList = new ConcurrentHashMap<>();
 
-    public ExecutionTokenService(@Qualifier("credentialMasterKey") byte[] masterKey) {
-        this.masterKey = masterKey;
+    public HmacExecutionTokenIssuer(MasterKeyProvider masterKeyProvider) {
+        this.masterKey = masterKeyProvider.getMasterKey();
     }
 
-    /**
-     * Mint a new execution token.
-     *
-     * @param userId         the authenticated user's ID (or username for login tokens)
-     * @param executionId    the execution ID (or "login" for login tokens)
-     * @param declaredNames  credential names declared by the agent (bounds resolution)
-     * @param executionTimeoutSeconds execution timeout; TTL = max(3600, executionTimeoutSeconds)
-     * @return signed token string
-     */
+    @Override
     public String mint(String userId, String executionId, List<String> declaredNames, long executionTimeoutSeconds) {
         long now = Instant.now().getEpochSecond();
         long ttl = Math.max(ONE_HOUR_SECONDS, executionTimeoutSeconds);
@@ -84,13 +79,7 @@ public class ExecutionTokenService {
         }
     }
 
-    /**
-     * Validate a token and return its payload.
-     *
-     * @throws TokenExpiredException  if exp is in the past
-     * @throws TokenRevokedException  if jti is in the deny-list
-     * @throws TokenInvalidException  if signature or structure is invalid
-     */
+    @Override
     @SuppressWarnings("unchecked")
     public TokenPayload validate(String token) {
         String[] parts = token.split("\\.");
@@ -126,13 +115,7 @@ public class ExecutionTokenService {
         return new TokenPayload(jti, (String) claims.get("sub"), (String) claims.get("wid"), exp, names);
     }
 
-    /**
-     * Revoke a token by adding its jti to the deny-list.
-     * Called when an execution is cancelled or terminated.
-     *
-     * @param jti the unique token ID
-     * @param exp the token's expiry epoch second (for self-pruning)
-     */
+    @Override
     public void revoke(String jti, long exp) {
         denyList.put(jti, exp);
         log.info("Execution token revoked: jti={}", jti);
@@ -175,27 +158,5 @@ public class ExecutionTokenService {
             diff |= a.charAt(i) ^ b.charAt(i);
         }
         return diff == 0;
-    }
-
-    // ── Value types ───────────────────────────────────────────────────
-
-    public record TokenPayload(String jti, String userId, String executionId, long exp, List<String> declaredNames) {}
-
-    public static class TokenInvalidException extends RuntimeException {
-        public TokenInvalidException(String msg) {
-            super(msg);
-        }
-    }
-
-    public static class TokenExpiredException extends RuntimeException {
-        public TokenExpiredException(String msg) {
-            super(msg);
-        }
-    }
-
-    public static class TokenRevokedException extends RuntimeException {
-        public TokenRevokedException(String msg) {
-            super(msg);
-        }
     }
 }

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/ai/AgentspanAIModelProviderTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/ai/AgentspanAIModelProviderTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.env.Environment;
 
 import dev.agentspan.runtime.credentials.CredentialResolutionService;
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 import okhttp3.OkHttpClient;
 
@@ -23,19 +23,19 @@ class AgentspanAIModelProviderTest {
     private static final String ANON_USER = "00000000-0000-0000-0000-000000000000";
 
     private CredentialResolutionService credentialService;
-    private ExecutionTokenService tokenService;
+    private ExecutionTokenIssuer tokenIssuer;
     private OkHttpClient httpClient;
     private AgentspanAIModelProvider provider;
 
     @BeforeEach
     void setUp() {
         credentialService = mock(CredentialResolutionService.class);
-        tokenService = mock(ExecutionTokenService.class);
+        tokenIssuer = mock(ExecutionTokenIssuer.class);
         httpClient = new OkHttpClient();
         Environment env = mock(Environment.class);
         when(env.getProperty(anyString(), anyString())).thenAnswer(i -> i.getArgument(1));
 
-        provider = new AgentspanAIModelProvider(List.of(), env, httpClient, credentialService, tokenService);
+        provider = new AgentspanAIModelProvider(List.of(), env, httpClient, credentialService, tokenIssuer);
     }
 
     @Test

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/WorkerCredentialsIntegrationTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/WorkerCredentialsIntegrationTest.java
@@ -19,9 +19,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.agentspan.runtime.AgentRuntime;
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
 import dev.agentspan.runtime.model.credentials.ResolveRequest;
 import dev.agentspan.runtime.spi.CredentialStoreProvider;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 /**
  * Audit gaps C + F — full-stack {@code POST /api/workers/secrets} integration.
@@ -30,7 +30,7 @@ import dev.agentspan.runtime.spi.CredentialStoreProvider;
  * good for controller wiring but blind to the user-scoping behavior of the
  * real store. This test wires the real Spring beans (real
  * {@code CredentialResolutionService}, real {@code EncryptedDbCredentialStoreProvider},
- * real {@code ExecutionTokenService}) and exercises the integration boundary.</p>
+ * real {@code ExecutionTokenIssuer}) and exercises the integration boundary.</p>
  *
  * <p><strong>Gap C:</strong> two users, same secret name, different values.
  * Each user's execution token must return only its OWN value when the worker
@@ -53,7 +53,7 @@ class WorkerCredentialsIntegrationTest {
     private CredentialStoreProvider store;
 
     @Autowired
-    private ExecutionTokenService tokenService;
+    private ExecutionTokenIssuer tokenIssuer;
 
     // Use a non-seeded name so the CredentialEnvSeeder doesn't accidentally
     // populate it for the anonymous user (and pollute the test).
@@ -85,8 +85,8 @@ class WorkerCredentialsIntegrationTest {
     @Test
     @SuppressWarnings("unchecked")
     void resolve_eachUserGetsOnlyTheirOwnValue() {
-        String tokenA = tokenService.mint(USER_A, "wf-A", List.of(NAME), 3600);
-        String tokenB = tokenService.mint(USER_B, "wf-B", List.of(NAME), 3600);
+        String tokenA = tokenIssuer.mint(USER_A, "wf-A", List.of(NAME), 3600);
+        String tokenB = tokenIssuer.mint(USER_B, "wf-B", List.of(NAME), 3600);
 
         // User A's token
         ResolveRequest reqA = new ResolveRequest();
@@ -116,7 +116,7 @@ class WorkerCredentialsIntegrationTest {
         // User A's token declares a name that doesn't exist for user A.
         // (User B has it stored, but A's token must NOT reach B's storage.)
         store.delete(USER_A, NAME);
-        String tokenA = tokenService.mint(USER_A, "wf-AX", List.of(NAME), 3600);
+        String tokenA = tokenIssuer.mint(USER_A, "wf-AX", List.of(NAME), 3600);
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(tokenA);
@@ -137,7 +137,7 @@ class WorkerCredentialsIntegrationTest {
     @Test
     @SuppressWarnings("unchecked")
     void resolve_sameTokenSeesUpdatedValueAfterRotation() {
-        String token = tokenService.mint(USER_A, "wf-rot", List.of(NAME), 3600);
+        String token = tokenIssuer.mint(USER_A, "wf-rot", List.of(NAME), 3600);
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(token);
@@ -165,7 +165,7 @@ class WorkerCredentialsIntegrationTest {
         // Edge case: credential is deleted between mint and resolve. The token is
         // still valid (it doesn't lock the value, only declared names), but
         // the response simply omits the unresolvable name.
-        String token = tokenService.mint(USER_A, "wf-del", List.of(NAME), 3600);
+        String token = tokenIssuer.mint(USER_A, "wf-del", List.of(NAME), 3600);
         store.delete(USER_A, NAME);
 
         ResolveRequest req = new ResolveRequest();
@@ -187,7 +187,7 @@ class WorkerCredentialsIntegrationTest {
         // every agent that doesn't declare credentials — the common case) must
         // NOT permit resolving arbitrary credential names. The defense-in-depth
         // claim of declared-name binding requires this.
-        String token = tokenService.mint(USER_A, "wf-empty", List.of(), 3600);
+        String token = tokenIssuer.mint(USER_A, "wf-empty", List.of(), 3600);
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(token);
@@ -207,7 +207,7 @@ class WorkerCredentialsIntegrationTest {
         // Even though A's user_id is authoritative (so cross-user leak wouldn't
         // happen anyway), the binding-check should reject the name itself
         // before any user-scoped resolve is attempted.
-        String token = tokenService.mint(USER_A, "wf-empty2", List.of(), 3600);
+        String token = tokenIssuer.mint(USER_A, "wf-empty2", List.of(), 3600);
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(token);

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/WorkerCredentialsTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/WorkerCredentialsTest.java
@@ -27,6 +27,7 @@ import dev.agentspan.runtime.context.*;
 import dev.agentspan.runtime.credentials.*;
 import dev.agentspan.runtime.model.credentials.ResolveRequest;
 import dev.agentspan.runtime.spi.CredentialStoreProvider;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 @ExtendWith(MockitoExtension.class)
 class WorkerCredentialsTest {
@@ -38,7 +39,7 @@ class WorkerCredentialsTest {
     private CredentialResolutionService resolutionService;
 
     @Mock
-    private ExecutionTokenService tokenService;
+    private ExecutionTokenIssuer tokenIssuer;
 
     @InjectMocks
     private WorkerController controller;
@@ -47,8 +48,8 @@ class WorkerCredentialsTest {
     void setUp() {
         byte[] key = new byte[32];
         new SecureRandom().nextBytes(key);
-        tokenService = new ExecutionTokenService(key);
-        ReflectionTestUtils.setField(controller, "tokenService", tokenService);
+        tokenIssuer = new HmacExecutionTokenIssuer(() -> key);
+        ReflectionTestUtils.setField(controller, "tokenIssuer", tokenIssuer);
         ReflectionTestUtils.setField(controller, "resolveRateLimit", 3); // low limit for test
 
         RequestContextHolder.set(RequestContext.builder()
@@ -66,7 +67,7 @@ class WorkerCredentialsTest {
     @Test
     @SuppressWarnings("unchecked")
     void resolve_validToken_returnsValues() {
-        String token = tokenService.mint("u-test", "wf-1", List.of("GITHUB_TOKEN"), 3600);
+        String token = tokenIssuer.mint("u-test", "wf-1", List.of("GITHUB_TOKEN"), 3600);
         when(resolutionService.resolve("u-test", "GITHUB_TOKEN")).thenReturn("ghp_secret");
 
         ResolveRequest req = new ResolveRequest();
@@ -86,7 +87,7 @@ class WorkerCredentialsTest {
     @Test
     void resolve_loginToken_returns401() {
         // Login tokens use wid="login" — must not be accepted at /resolve
-        String loginToken = tokenService.mint("u-test", "login", List.of(), 3600);
+        String loginToken = tokenIssuer.mint("u-test", "login", List.of(), 3600);
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(loginToken);
@@ -99,7 +100,7 @@ class WorkerCredentialsTest {
     @Test
     void resolve_nameNotInDeclared_isExcluded() {
         // Token only declares GITHUB_TOKEN, but request asks for OPENAI_KEY too
-        String token = tokenService.mint("u-test", "wf-1", List.of("GITHUB_TOKEN"), 3600);
+        String token = tokenIssuer.mint("u-test", "wf-1", List.of("GITHUB_TOKEN"), 3600);
         when(resolutionService.resolve(eq("u-test"), eq("GITHUB_TOKEN"))).thenReturn("ghp_val");
 
         ResolveRequest req = new ResolveRequest();
@@ -116,7 +117,7 @@ class WorkerCredentialsTest {
         // Tool declared the parent name "GCP_SVC". A request for "GCP_SVC.project_id"
         // is allowed because the JSONPath access doesn't expand the blast radius —
         // the tool already had the whole blob via the declared parent name.
-        String token = tokenService.mint("u-test", "wf-jp", List.of("GCP_SVC"), 3600);
+        String token = tokenIssuer.mint("u-test", "wf-jp", List.of("GCP_SVC"), 3600);
         when(resolutionService.resolve("u-test", "GCP_SVC.project_id")).thenReturn("my-proj-123");
 
         ResolveRequest req = new ResolveRequest();
@@ -132,7 +133,7 @@ class WorkerCredentialsTest {
     @Test
     void resolve_dottedPathOfUndeclaredBase_isRejected() {
         // Tool declared only GITHUB_TOKEN. A request for OTHER.field must be filtered out.
-        String token = tokenService.mint("u-test", "wf-jp2", List.of("GITHUB_TOKEN"), 3600);
+        String token = tokenIssuer.mint("u-test", "wf-jp2", List.of("GITHUB_TOKEN"), 3600);
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(token);
@@ -145,7 +146,7 @@ class WorkerCredentialsTest {
     void resolve_prefixCollisionGuard() {
         // Declared "FOO" must NOT permit "FOOBAR.x" — the boundary requires a dot
         // immediately after the declared name, not just a string prefix match.
-        String token = tokenService.mint("u-test", "wf-jp3", List.of("FOO"), 3600);
+        String token = tokenIssuer.mint("u-test", "wf-jp3", List.of("FOO"), 3600);
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(token);
@@ -156,7 +157,7 @@ class WorkerCredentialsTest {
 
     @Test
     void resolve_rateLimitExceeded_returns429() {
-        String token = tokenService.mint("u-test", "wf-2", List.of("KEY_A"), 3600);
+        String token = tokenIssuer.mint("u-test", "wf-2", List.of("KEY_A"), 3600);
         when(resolutionService.resolve(anyString(), anyString())).thenReturn("val");
 
         ResolveRequest req = new ResolveRequest();
@@ -175,9 +176,9 @@ class WorkerCredentialsTest {
 
     @Test
     void resolve_revokedToken_returns401() {
-        String token = tokenService.mint("u-test", "wf-3", List.of("KEY_B"), 3600);
-        ExecutionTokenService.TokenPayload payload = tokenService.validate(token);
-        tokenService.revoke(payload.jti(), payload.exp());
+        String token = tokenIssuer.mint("u-test", "wf-3", List.of("KEY_B"), 3600);
+        ExecutionTokenIssuer.TokenPayload payload = tokenIssuer.validate(token);
+        tokenIssuer.revoke(payload.jti(), payload.exp());
 
         ResolveRequest req = new ResolveRequest();
         req.setToken(token);

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/credentials/FileEnvMasterKeyProviderTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/credentials/FileEnvMasterKeyProviderTest.java
@@ -8,10 +8,14 @@ import java.util.Base64;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-class MasterKeyConfigTest {
+class FileEnvMasterKeyProviderTest {
 
     @TempDir
     Path tempDir;
+
+    private FileEnvMasterKeyProvider newProvider() {
+        return new FileEnvMasterKeyProvider(null);
+    }
 
     @Test
     void loadKey_fromBase64String_returns32ByteKey() {
@@ -19,8 +23,7 @@ class MasterKeyConfigTest {
         new java.security.SecureRandom().nextBytes(raw);
         String b64 = Base64.getEncoder().encodeToString(raw);
 
-        MasterKeyConfig config = new MasterKeyConfig();
-        byte[] key = config.loadOrGenerate(b64, tempDir);
+        byte[] key = newProvider().loadOrGenerate(b64, tempDir);
 
         assertThat(key).hasSize(32);
         assertThat(key).isEqualTo(raw);
@@ -28,8 +31,7 @@ class MasterKeyConfigTest {
 
     @Test
     void loadKey_autoGen_onLocalhost_writesFileAndWarns() {
-        MasterKeyConfig config = new MasterKeyConfig();
-        byte[] key = config.loadOrGenerate(null, tempDir);
+        byte[] key = newProvider().loadOrGenerate(null, tempDir);
 
         assertThat(key).hasSize(32);
         // Key file is written to tempDir/.agentspan/master.key
@@ -38,17 +40,16 @@ class MasterKeyConfigTest {
 
     @Test
     void loadKey_autoGen_subsequentCall_returnsSameKey() {
-        MasterKeyConfig config = new MasterKeyConfig();
-        byte[] key1 = config.loadOrGenerate(null, tempDir);
-        byte[] key2 = config.loadOrGenerate(null, tempDir);
+        FileEnvMasterKeyProvider provider = newProvider();
+        byte[] key1 = provider.loadOrGenerate(null, tempDir);
+        byte[] key2 = provider.loadOrGenerate(null, tempDir);
 
         assertThat(key1).isEqualTo(key2);
     }
 
     @Test
     void loadKey_missingKey_autoGenerates() {
-        MasterKeyConfig config = new MasterKeyConfig();
-        byte[] key = config.loadOrGenerate(null, tempDir);
+        byte[] key = newProvider().loadOrGenerate(null, tempDir);
 
         assertThat(key).hasSize(32);
         assertThat(tempDir.resolve(".agentspan/master.key")).exists();
@@ -56,9 +57,7 @@ class MasterKeyConfigTest {
 
     @Test
     void loadKey_invalidBase64_throws() {
-        MasterKeyConfig config = new MasterKeyConfig();
-
-        assertThatThrownBy(() -> config.loadOrGenerate("not-valid-base64!!!", tempDir))
+        assertThatThrownBy(() -> newProvider().loadOrGenerate("not-valid-base64!!!", tempDir))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -67,10 +66,23 @@ class MasterKeyConfigTest {
         // 16 bytes = 128-bit, not valid for AES-256
         byte[] short16 = new byte[16];
         String b64 = Base64.getEncoder().encodeToString(short16);
-        MasterKeyConfig config = new MasterKeyConfig();
 
-        assertThatThrownBy(() -> config.loadOrGenerate(b64, tempDir))
+        assertThatThrownBy(() -> newProvider().loadOrGenerate(b64, tempDir))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("32 bytes");
+    }
+
+    @Test
+    void getMasterKey_memoizesAcrossCalls() {
+        byte[] raw = new byte[32];
+        new java.security.SecureRandom().nextBytes(raw);
+        FileEnvMasterKeyProvider provider =
+                new FileEnvMasterKeyProvider(Base64.getEncoder().encodeToString(raw));
+
+        byte[] first = provider.getMasterKey();
+        byte[] second = provider.getMasterKey();
+
+        assertThat(first).isEqualTo(raw);
+        assertThat(second).isSameAs(first);
     }
 }

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/credentials/HmacExecutionTokenIssuerTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/credentials/HmacExecutionTokenIssuerTest.java
@@ -4,7 +4,9 @@
  */
 package dev.agentspan.runtime.credentials;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -18,23 +20,25 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ExecutionTokenServiceTest {
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
+
+class HmacExecutionTokenIssuerTest {
 
     private byte[] masterKey;
-    private ExecutionTokenService service;
+    private HmacExecutionTokenIssuer service;
 
     @BeforeEach
     void setUp() {
         masterKey = new byte[32];
         new SecureRandom().nextBytes(masterKey);
-        service = new ExecutionTokenService(masterKey);
+        service = new HmacExecutionTokenIssuer(() -> masterKey);
     }
 
     @Test
     void mintAndValidate_validToken_returnsPayload() {
         String token = service.mint("user-123", "wf-456", List.of("GITHUB_TOKEN"), 3600);
 
-        ExecutionTokenService.TokenPayload payload = service.validate(token);
+        ExecutionTokenIssuer.TokenPayload payload = service.validate(token);
 
         assertThat(payload.userId()).isEqualTo("user-123");
         assertThat(payload.executionId()).isEqualTo("wf-456");
@@ -62,7 +66,7 @@ class ExecutionTokenServiceTest {
         String token = signingInput + "." + sig;
 
         assertThatThrownBy(() -> service.validate(token))
-                .isInstanceOf(ExecutionTokenService.TokenExpiredException.class);
+                .isInstanceOf(ExecutionTokenIssuer.TokenExpiredException.class);
     }
 
     @Test
@@ -72,7 +76,7 @@ class ExecutionTokenServiceTest {
         String tampered = token.substring(0, token.length() - 1) + "X";
 
         assertThatThrownBy(() -> service.validate(tampered))
-                .isInstanceOf(ExecutionTokenService.TokenInvalidException.class);
+                .isInstanceOf(ExecutionTokenIssuer.TokenInvalidException.class);
     }
 
     @Test
@@ -86,25 +90,25 @@ class ExecutionTokenServiceTest {
         String tampered = parts[0] + "." + fakePayload + "." + parts[2];
 
         assertThatThrownBy(() -> service.validate(tampered))
-                .isInstanceOf(ExecutionTokenService.TokenInvalidException.class);
+                .isInstanceOf(ExecutionTokenIssuer.TokenInvalidException.class);
     }
 
     @Test
     void revoke_invalidatesToken() {
         String token = service.mint("user-1", "wf-1", List.of(), 3600);
-        ExecutionTokenService.TokenPayload payload = service.validate(token);
+        ExecutionTokenIssuer.TokenPayload payload = service.validate(token);
 
         service.revoke(payload.jti(), payload.exp());
 
         assertThatThrownBy(() -> service.validate(token))
-                .isInstanceOf(ExecutionTokenService.TokenRevokedException.class);
+                .isInstanceOf(ExecutionTokenIssuer.TokenRevokedException.class);
     }
 
     @Test
     void mint_usesMaxTtl_forLongRunningExecution() {
         // execution_timeout=6000 → exp should be ~6000s from now, not 1h
         String token = service.mint("u", "wf", List.of(), 6000);
-        ExecutionTokenService.TokenPayload payload = service.validate(token);
+        ExecutionTokenIssuer.TokenPayload payload = service.validate(token);
 
         long ttl = payload.exp() - Instant.now().getEpochSecond();
         assertThat(ttl).isGreaterThan(5000); // roughly 6000s
@@ -114,10 +118,10 @@ class ExecutionTokenServiceTest {
     void validate_sameKey_succeeds() throws Exception {
         byte[] key = new byte[32];
         new SecureRandom().nextBytes(key);
-        ExecutionTokenService svc = new ExecutionTokenService(key);
-        ExecutionTokenService otherSvc = new ExecutionTokenService(key); // same key
-        String token = otherSvc.mint("u", "wf", List.of(), 3600);
+        HmacExecutionTokenIssuer issuer = new HmacExecutionTokenIssuer(() -> key);
+        HmacExecutionTokenIssuer otherIssuer = new HmacExecutionTokenIssuer(() -> key); // same key
+        String token = otherIssuer.mint("u", "wf", List.of(), 3600);
         // This should pass (same key)
-        assertThatCode(() -> svc.validate(token)).doesNotThrowAnyException();
+        assertThatCode(() -> issuer.validate(token)).doesNotThrowAnyException();
     }
 }

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/AgentEventListenerTokenRevocationTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/AgentEventListenerTokenRevocationTest.java
@@ -18,7 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.netflix.conductor.model.WorkflowModel;
 
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
+import dev.agentspan.runtime.credentials.HmacExecutionTokenIssuer;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 @ExtendWith(MockitoExtension.class)
 class AgentEventListenerTokenRevocationTest {
@@ -26,21 +27,21 @@ class AgentEventListenerTokenRevocationTest {
     @Mock
     private AgentStreamRegistry streamRegistry;
 
-    private ExecutionTokenService tokenService;
+    private ExecutionTokenIssuer tokenIssuer;
     private AgentEventListener listener;
 
     @BeforeEach
     void setUp() {
         byte[] key = new byte[32];
         new SecureRandom().nextBytes(key);
-        tokenService = spy(new ExecutionTokenService(key));
-        listener = new AgentEventListener(streamRegistry, tokenService);
+        tokenIssuer = spy(new HmacExecutionTokenIssuer(() -> key));
+        listener = new AgentEventListener(streamRegistry, tokenIssuer);
     }
 
     @Test
     void onWorkflowTerminated_revokesExecutionToken() {
-        String token = tokenService.mint("u1", "wf-1", List.of(), 3600);
-        ExecutionTokenService.TokenPayload payload = tokenService.validate(token);
+        String token = tokenIssuer.mint("u1", "wf-1", List.of(), 3600);
+        ExecutionTokenIssuer.TokenPayload payload = tokenIssuer.validate(token);
 
         WorkflowModel workflow = new WorkflowModel();
         workflow.setWorkflowId("wf-1");
@@ -49,13 +50,13 @@ class AgentEventListenerTokenRevocationTest {
 
         listener.onWorkflowTerminatedIfEnabled(workflow);
 
-        verify(tokenService).revoke(payload.jti(), payload.exp());
+        verify(tokenIssuer).revoke(payload.jti(), payload.exp());
     }
 
     @Test
     void onWorkflowCompleted_revokesExecutionToken() {
-        String token = tokenService.mint("u1", "wf-2", List.of(), 3600);
-        ExecutionTokenService.TokenPayload payload = tokenService.validate(token);
+        String token = tokenIssuer.mint("u1", "wf-2", List.of(), 3600);
+        ExecutionTokenIssuer.TokenPayload payload = tokenIssuer.validate(token);
 
         WorkflowModel workflow = new WorkflowModel();
         workflow.setWorkflowId("wf-2");
@@ -65,6 +66,6 @@ class AgentEventListenerTokenRevocationTest {
 
         listener.onWorkflowCompletedIfEnabled(workflow);
 
-        verify(tokenService).revoke(payload.jti(), payload.exp());
+        verify(tokenIssuer).revoke(payload.jti(), payload.exp());
     }
 }

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/AgentServiceTokenTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/service/AgentServiceTokenTest.java
@@ -24,7 +24,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import dev.agentspan.runtime.context.*;
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
+import dev.agentspan.runtime.credentials.HmacExecutionTokenIssuer;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 @ExtendWith(MockitoExtension.class)
 class AgentServiceTokenTest {
@@ -57,13 +58,13 @@ class AgentServiceTokenTest {
     private dev.agentspan.runtime.util.ProviderValidator providerValidator;
 
     private AgentService agentService;
-    private ExecutionTokenService tokenService;
+    private ExecutionTokenIssuer tokenIssuer;
 
     @BeforeEach
     void setUp() {
         byte[] key = new byte[32];
         new SecureRandom().nextBytes(key);
-        tokenService = new ExecutionTokenService(key);
+        tokenIssuer = new HmacExecutionTokenIssuer(() -> key);
 
         agentService = new AgentService(
                 agentCompiler,
@@ -75,7 +76,7 @@ class AgentServiceTokenTest {
                 streamRegistry,
                 executionService,
                 providerValidator,
-                tokenService);
+                tokenIssuer);
 
         RequestContextHolder.set(RequestContext.builder()
                 .requestId("r1")
@@ -123,7 +124,7 @@ class AgentServiceTokenTest {
         assertThat(ctx).containsKey("execution_token");
 
         String executionToken = (String) ctx.get("execution_token");
-        ExecutionTokenService.TokenPayload payload = tokenService.validate(executionToken);
+        ExecutionTokenIssuer.TokenPayload payload = tokenIssuer.validate(executionToken);
         assertThat(payload.userId()).isEqualTo("user-999");
         assertThat(payload.declaredNames()).containsExactlyInAnyOrder("AGENT_LEVEL", "REQUEST_LEVEL");
         assertThat(input.get("credentials")).isEqualTo(List.of("REQUEST_LEVEL"));

--- a/server/conductor-agentspan/build.gradle
+++ b/server/conductor-agentspan/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
     testImplementation "org.assertj:assertj-core:${assertjVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "com.tngtech.archunit:archunit-junit5:${archunitVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testImplementation 'org.graalvm.polyglot:polyglot:25.0.2'

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/ai/AgentspanAIModelProvider.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/ai/AgentspanAIModelProvider.java
@@ -30,7 +30,7 @@ import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
 
 import dev.agentspan.runtime.context.RequestContextHolder;
 import dev.agentspan.runtime.credentials.CredentialResolutionService;
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 import okhttp3.OkHttpClient;
 
@@ -77,18 +77,18 @@ public class AgentspanAIModelProvider extends AIModelProvider {
             Map.entry("azureopenai", "AZURE_OPENAI_BASE_URL"));
 
     private final CredentialResolutionService resolutionService;
-    private final ExecutionTokenService tokenService;
+    private final ExecutionTokenIssuer tokenIssuer;
 
     public AgentspanAIModelProvider(
             List<ModelConfiguration<? extends AIModel>> modelConfigurations,
             Environment env,
             OkHttpClient conductorAiHttpClient,
             CredentialResolutionService resolutionService,
-            ExecutionTokenService tokenService) {
+            ExecutionTokenIssuer tokenIssuer) {
         super(modelConfigurations, env);
         this.conductorAiHttpClient = conductorAiHttpClient;
         this.resolutionService = resolutionService;
-        this.tokenService = tokenService;
+        this.tokenIssuer = tokenIssuer;
         log.info("AgentspanAIModelProvider initialized (per-user credential resolution enabled)");
     }
 
@@ -183,7 +183,7 @@ public class AgentspanAIModelProvider extends AIModelProvider {
             }
             if (token == null) return null;
 
-            return tokenService.validate(token).userId();
+            return tokenIssuer.validate(token).userId();
         } catch (Exception e) {
             return null;
         }

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/AgentExceptionHandler.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/AgentExceptionHandler.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import dev.agentspan.runtime.credentials.CredentialResolutionService;
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 @ControllerAdvice
 public class AgentExceptionHandler {
@@ -36,9 +36,9 @@ public class AgentExceptionHandler {
     }
 
     @ExceptionHandler({
-        ExecutionTokenService.TokenInvalidException.class,
-        ExecutionTokenService.TokenExpiredException.class,
-        ExecutionTokenService.TokenRevokedException.class
+        ExecutionTokenIssuer.TokenInvalidException.class,
+        ExecutionTokenIssuer.TokenExpiredException.class,
+        ExecutionTokenIssuer.TokenRevokedException.class
     })
     public ResponseEntity<Map<String, Object>> handleTokenError(RuntimeException ex) {
         Map<String, Object> body = new LinkedHashMap<>();

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/WorkerController.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/WorkerController.java
@@ -18,8 +18,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.*;
 
 import dev.agentspan.runtime.credentials.CredentialResolutionService;
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
 import dev.agentspan.runtime.model.credentials.ResolveRequest;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 import lombok.RequiredArgsConstructor;
 
@@ -48,7 +48,7 @@ public class WorkerController {
     private static final Logger log = LoggerFactory.getLogger(WorkerController.class);
 
     private final CredentialResolutionService resolutionService;
-    private final ExecutionTokenService tokenService;
+    private final ExecutionTokenIssuer tokenIssuer;
 
     /** Per-token fixed-window rate limiter (jti+minute → count). */
     private final ConcurrentHashMap<String, RateLimitBucket> rateLimitMap = new ConcurrentHashMap<>();
@@ -73,14 +73,14 @@ public class WorkerController {
             return ResponseEntity.ok(Map.of());
         }
 
-        ExecutionTokenService.TokenPayload payload;
+        ExecutionTokenIssuer.TokenPayload payload;
         try {
-            payload = tokenService.validate(request.getToken());
-        } catch (ExecutionTokenService.TokenExpiredException e) {
+            payload = tokenIssuer.validate(request.getToken());
+        } catch (ExecutionTokenIssuer.TokenExpiredException e) {
             return ResponseEntity.status(401).body(Map.of("error", "Token expired"));
-        } catch (ExecutionTokenService.TokenRevokedException e) {
+        } catch (ExecutionTokenIssuer.TokenRevokedException e) {
             return ResponseEntity.status(401).body(Map.of("error", "Token revoked"));
-        } catch (ExecutionTokenService.TokenInvalidException e) {
+        } catch (ExecutionTokenIssuer.TokenInvalidException e) {
             return ResponseEntity.status(401).body(Map.of("error", "Token invalid"));
         }
 

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareHttpTask.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareHttpTask.java
@@ -19,6 +19,8 @@ import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.tasks.http.HttpTask;
 import com.netflix.conductor.tasks.http.providers.RestTemplateProvider;
 
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
+
 /**
  * Extends Conductor's HttpTask to resolve credential placeholders in HTTP
  * headers before execution.  Placeholders arrive as {@code #{NAME}} because
@@ -35,16 +37,16 @@ public class CredentialAwareHttpTask extends HttpTask {
     private static final Logger log = LoggerFactory.getLogger(CredentialAwareHttpTask.class);
     private static final Pattern PLACEHOLDER = Pattern.compile("#\\{([\\w.]+)}");
 
-    private final ExecutionTokenService tokenService;
+    private final ExecutionTokenIssuer tokenIssuer;
     private final CredentialResolutionService resolutionService;
 
     public CredentialAwareHttpTask(
             RestTemplateProvider restTemplateProvider,
             ObjectMapper objectMapper,
-            ExecutionTokenService tokenService,
+            ExecutionTokenIssuer tokenIssuer,
             CredentialResolutionService resolutionService) {
         super(restTemplateProvider, objectMapper);
-        this.tokenService = tokenService;
+        this.tokenIssuer = tokenIssuer;
         this.resolutionService = resolutionService;
     }
 
@@ -109,7 +111,7 @@ public class CredentialAwareHttpTask extends HttpTask {
         }
         if (token == null) return null;
         try {
-            return tokenService.validate(token).userId();
+            return tokenIssuer.validate(token).userId();
         } catch (Exception e) {
             log.warn("Failed to validate token for header resolution: {}", e.getMessage());
             return null;

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareHttpTaskConfig.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareHttpTaskConfig.java
@@ -12,6 +12,8 @@ import org.springframework.context.annotation.Primary;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.conductor.tasks.http.providers.RestTemplateProvider;
 
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
+
 /**
  * Registers {@link CredentialAwareHttpTask} as the primary HTTP system task,
  * overriding Conductor's default HttpTask.
@@ -35,8 +37,8 @@ public class CredentialAwareHttpTaskConfig {
     public CredentialAwareHttpTask credentialAwareHttpTask(
             RestTemplateProvider restTemplateProvider,
             ObjectMapper objectMapper,
-            ExecutionTokenService tokenService,
+            ExecutionTokenIssuer tokenIssuer,
             CredentialResolutionService resolutionService) {
-        return new CredentialAwareHttpTask(restTemplateProvider, objectMapper, tokenService, resolutionService);
+        return new CredentialAwareHttpTask(restTemplateProvider, objectMapper, tokenIssuer, resolutionService);
     }
 }

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareMcpService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/CredentialAwareMcpService.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Component;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
 
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
+
 import io.modelcontextprotocol.spec.McpSchema;
 import okhttp3.OkHttpClient;
 
@@ -47,15 +49,15 @@ public class CredentialAwareMcpService extends MCPService {
     private static final Logger log = LoggerFactory.getLogger(CredentialAwareMcpService.class);
     private static final Pattern PLACEHOLDER = Pattern.compile("#\\{([\\w.]+)}");
 
-    private final ExecutionTokenService tokenService;
+    private final ExecutionTokenIssuer tokenIssuer;
     private final CredentialResolutionService resolutionService;
 
     public CredentialAwareMcpService(
             OkHttpClient conductorAiHttpClient,
-            ExecutionTokenService tokenService,
+            ExecutionTokenIssuer tokenIssuer,
             CredentialResolutionService resolutionService) {
         super(conductorAiHttpClient);
-        this.tokenService = tokenService;
+        this.tokenIssuer = tokenIssuer;
         this.resolutionService = resolutionService;
     }
 
@@ -141,7 +143,7 @@ public class CredentialAwareMcpService extends MCPService {
         }
         if (token == null) return null;
         try {
-            return tokenService.validate(token).userId();
+            return tokenIssuer.validate(token).userId();
         } catch (Exception e) {
             log.warn("Failed to validate token for MCP header resolution: {}", e.getMessage());
             return null;

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentEventListener.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentEventListener.java
@@ -21,8 +21,8 @@ import com.netflix.conductor.core.listener.WorkflowStatusListener;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
 import dev.agentspan.runtime.model.AgentSSEEvent;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -48,7 +48,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
     private final MeterRegistry meterRegistry;
 
     @Autowired(required = false)
-    private ExecutionTokenService executionTokenService;
+    private ExecutionTokenIssuer executionTokenIssuer;
 
     @Autowired
     public AgentEventListener(AgentStreamRegistry streamRegistry, MeterRegistry meterRegistry) {
@@ -58,10 +58,10 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
     }
 
     /** Package-private constructor for testing with token revocation. */
-    AgentEventListener(AgentStreamRegistry streamRegistry, ExecutionTokenService tokenService) {
+    AgentEventListener(AgentStreamRegistry streamRegistry, ExecutionTokenIssuer tokenIssuer) {
         this.streamRegistry = streamRegistry;
         this.meterRegistry = null;
-        this.executionTokenService = tokenService;
+        this.executionTokenIssuer = tokenIssuer;
     }
 
     // ── TaskStatusListener ───────────────────────────────────────────
@@ -247,7 +247,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
 
         Map<String, Object> output = workflow.getOutput();
         emit(wfId, AgentSSEEvent.done(wfId, output));
-        if (executionTokenService != null) {
+        if (executionTokenIssuer != null) {
             revokeWorkflowToken(workflow);
         }
         streamRegistry.complete(wfId);
@@ -259,7 +259,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
         recordWorkflowAIMetrics(workflow);
         String reason = workflow.getReasonForIncompletion();
         emit(wfId, AgentSSEEvent.error(wfId, "workflow", reason != null ? reason : "Workflow terminated"));
-        if (executionTokenService != null) {
+        if (executionTokenIssuer != null) {
             revokeWorkflowToken(workflow);
         }
         streamRegistry.complete(wfId);
@@ -272,8 +272,8 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
             if (!(ctx instanceof Map)) return;
             Object tokenObj = ((Map<?, ?>) ctx).get("execution_token");
             if (!(tokenObj instanceof String token)) return;
-            ExecutionTokenService.TokenPayload payload = executionTokenService.validate(token);
-            executionTokenService.revoke(payload.jti(), payload.exp());
+            ExecutionTokenIssuer.TokenPayload payload = executionTokenIssuer.validate(token);
+            executionTokenIssuer.revoke(payload.jti(), payload.exp());
             logger.info("Execution token revoked for terminated workflow {}", workflow.getWorkflowId());
         } catch (Exception e) {
             logger.debug(

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -45,9 +45,9 @@ import com.netflix.conductor.service.WorkflowService;
 import dev.agentspan.runtime.compiler.AgentCompiler;
 import dev.agentspan.runtime.compiler.MultiAgentCompiler;
 import dev.agentspan.runtime.context.RequestContextHolder;
-import dev.agentspan.runtime.credentials.ExecutionTokenService;
 import dev.agentspan.runtime.model.*;
 import dev.agentspan.runtime.normalizer.NormalizerRegistry;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
 import dev.agentspan.runtime.util.ModelParser;
 import dev.agentspan.runtime.util.ProviderValidator;
 
@@ -71,7 +71,7 @@ public class AgentService {
     private final ProviderValidator providerValidator;
 
     @Autowired(required = false)
-    private ExecutionTokenService executionTokenService;
+    private ExecutionTokenIssuer executionTokenIssuer;
 
     @Autowired(required = false)
     private SkillRegistryService skillRegistryService;
@@ -96,7 +96,7 @@ public class AgentService {
     @Autowired(required = false)
     private MetadataService metadataService;
 
-    /** Package-private constructor for testing with ExecutionTokenService */
+    /** Package-private constructor for testing with ExecutionTokenIssuer */
     AgentService(
             AgentCompiler agentCompiler,
             NormalizerRegistry normalizerRegistry,
@@ -107,7 +107,7 @@ public class AgentService {
             AgentStreamRegistry streamRegistry,
             ExecutionService executionService,
             ProviderValidator providerValidator,
-            ExecutionTokenService executionTokenService) {
+            ExecutionTokenIssuer executionTokenIssuer) {
         this.agentCompiler = agentCompiler;
         this.normalizerRegistry = normalizerRegistry;
         this.executionDAO = executionDAO;
@@ -117,7 +117,7 @@ public class AgentService {
         this.streamRegistry = streamRegistry;
         this.executionService = executionService;
         this.providerValidator = providerValidator;
-        this.executionTokenService = executionTokenService;
+        this.executionTokenIssuer = executionTokenIssuer;
     }
 
     /**
@@ -334,7 +334,7 @@ public class AgentService {
                 idGenerator != null ? idGenerator.generate() : UUID.randomUUID().toString();
 
         // Mint execution token and embed in workflow variables for worker credential resolution
-        if (executionTokenService != null) {
+        if (executionTokenIssuer != null) {
             try {
                 long timeoutSeconds = config.getTimeoutSeconds() > 0 ? config.getTimeoutSeconds() : 0;
                 List<String> declaredNames = extractDeclaredCredentials(config);
@@ -350,7 +350,7 @@ public class AgentService {
                 }
                 String currentUserId = principal;
                 if (currentUserId != null) {
-                    String token = executionTokenService.mint(
+                    String token = executionTokenIssuer.mint(
                             currentUserId, preallocatedExecutionId, declaredNames, timeoutSeconds);
                     Map<String, Object> agentCtx = new LinkedHashMap<>();
                     agentCtx.put("execution_token", token);

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/spi/ExecutionTokenIssuer.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/spi/ExecutionTokenIssuer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License.
+ */
+package dev.agentspan.runtime.spi;
+
+import java.util.List;
+
+/**
+ * Strategy interface for minting, validating and revoking the short-lived execution tokens that
+ * authorize a worker to resolve a bounded set of credentials for one execution.
+ *
+ * <p>The standalone server ships an HMAC-SHA256 implementation signed with the master key and an
+ * in-memory jti deny-list; an embedding host (e.g. orkes-conductor) can supply an asymmetric or
+ * KMS-backed signer and a durable (e.g. Redis) revocation list. The token wire format is an
+ * implementation concern — callers only depend on this contract and {@link TokenPayload}.</p>
+ */
+public interface ExecutionTokenIssuer {
+
+    /**
+     * Mint a new execution token.
+     *
+     * @param userId         the authenticated user's ID (or username for login tokens)
+     * @param executionId    the execution ID (or "login" for login tokens)
+     * @param declaredNames  credential names declared by the agent (bounds resolution)
+     * @param executionTimeoutSeconds execution timeout; TTL = max(3600, executionTimeoutSeconds)
+     * @return signed token string
+     */
+    String mint(String userId, String executionId, List<String> declaredNames, long executionTimeoutSeconds);
+
+    /**
+     * Validate a token and return its payload.
+     *
+     * @throws TokenExpiredException  if exp is in the past
+     * @throws TokenRevokedException  if jti is in the deny-list
+     * @throws TokenInvalidException  if signature or structure is invalid
+     */
+    TokenPayload validate(String token);
+
+    /**
+     * Revoke a token by its jti. Called when an execution is cancelled or terminated.
+     *
+     * @param jti the unique token ID
+     * @param exp the token's expiry epoch second (for self-pruning)
+     */
+    void revoke(String jti, long exp);
+
+    // ── Value types ───────────────────────────────────────────────────
+
+    record TokenPayload(String jti, String userId, String executionId, long exp, List<String> declaredNames) {}
+
+    class TokenInvalidException extends RuntimeException {
+        public TokenInvalidException(String msg) {
+            super(msg);
+        }
+    }
+
+    class TokenExpiredException extends RuntimeException {
+        public TokenExpiredException(String msg) {
+            super(msg);
+        }
+    }
+
+    class TokenRevokedException extends RuntimeException {
+        public TokenRevokedException(String msg) {
+            super(msg);
+        }
+    }
+}

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/spi/MasterKeyProvider.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/spi/MasterKeyProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License.
+ */
+package dev.agentspan.runtime.spi;
+
+/**
+ * Strategy interface for sourcing the AES-256 master key used to protect credentials at rest
+ * (AES-256-GCM in the encrypted store) and to sign execution tokens (HMAC-SHA256).
+ *
+ * <p>The standalone server ships a file/env implementation (key from {@code AGENTSPAN_MASTER_KEY},
+ * else auto-generated and persisted to {@code ~/.agentspan/master.key}); an embedding host
+ * (e.g. orkes-conductor) can supply AWS KMS, HashiCorp Vault, Azure Key Vault, GCP KMS, etc.
+ * All implementations feed the same key material into the credential-crypto pipeline.</p>
+ */
+public interface MasterKeyProvider {
+
+    /**
+     * Return the 32-byte (256-bit) master key. Implementations must return the same key for the
+     * lifetime of the process — losing or rotating it invalidates all stored credentials and any
+     * outstanding execution tokens.
+     */
+    byte[] getMasterKey();
+}

--- a/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/architecture/LibraryPurityTest.java
+++ b/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/architecture/LibraryPurityTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License.
+ */
+package dev.agentspan.runtime.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import dev.agentspan.runtime.spi.CredentialStoreProvider;
+import dev.agentspan.runtime.spi.ExecutionTokenIssuer;
+import dev.agentspan.runtime.spi.MasterKeyProvider;
+import dev.agentspan.runtime.spi.SecretOutputMasker;
+import dev.agentspan.runtime.spi.SkillMetadataDAO;
+import dev.agentspan.runtime.spi.SkillPackageStore;
+
+/**
+ * Library-purity check ("AgentSpan as a library" §9).
+ *
+ * <p>The {@code conductor-agentspan} library defines the SPI <b>interfaces</b> and the logic that
+ * operates on them; the concrete store/crypto <b>implementations</b> are a host concern, living in
+ * {@code conductor-agentspan-server} (OSS defaults) or in an embedding host (e.g. orkes-conductor).
+ * These rules statically enforce that boundary on the library's own bytecode — they fail if a
+ * concrete impl ever leaks back into the library.
+ *
+ * <p>Why ArchUnit and not {@code @SpringBootTest}: this is a claim about the <i>classes in the
+ * jar</i>, not about bean wiring. Static analysis sees every class (including ones that are not
+ * Spring beans); a context-boot test only sees what gets registered, and would merely re-derive the
+ * module dependency graph that already forbids depending on the server.
+ *
+ * <p>Tests are excluded from the import ({@link ImportOption.DoNotIncludeTests}) so the in-test
+ * fakes used elsewhere never count as violations.
+ */
+@AnalyzeClasses(packages = "dev.agentspan.runtime", importOptions = ImportOption.DoNotIncludeTests.class)
+class LibraryPurityTest {
+
+    /**
+     * No class in the library may implement an SPI — implementations are contributed by the host.
+     * This is the core of the dependency-inversion design.
+     */
+    @ArchTest
+    static final ArchRule library_contains_no_spi_implementations = noClasses()
+            .should()
+            .implement(CredentialStoreProvider.class)
+            .orShould()
+            .implement(ExecutionTokenIssuer.class)
+            .orShould()
+            .implement(MasterKeyProvider.class)
+            .orShould()
+            .implement(SecretOutputMasker.class)
+            .orShould()
+            .implement(SkillMetadataDAO.class)
+            .orShould()
+            .implement(SkillPackageStore.class)
+            .because("SPI implementations belong to a host module (conductor-agentspan-server / "
+                    + "orkes-conductor); the library defines the interfaces only");
+
+    /**
+     * No class in the library may touch a persistence backend. Storage is behind the SPIs, and the
+     * host that implements them brings the JDBC/connection-pool dependencies.
+     */
+    @ArchTest
+    static final ArchRule library_does_not_depend_on_persistence_backends = noClasses()
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage("javax.sql..", "org.springframework.jdbc..", "com.zaxxer.hikari..")
+            .because("persistence backends belong to the host module that implements the storage "
+                    + "SPIs, not the engine-neutral library");
+
+    /**
+     * No class in the library may perform cryptography — that belongs to host-supplied SPI impls
+     * (the encrypted secret store behind {@code CredentialStoreProvider}, the HMAC token signer
+     * behind {@code ExecutionTokenIssuer}).
+     *
+     * <p>The former Phase-1 exception for {@code ExecutionTokenService} is gone: its HMAC impl was
+     * extracted to {@code HmacExecutionTokenIssuer} in the server, leaving the library crypto-free.
+     */
+    @ArchTest
+    static final ArchRule library_does_not_perform_cryptography = noClasses()
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage("javax.crypto..")
+            .because("cryptography belongs to host-supplied SPI implementations "
+                    + "(CredentialStoreProvider, ExecutionTokenIssuer), not the engine-neutral library");
+}


### PR DESCRIPTION
## Phase 1 — SPI extraction

Establishes the library/host **dependency-inversion boundary** for credential infrastructure. The engine-neutral `conductor-agentspan` library now defines **SPI interfaces only**; the concrete crypto / key-sourcing implementations live in `conductor-agentspan-server` (and can be replaced by an embedding host, e.g. orkes-conductor, with KMS/Vault-backed variants).

### Master key
- **New SPI** `dev.agentspan.runtime.spi.MasterKeyProvider` (lib).
- **Impl** `FileEnvMasterKeyProvider` (server) — `AGENTSPAN_MASTER_KEY` env var, else auto-generate `~/.agentspan/master.key`. Memoized.
- Removed the old `MasterKeyConfig` and its `credentialMasterKey` `byte[]` bean bridge — `EncryptedDbCredentialStoreProvider` and the token issuer now depend on the SPI directly.

### Execution tokens
- **New SPI** `dev.agentspan.runtime.spi.ExecutionTokenIssuer` (lib) — `mint` / `validate` / `revoke` + `TokenPayload` and exception types.
- **Impl** `HmacExecutionTokenIssuer` (server) — HMAC-SHA256 signing, constant-time verify, in-memory jti deny-list + scheduled pruning.
- This resolves the **Phase-1 debt** the purity test predicted: the library is now crypto-free.
- Renamed `tokenService` / `executionTokenService` fields to `tokenIssuer` to match the type.

### Enforcement
- `LibraryPurityTest`: added `MasterKeyProvider` and `ExecutionTokenIssuer` to the no-impl rule; **removed the crypto exception** (now unconditional). Added the ArchUnit test dependency.

## Testing
- Both modules' full test suites pass (`:conductor-agentspan:test`, `:conductor-agentspan-server:test`).
- CI lint gate passes (`spotlessCheck`, `checkNoInlineFQN`).
- Verified the tightened purity rules have teeth: a temporary lib class implementing the SPIs and touching `javax.crypto` tripped both the no-impl and crypto rules; removed after confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)