### PR TITLE
docs(server): scope version-drift to three consumption modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ obj/
 *.user
 *.suo
 .vs/
+
+# Editor / tooling local config
+.vscode/
+.claude/

--- a/server/README.md
+++ b/server/README.md
@@ -376,6 +376,28 @@ The server is a Spring Boot application (Java 21) built on top of [Conductor](ht
 
 Tests use an in-memory SQLite database with AI providers disabled.
 
+### Releasing
+
+The server splits into two Maven artifacts — `conductor-agentspan` (the library a host like
+orkes-conductor embeds) and `conductor-agentspan-server` (the runnable standalone app) — plus the
+Docker image and S3 fat jar. Releases are still **manual `workflow_dispatch`** (no tag-driven
+fan-out). Because the library declares its Conductor deps `compileOnly`, the embedded engine version
+is **not** carried in the published POM, so version coupling is a release-time convention:
+
+- **Release the platform artifacts together — same version, same commit.** Dispatch the Maven,
+  Docker, and S3 release workflows from one commit with the same version string. Nothing enforces
+  this; a given build can't produce a mismatched lib/server pair (both read `project.version` and
+  the single `conductorVersion`), but separate dispatches with different inputs can.
+- **Record the Conductor version the release was *built against* in the release notes** — read it
+  off `conductorVersion` in `build.gradle` (e.g. "built/tested against Conductor 3.30.2"). State it
+  as a **fact, not a required range**: a declared "compatible with 3.30.x" would only be honest if
+  tested across that range and kept current — maintenance we don't want. The deps stay `compileOnly`
+  so the host's version still wins; this line is just the build-against breadcrumb the POM can't
+  carry. An embedding host certifies *its own* engine version with its own tests. See design doc §9.2.
+- **Keep `conductorVersion` a single variable** in `build.gradle`. It is the source of truth for
+  both modules; splitting it reintroduces silent lib↔server drift. A Conductor bump (on whichever
+  side bumps) is the event that warrants re-running the conformance suite on that engine.
+
 ### Project structure
 
 ```

--- a/server/docs/agentspan-as-a-library.md
+++ b/server/docs/agentspan-as-a-library.md
@@ -774,6 +774,34 @@ entirely; the published jar gets a point-fact, not a range.
 > take-the-jar + self-certify as the best-effort fallback. No maintained compatibility range, no new
 > abstraction.
 
+### 9.3 Upgrade & adoption
+
+Both paths consume **whole releases, never hand-swapped jars** — so API/ABI is the release
+producer's build-time concern (§9.2 self-certify), and the consuming customer's job is **data + ops
+only**.
+
+**Version upgrade** (existing AgentSpan deployment → newer release) — like any stateful app:
+
+- Two schema lifecycles migrate on startup: Conductor's (engine-owned) **and** AgentSpan's
+  `credentials_store`. Back up both datasources.
+- In-flight workflows must deserialize under the new engine — note **long-paused HITL**
+  (`AgentHumanTask`) makes such executions routine, not rare.
+- Rollback = **restore from backup** (Flyway is forward-only), not redeploy-old-artifact.
+
+**Adoption** (plain Conductor → +AgentSpan) is **additive**: it adds `credentials_store`, custom
+task types, and agent `WorkflowDef`s; existing Conductor data is untouched. Net-new concerns:
+
+- **Engine direction is `>=`, same major** (no downgrade: forward-only Flyway + model
+  serialization); *equal* = pure additive, no migration.
+  - **Mode A:** customer must pick a server release whose bundled engine `>=` theirs; if their
+    engine is ahead of every release, fall back to **Mode B**.
+  - **Mode B (build-from-source):** aligned to the host's own engine by construction.
+  - **Mode C:** `>=` auto-enforced by moving forward along orkes' release line; orkes owns it.
+- Host supplies one impl bean per SPI (no embedded default) — a missing one fails fast at startup.
+
+**Removal asymmetry:** backing AgentSpan out is clean *before* any agent runs (`credentials_store`
+is a harmless orphan); *after* agents exist, their custom `TASK_TYPE`s no longer resolve.
+
 ---
 
 ## 10. Risks & Open Questions (verify before/while coding)

--- a/server/docs/agentspan-as-a-library.md
+++ b/server/docs/agentspan-as-a-library.md
@@ -440,6 +440,11 @@ its own modules. AgentSpan currently compiles against `org.conductoross:conducto
 AgentSpan ships those as transitive `implementation` deps, we get a version clash on the host
 classpath.
 
+> This section covers the **build/classpath mechanics** of alignment. For *who owns* alignment in
+> each deployment, see the three-consumption-mode table in §9.2: Mode A (standalone) is drift-free
+> by construction, Mode C (orkes) is one host-pinned pair, and Mode B (external OSS self-embed) is
+> explicitly best-effort + self-certify.
+
 **Strategy — `compileOnly`/provided for ALL Conductor artifacts:**
 
 - `conductor-agentspan` declares `conductor-common`, `conductor-core`, `conductor-ai` (and
@@ -625,7 +630,8 @@ failing test that pins the target behavior.
    security context → `RequestContextHolder`.
 3. Smoke + integration test inside orkes: deploy an agent, start it, observe status, exercise a
    tool call. Confirm no bean conflicts, no path collisions, scheduler/SSE intact, and that a
-   missing SPI impl fails startup loudly.
+   missing SPI impl fails startup loudly. See §9.1 for the two embedded-mode e2e layers
+   (in-orkes server e2e + reused SDK e2e) and the version-pinning requirement.
 
 ---
 
@@ -657,6 +663,116 @@ New test types introduced:
 7. **Secret masking seam test** — with a non-no-op `SecretOutputMasker`, assert
    `CredentialMaskingResponseAdvice` redacts execution-read responses; with the no-op (OSS),
    assert payloads pass through unchanged. No real secrets/LLM — deterministic fixtures.
+
+### 9.1 Embedded-mode e2e (orkes repo)
+
+Test types 1–7 above cover the **standalone** module and the library boundary *in this repo*. The
+**embedded** deployment (AgentSpan-as-a-library inside orkes-conductor) is verified in the
+**orkes-conductor repo**, because that's the only side that can depend on both — orkes depends on
+`conductor-agentspan`, never the reverse (§3.1). It splits into two layers:
+
+1. **Server e2e (in-JVM, host-specific) — lives in orkes.** The Phase-4 §8 smoke/integration
+   tests: a `@SpringBootTest` that boots orkes' context with the embedded library **plus orkes'
+   own SPI impl beans**, then asserts deploy → start → status → tool-call, no bean conflicts, no
+   `/api/...` path collisions, scheduler/SSE intact, and that **omitting** an SPI impl fails
+   startup loudly. These compile against orkes' application class and its impl beans, so they
+   *cannot* live here — the dependency direction forbids it.
+
+2. **SDK e2e (black-box HTTP) — reused, not rewritten.** The existing per-language suites
+   (`sdk/{java,python,ts,csharp}`) are pure HTTP clients parameterized only by
+   `AGENTSPAN_SERVER_URL`; they don't depend on either server at the code level. So the **same
+   suites** run against a booted orkes instance — the only delta is the URL (and orkes' base
+   path/port). This is the behavioral-equivalence oracle: if the suites that pass against
+   `agentspan-runtime.jar` also pass against orkes, the embedding behaves identically.
+
+**Where the pipeline lives.** The embedded-e2e workflow is configured in the **orkes repo** (its
+CI secrets, runners, backing services — Postgres/Redis/ES). It: builds orkes-with-lib → boots it →
+runs layer 1 (its own tests) and layer 2 (agentspan's suites). orkes *reads* the agentspan repo
+for layer 2 (`actions/checkout` of the suite, or a published test artifact) — that's test input,
+not a build dependency, so the direction stays clean.
+
+**Version pinning (required).** Layer 2 is only a valid oracle for the exact server version it was
+written against. The embedded library coordinate
+(`dev.agentspan:conductor-agentspan:vX`), the checked-out suite (`ref: vX`), **and** the SDK
+client package the suite imports (`agentspan==X` / `@agentspan-ai/sdk@X` / Maven / NuGet) must all
+be the **same `vX`** — drive them from one `AGENTSPAN_VERSION` variable so they can't drift.
+Mismatched versions yield false failures (suite expects a field the lib doesn't emit) or false
+passes (suite too old to cover a new path). This is distinct from the §6 *Conductor*-version pin.
+
+**Validation stays LLM-free** in both layers (compile/start/status/tool-call assertions), same as
+the standalone e2e.
+
+### 9.2 Interoperability & version drift (scoped to three consumption modes)
+
+Conductor-version alignment is an **ongoing** concern, not a one-time "verify before coding" item:
+`compileOnly` means **nothing bundles or enforces an engine version — the host's classpath wins**,
+so a mismatch is silent until runtime. Two failure classes:
+
+1. **Linkage (ABI)** — `NoSuchMethodError`/`ClassNotFoundException` the first time a path hits a
+   method that moved or a class the host repackaged. The surface is small and enumerable: the
+   injected Conductor services (`WorkflowService`, `MetadataDAO`/`MetadataService`,
+   `ExecutionService`, `WorkflowExecutor`, `ExecutionDAO`), the extended base classes
+   (`WorkflowSystemTask`, `HttpTask`, `MCPService`), and `conductor-common` models on the public API
+   (`WorkflowDef`/`WorkflowTask` — §10.8).
+2. **Semantic** — even when it links, engines may differ (JOIN, sub-workflow, HTTP task, scheduler,
+   SSE). No static check; the **SDK conformance suite (§9.1 layer 2) is the only oracle** — "is it
+   interoperable" = "does the same suite pass on each engine."
+
+Rather than reason about "any host at any version," scope the concern to the **three concrete ways
+a consumer actually picks an AgentSpan + Conductor pair**. Each mode has a different owner and a
+different (or zero) drift risk:
+
+| Mode | What the consumer takes | AgentSpan ver. | Conductor ver. | Drift risk | Owner |
+| --- | --- | --- | --- | --- | --- |
+| **A — Standalone** | `conductor-agentspan-server` bootJar / Docker | our release | **fixed**, bundled | **none** (consistent by construction) | us |
+| **B — Self-embed (external OSS)** | `conductor-agentspan` library | library ver. | host-supplied, arbitrary | **real, unbounded** | the host |
+| **C — Enterprise embed** | `orkes-conductor` (embeds the library) | orkes picks | orkes pins (`3.30.0.rc8`) | **real, but single pinned pair** | orkes |
+
+**Mode A — drift-free by construction.** The standalone bootJar reads the **single**
+`conductorVersion` (`server/build.gradle`) at the same commit for both lib and server (§7), so the
+lib is always compiled against the engine it ships with. This protection holds *only* while it stays
+one variable — **don't split it.** No extra handling needed; the boot/smoke test already links lib
+against the bundled engine.
+
+**Mode C — one pinned pair, host-certified.** orkes pins its engine (`3.30.0.rc8`, §6) and runs its
+own integration + conformance suite against that pair. Compatibility is proven at *its* one version,
+re-validated whenever orkes bumps the engine. No range, no matrix — exactly one certified pair, owned
+by orkes.
+
+**Mode B — the genuinely open case; both sides are OSS, so the host owns the pairing.** When the
+external host runs a Conductor version that differs from our pinned `conductorVersion`, there are two
+paths, and we recommend the first:
+
+1. **Build from source against your engine (recommended).** Clone the repo, set `conductorVersion`
+   to *your* engine version, and build `conductor-agentspan` yourself. The library is then compiled
+   against the exact engine you run — drift is eliminated **by construction**, the same guarantee
+   Mode A gets, because the `compileOnly` deps resolve to your version at compile time. No trust, no
+   breadcrumb, no self-certify guesswork. This is the right path for anyone off our pinned version,
+   and it's the natural OSS answer: the source is right there.
+2. **Take the published jar + self-certify (fallback).** `conductor-agentspan` publishes to Maven
+   Central, and `compileOnly` deps **don't appear in the POM**, so the published jar is compiled
+   against *our* pinned `conductorVersion` and carries **no version constraint**. Drop it onto a
+   different engine and you are trusting ABI compatibility you haven't verified. We **cannot** and
+   **do not** promise this works across arbitrary versions. If you go this route:
+   - **We state only the point fact we get for free:** "built/tested against `conductorVersion`"
+     (auto-derived, always true, nothing to maintain). Surface it where the POM can't — release
+     notes / README, and a `Conductor-Built-Against` jar-manifest breadcrumb so a mismatch is
+     diagnosable at a glance rather than a bare runtime `NoSuchMethodError`. It is **informational,
+     not a constraint** (deps stay `compileOnly`, host's version still wins — §6).
+   - **The host self-certifies**, exactly as a JDBC driver vendor certifies against the spec rather
+     than the spec enumerating drivers. Re-running the SDK conformance suite (§9.1 layer 2) against
+     their engine is the only honest proof; the burden sits with the implementor.
+
+**A declared *range* is out of scope either way.** "Compatible with 3.30.x" is only honest if we test
+across it and keep re-testing as Conductor moves — the matrix maintenance we are deliberately not
+signing up for. An unverified range is a false promise. Build-from-source sidesteps the question
+entirely; the published jar gets a point-fact, not a range.
+
+> Why the residual risk is *only* drift, not structure: §4.1 keeps the interop surface tiny (no
+> execution SPI). Modes A and C are each a single pinned pair re-checked on bump; Mode B's
+> recommended path (build from source) inherits Mode A's by-construction guarantee, with
+> take-the-jar + self-certify as the best-effort fallback. No maintained compatibility range, no new
+> abstraction.
 
 ---
 

--- a/server/docs/agentspan-validation-readiness.md
+++ b/server/docs/agentspan-validation-readiness.md
@@ -1,0 +1,132 @@
+# AgentSpan — Testing, Deployment & Integration Validation: Scope & Gaps
+
+**Status:** Working notes (for review)
+**Owner:** validation / deployment side
+**Companion to:** [agentspan-as-a-library.md](agentspan-as-a-library.md) — §9.1 (embedded e2e), §9.2 (three modes & version drift), §9.3 (upgrade & adoption)
+
+This is a **gap analysis** of what the testing/deployment/integration-validation task still needs to
+cover, given the design now in `agentspan-as-a-library.md`. It is intentionally scoped to the
+*validation owner's* concerns, not the implementer's.
+
+---
+
+## Framing (settled in the design doc)
+
+- **Three consumption modes** (§9.2): **A** standalone server, **B** external OSS self-embed,
+  **C** orkes enterprise embed.
+- **Customers consume whole releases, never hand-swapped jars** → API/ABI is the *release
+  producer's* build-time concern (self-certify, §9.2). The consuming customer's job on upgrade is
+  **data + ops only**.
+- **Upgrade vs adoption** (§9.3): upgrade = stateful-app data migration; adoption (plain Conductor →
+  +AgentSpan) is **additive** with a `>=` same-major engine-direction rule.
+
+Everything below assumes that framing and asks: *what's still uncovered for validation?*
+
+---
+
+## Prerequisites — these gate everything else
+
+1. **Conformance-suite instrument — already exists, no need to build.** *(Corrected.)* The SDK e2e
+   suites (`sdk/{python,java,ts,csharp}/e2e/`) are **already** pure black-box HTTP clients
+   parameterized only by `AGENTSPAN_SERVER_URL` (`sdk/python/e2e/conftest.py`). Point the env var at
+   an embedded host and the *identical* suite runs — no code change. So the instrument is **not** a
+   gap. The real remaining work is (a) standing up the embedded target to point it at, and (b) the
+   reuse mechanism from the orkes repo — see "Reusing the suite from orkes" below.
+2. **§6 engine coordinates (Mode C blocker).** Which orkes module/artifact provides the engine
+   classes (`WorkflowExecutor`, `WorkflowSystemTask`, `ExecutionDAO`, `MetadataDAO`, …), and at what
+   version. Until pinned, Phase 4 can't start → nothing to integration-test. Upstream of this task
+   but blocks it.
+
+### Reusing the SDK e2e suite from the orkes repo
+
+The suite is reusable because it depends on the **SDK client package + a URL**, never on server
+code (test input, not a build dependency — keeps the §3.1 direction clean). "Reuse" = assemble three
+things at one matching `AGENTSPAN_VERSION`: the **suite files**, the **SDK client package** it
+imports, and **`AGENTSPAN_SERVER_URL`** pointed at the booted orkes instance.
+
+| Option | Mechanism | Status today | Notes |
+| --- | --- | --- | --- |
+| **A — checkout + in-repo run** | orkes `actions/checkout` of agentspan@`vX`, `pip install agentspan==vX`, `pytest e2e/` | **works now** (how agentspan CI runs it) | zero new infra; manual version discipline; orkes CI needs a Python/uv toolchain (or reuse the Java suite via `./gradlew test -Pe2e`) |
+| **B — published test artifact** | publish suite as a wheel / Maven test-jar; orkes pulls `vX` | **not built** | decouples from repo layout; agentspan must publish |
+| **C — conformance-runner container** | image with suite + client baked at `vX`; orkes `docker run -e AGENTSPAN_SERVER_URL=…` | **does NOT exist today** — proposed | best version-coherence (suite+client locked together), no Python toolchain in orkes CI; net-new Dockerfile + release workflow |
+
+- **Today there is no `agentspan/conformance` image.** The only Docker image is the *server*
+  (`server/Dockerfile` → `agentspan-runtime.jar`). The e2e suites run in-repo (pytest marker /
+  `-Pe2e`), not as a published artifact. So **today's only orkes-reuse path is Option A.**
+- **In every option the engine under test is the orkes conductor** — the suite/container is
+  engine-free and only drives the booted orkes instance over HTTP.
+- **Recommendation:** Option A to start (zero infra, matches §9.1); build **Option C** as the
+  end-state to make cross-repo version-pinning robust instead of manual. Small, high-leverage.
+
+---
+
+## Entirely uncovered dimensions
+
+3. **Security validation — biggest blind spot.** Not in scope anywhere yet:
+   - Two auth boundaries (per §2 secrets note): `SecretController` `/api/secrets` (login-JWT /
+     API-key) vs `WorkerController` `/api/workers/secrets` (HMAC execution-token, declared-name
+     bounded, rate-limited). Validate the token bounding actually holds.
+   - Output masking: `CredentialOutputMasker` redacts; no secret leakage in logs/payloads; masking
+     advice covers `/api/workflow/{id}` reads.
+   - **Embed only:** the security-context bridge (host identity → `RequestContextHolder`) does not
+     grant cross-tenant access.
+4. **Performance / regression baseline.** Does embedding AgentSpan (`@Primary` HttpTask/MCPService
+   overrides, the masking `@ControllerAdvice`) change engine throughput/latency? No baseline ⇒ can't
+   detect upgrade regressions.
+
+---
+
+## Deployment — mechanics not yet discussed
+
+5. **Post-deploy liveness, not just "context loads."** Deterministic smoke test proving agents
+   actually run end-to-end (define → start → terminal status). **No LLM-judged output** (per
+   `CLAUDE.md`) — assert on compile/start/status only.
+6. **Multi-replica / rolling-deploy safety.** Confirm AgentSpan servers are stateless +
+   horizontally scalable (like Conductor). `CredentialSchemaMigrator` claims multi-replica safety —
+   validate concurrent replicas during a rolling upgrade don't race on schema init or task
+   registration.
+7. **Config / secrets provisioning at deploy.** SPI impl beans, master key, DB credentials for
+   **both** datasources — the deploy-config story, especially in embed where the host wires every
+   SPI.
+
+---
+
+## Testing — fixtures needed
+
+8. **Realistic upgrade fixtures.** Validating §9.3's upgrade path needs a **populated** DB with
+   **in-flight / long-paused HITL** executions (`AgentHumanTask`) spanning the bump, across **both**
+   datasources — not a clean-start test.
+
+---
+
+## Embed coexistence checks (Mode C) — need an owner even without a formal checklist
+
+- `@Primary` collision/behavior: `CredentialAwareHttpTask`, `CredentialAwareMcpService`,
+  `AgentHumanTask`, event listener (§5.2).
+- CORS / auth coexistence with host (§5.3).
+- Endpoint path overlaps; scheduler intact; SSE intact.
+- Missing SPI impl ⇒ **fail fast at startup** (the one property verifiable today, by construction).
+- Kill-switch: `agentspan.embedded=false` returns a clean Conductor, no residual beans/paths.
+
+---
+
+## Top 3 for this task (if prioritizing)
+
+1. **Stand up the embedded orkes target + reuse the existing suite against it** (Option A today) —
+   the instrument already exists; the work is the target + the cross-repo wiring. Gated on §6.
+2. **Stand up security validation** — the largest currently-uncovered surface.
+3. **Deterministic agent-runs-end-to-end smoke test** — for post-deploy confidence.
+
+The rest are real but secondary. (Building the Option C conformance container is a high-leverage
+follow-on, not a blocker.)
+
+---
+
+## Open questions to resolve
+
+- Does Conductor 3.30.2's relational persistence auto-migrate an existing populated schema on
+  startup (Flyway forward-only), or require manual scripts? (Affects §9.3 upgrade + Mode A adoption.)
+- Is Mode B (external OSS self-embed) a *supported* offering or an internal stepping-stone to C?
+  (Changes how much B-specific validation is warranted.)
+- Is the `Conductor-Built-Against` manifest breadcrumb (§9.2) going to be implemented? (Affects
+  jar-consumer diagnosability in Mode B.)


### PR DESCRIPTION
## What

Documentation for the **AgentSpan-as-a-library version alignment** strategy, plus a companion **testing/deployment/integration-validation** readiness doc. No code changes.

## Changes

### 1. Design doc §9.2 — scope version-drift to three consumption modes
Reworks §9.2 (*Interoperability & version drift*) around the **three concrete ways a consumer picks an AgentSpan + Conductor pair**, replacing the open-ended "every consumer of the published library" framing.

| Mode | Consumes | Conductor version | Drift risk | Owner |
| --- | --- | --- | --- | --- |
| **A — Standalone** | `conductor-agentspan-server` bootJar / Docker | fixed, bundled | **none** (by construction) | us |
| **B — Self-embed (external OSS)** | `conductor-agentspan` library | host-supplied | real → mitigated | the host |
| **C — Enterprise embed** | `orkes-conductor` (embeds the lib) | orkes-pinned | single pinned pair | orkes |

Mode B recommends **build-from-source against your engine** (inherits Mode A's drift-free-by-construction guarantee); take-the-jar + self-certify is the documented fallback. Adds a forward-reference from §6 (build/classpath *mechanics*) → §9.2 (*ownership* per deployment).

### 2. Design doc §9.3 — upgrade & adoption (new)
- **Version upgrade** = data + ops only (whole-release consumption means API/ABI is the producer's build-time concern): two schema lifecycles (Conductor's Flyway + AgentSpan's `credentials_store`), in-flight/long-paused-HITL deserialization, restore-from-backup rollback.
- **Adoption** (plain Conductor → +AgentSpan) is **additive**, with a `>=` same-major engine-direction rule (Mode A: check or fall back to B; B: aligned by construction; C: auto-enforced by orkes' release line), SPI fail-fast, and the removal asymmetry.

### 3. README "Releasing" section
Documents the matching release-time convention (single `conductorVersion`, state the build-against version as a *fact, not a range*).

### 4. `agentspan-validation-readiness.md` (new)
Gap analysis for the testing/deployment/integration-validation task: notes the SDK e2e suite is **already** black-box / endpoint-parameterizable (the instrument exists — not a gap), documents the three **orkes-reuse options** (A checkout+in-repo works today; B test-artifact and C conformance-container do **not** exist yet), and flags **security validation** + a **deterministic post-deploy smoke test** as the real uncovered gaps.

### 5. `.gitignore`
Ignore `.vscode/` and `.claude/` local config.

## Verification

Doc-only change. README factual claims verified against the repo: module structure (`settings.gradle`), single `conductorVersion` + `version = rootProject.version` (`build.gradle`), `compileOnly` Conductor deps (`conductor-agentspan/build.gradle`), and that all three server-release workflows are manual `workflow_dispatch` with no tag-driven trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)