### PR TITLE
ci: publish server to Maven Central on release + add GitHub Packages

### DIFF
--- a/.github/workflows/release-server-maven.yml
+++ b/.github/workflows/release-server-maven.yml
@@ -1,6 +1,8 @@
 name: Publish Server to Maven Central
 
 on:
+  release:
+    types: [created]
   workflow_dispatch:
     inputs:
       version:
@@ -31,12 +33,17 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          VERSION="${{ inputs.version }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Publishing version: ${VERSION}"
 
       # Publishes both modules (conductor-agentspan, conductor-agentspan-server)
-      # under org.conductoross.conductor. The runnable fat jar is released
+      # under org.conductoross. The runnable fat jar is released
       # separately via the S3/GitHub workflow, not to Maven Central.
       - name: Publish to Maven Central
         run: |
@@ -48,3 +55,49 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+
+  publish-github-packages:
+    runs-on: ubuntu-latest
+    # Least privilege: GitHub Packages only needs to write packages with the
+    # built-in GITHUB_TOKEN. No Sonatype/signing secrets or protected
+    # environment required, so this is a separate job from Maven Central.
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        working-directory: server
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Zulu JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "21"
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: ${VERSION}"
+
+      # Publishes both modules to GitHub Packages
+      # (https://maven.pkg.github.com/${{ github.repository }}). Unsigned —
+      # GitHub Packages does not require GPG signatures, so no signing secrets
+      # are passed here (the vanniktech block only signs when a signing key is
+      # present). The runnable fat jar is released via the S3/GitHub workflow.
+      - name: Publish to GitHub Packages
+        run: |
+          ./gradlew publishAllPublicationsToGitHubPackagesRepository --no-configuration-cache \
+            -Pversion=${{ steps.version.outputs.version }}
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -84,6 +84,30 @@ subprojects {
         options.addStringOption('Xdoclint:none', '-quiet')
         failOnError = false
     }
+
+    // Second publish target: GitHub Packages (Maven registry at
+    // https://maven.pkg.github.com/<owner>/<repo>). Maven Central itself is
+    // configured per-module via the vanniktech `mavenPublishing` block and the
+    // `publishAndReleaseToMavenCentral` task; this adds GitHub Packages as an
+    // additional standard maven-publish repository. CI publishes to it with
+    // `publishAllPublicationsToGitHubPackagesRepository`. Credentials are read
+    // from the GITHUB_ACTOR / GITHUB_TOKEN env vars set by the release workflow;
+    // they are only required when the publish task actually runs, so local
+    // `./gradlew tasks` and Maven Central publishing are unaffected.
+    plugins.withId('maven-publish') {
+        publishing {
+            repositories {
+                maven {
+                    name = 'GitHubPackages'
+                    url = uri("https://maven.pkg.github.com/${System.getenv('GITHUB_REPOSITORY') ?: 'agentspan-ai/agentspan'}")
+                    credentials {
+                        username = System.getenv('GITHUB_ACTOR')
+                        password = System.getenv('GITHUB_TOKEN')
+                    }
+                }
+            }
+        }
+    }
 }
 
 // ── Code formatting ──────────────────────────────────────────────


### PR DESCRIPTION
## Why

`release-server-maven.yml` ("Publish Server to Maven Central") only had a `workflow_dispatch` trigger, so creating the **v0.2.0** release never published the server modules — the job has to be run manually. The Python/JS SDK release workflows already fire on `release: [created]`; this brings the server Maven workflow in line.

## Changes

- **Release trigger:** add `release: [created]` to `release-server-maven.yml` (keeps `workflow_dispatch`), with the same version-extraction step the Python/JS SDK workflows use (`inputs.version` on dispatch, `tag_name` minus `v` on release).
- **GitHub Packages:** publish both modules (`conductor-agentspan`, `conductor-agentspan-server`) to GitHub Packages as a secondary Maven registry.
  - `server/build.gradle`: add a `GitHubPackages` maven repository to the `subprojects` publishing config (generates `publishAllPublicationsToGitHubPackagesRepository`). Credentials come from `GITHUB_ACTOR`/`GITHUB_TOKEN` and are only needed when the publish task runs, so local builds and Maven Central publishing are unaffected.
  - New `publish-github-packages` job: separate, least-privilege (`packages: write` + built-in `GITHUB_TOKEN`), no Sonatype/signing secrets or protected environment. Maven Central stays a distinct job.

> Note: this is **GitHub Packages** (`maven.pkg.github.com`), not GHCR — GHCR (`ghcr.io`) only stores container images, not Maven artifacts.

## Validation

- `./gradlew tasks` confirms both modules expose `publishAllPublicationsToGitHubPackagesRepository`; existing `publishAndReleaseToMavenCentral` path is untouched (targets are isolated).
- `publishToMavenLocal` of `conductor-agentspan` produces a plain library jar (175 classes, not a fat jar) + sources + javadoc, coordinates `org.conductoross:conductor-agentspan`, and ships the Spring `AutoConfiguration.imports` — i.e. the consumable library that PR #271 enables embedding.
- All 11 release workflow YAMLs parse; `release-server-maven.yml` now shows `triggers=[release, workflow_dispatch]`, `jobs=[publish-maven-central, publish-github-packages]`.

Relates to #271 (server library/app split — publishes the `conductor-agentspan` library for downstream Conductor distributions to consume).