### PR TITLE
docs: fix SDK naming + sharpen why-agentspan three-pillar page

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ irm https://raw.githubusercontent.com/agentspan-ai/agentspan/main/cli/install.ps
 
 ## Install SDKs
 
-Build on Agentspan with the Conductor agent SDK, available for Python, TypeScript/JavaScript, and C#/.NET:
+Build on Agentspan with the Conductor Agent SDK, available for Python, TypeScript/JavaScript, and C#/.NET:
 
 ```bash
 # Python

--- a/docs/assets/plan-execute-boundary.svg
+++ b/docs/assets/plan-execute-boundary.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 220" fill="none">
+
+  <!-- ── Left panel: LLM Zone ───────────────────────────────────────── -->
+  <rect x="0" y="0" width="390" height="220" rx="12" fill="#FFF7ED"/>
+  <rect x="0" y="0" width="390" height="220" rx="12" stroke="#FED7AA" stroke-width="1.5"/>
+
+  <!-- Zone label -->
+  <text x="20" y="28" font-family="'IBM Plex Mono',monospace" font-size="10" font-weight="600" fill="#C2410C" letter-spacing="0.08em" text-transform="uppercase">LLM ZONE · non-deterministic</text>
+
+  <!-- Prompt box -->
+  <rect x="20" y="44" width="110" height="36" rx="8" fill="#FEF3C7" stroke="#FDE68A" stroke-width="1.5"/>
+  <text x="75" y="57" text-anchor="middle" font-family="system-ui,sans-serif" font-size="11" font-weight="600" fill="#92400E">User</text>
+  <text x="75" y="72" text-anchor="middle" font-family="system-ui,sans-serif" font-size="11" font-weight="600" fill="#92400E">Prompt</text>
+
+  <!-- Arrow: Prompt → Planner -->
+  <line x1="130" y1="62" x2="158" y2="62" stroke="#F97316" stroke-width="1.5"/>
+  <polygon points="158,62 152,58 152,66" fill="#F97316"/>
+
+  <!-- Planner LLM box -->
+  <rect x="160" y="44" width="115" height="36" rx="8" fill="#FEF3C7" stroke="#FDE68A" stroke-width="1.5"/>
+  <text x="217" y="57" text-anchor="middle" font-family="system-ui,sans-serif" font-size="11" font-weight="600" fill="#92400E">Planner</text>
+  <text x="217" y="72" text-anchor="middle" font-family="system-ui,sans-serif" font-size="10" fill="#B45309">one LLM call</text>
+
+  <!-- Arrow: Planner → JSON Plan -->
+  <line x1="275" y1="62" x2="303" y2="62" stroke="#F97316" stroke-width="1.5"/>
+  <polygon points="303,62 297,58 297,66" fill="#F97316"/>
+
+  <!-- JSON Plan box (highlighted) -->
+  <rect x="305" y="38" width="72" height="46" rx="8" fill="#F97316"/>
+  <text x="341" y="57" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" font-weight="600" fill="white">JSON</text>
+  <text x="341" y="72" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" font-weight="600" fill="white">Plan</text>
+
+  <!-- LLM stats -->
+  <text x="20" y="118" font-family="system-ui,sans-serif" font-size="12" fill="#C2410C">✓  One planner call only</text>
+  <text x="20" y="138" font-family="system-ui,sans-serif" font-size="12" fill="#C2410C">✓  Non-deterministic reasoning</text>
+  <text x="20" y="158" font-family="system-ui,sans-serif" font-size="12" fill="#C2410C">✓  Produces a plan as a value</text>
+  <text x="20" y="198" font-family="system-ui,sans-serif" font-size="11" fill="#D97706" font-style="italic">Static plan? Planner is skipped entirely →</text>
+
+  <!-- ── Dividing boundary ───────────────────────────────────────────── -->
+  <line x1="410" y1="10" x2="410" y2="210" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <rect x="370" y="96" width="80" height="28" rx="14" fill="#F3F4F6" stroke="#D1D5DB" stroke-width="1"/>
+  <text x="410" y="115" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="10" font-weight="600" fill="#6B7280" letter-spacing="0.04em">BOUNDARY</text>
+
+  <!-- Arrow across boundary -->
+  <line x1="377" y1="62" x2="433" y2="62" stroke="#6366F1" stroke-width="2"/>
+  <polygon points="433,62 427,58 427,66" fill="#6366F1"/>
+
+  <!-- ── Right panel: Conductor Zone ────────────────────────────────── -->
+  <rect x="430" y="0" width="390" height="220" rx="12" fill="#EEF2FF"/>
+  <rect x="430" y="0" width="390" height="220" rx="12" stroke="#C7D2FE" stroke-width="1.5"/>
+
+  <!-- Zone label -->
+  <text x="450" y="28" font-family="'IBM Plex Mono',monospace" font-size="10" font-weight="600" fill="#4338CA" letter-spacing="0.08em">CONDUCTOR ZONE · deterministic</text>
+
+  <!-- PAC Compiler box -->
+  <rect x="450" y="44" width="100" height="36" rx="8" fill="#E0E7FF" stroke="#C7D2FE" stroke-width="1.5"/>
+  <text x="500" y="57" text-anchor="middle" font-family="system-ui,sans-serif" font-size="11" font-weight="600" fill="#3730A3">PAC</text>
+  <text x="500" y="72" text-anchor="middle" font-family="system-ui,sans-serif" font-size="10" fill="#4F46E5">compile once</text>
+
+  <!-- Arrow -->
+  <line x1="550" y1="62" x2="578" y2="62" stroke="#4F46E5" stroke-width="1.5"/>
+  <polygon points="578,62 572,58 572,66" fill="#4F46E5"/>
+
+  <!-- Workflow execution box -->
+  <rect x="580" y="38" width="215" height="46" rx="8" fill="#4F46E5"/>
+  <!-- Steps inside -->
+  <rect x="590" y="48" width="44" height="26" rx="4" fill="#6366F1"/>
+  <text x="612" y="65" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="white">SET</text>
+
+  <line x1="634" y1="61" x2="642" y2="61" stroke="white" stroke-width="1.2"/>
+  <polygon points="642,61 638,58 638,64" fill="white"/>
+
+  <rect x="644" y="48" width="44" height="26" rx="4" fill="#6366F1"/>
+  <text x="666" y="65" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="white">FORK</text>
+
+  <line x1="688" y1="61" x2="696" y2="61" stroke="white" stroke-width="1.2"/>
+  <polygon points="696,61 692,58 692,64" fill="white"/>
+
+  <rect x="698" y="48" width="44" height="26" rx="4" fill="#6366F1"/>
+  <text x="720" y="65" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="8" fill="white">JOIN</text>
+
+  <line x1="742" y1="61" x2="750" y2="61" stroke="white" stroke-width="1.2"/>
+  <polygon points="750,61 746,58 746,64" fill="white"/>
+
+  <rect x="752" y="48" width="34" height="26" rx="4" fill="#4338CA"/>
+  <text x="769" y="61" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" fill="white">VALI</text>
+  <text x="769" y="72" text-anchor="middle" font-family="'IBM Plex Mono',monospace" font-size="7" fill="white">DATE</text>
+
+  <!-- Conductor stats -->
+  <text x="450" y="118" font-family="system-ui,sans-serif" font-size="12" fill="#4338CA">✓  No LLM in the execution path</text>
+  <text x="450" y="138" font-family="system-ui,sans-serif" font-size="12" fill="#4338CA">✓  Retries, FORK_JOIN, SWITCH — pure Conductor</text>
+  <text x="450" y="158" font-family="system-ui,sans-serif" font-size="12" fill="#4338CA">✓  Crash-safe: resumes at last step</text>
+  <text x="450" y="178" font-family="system-ui,sans-serif" font-size="12" fill="#4338CA">✓  Same plan → identical execution, always</text>
+
+</svg>

--- a/docs/assets/three-pillars.svg
+++ b/docs/assets/three-pillars.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 315" fill="none">
+
+  <!-- ── Card 1: Long-running ─────────────────────────────────────── -->
+  <rect x="10" y="10" width="238" height="210" rx="12" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <!-- icon background -->
+  <circle cx="129" cy="62" r="28" fill="#EEF2FF"/>
+  <!-- clock icon -->
+  <circle cx="129" cy="62" r="16" stroke="#4F46E5" stroke-width="2"/>
+  <line x1="129" y1="62" x2="129" y2="50" stroke="#4F46E5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="129" y1="62" x2="139" y2="67" stroke="#4F46E5" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="129" cy="62" r="2.5" fill="#4F46E5"/>
+  <!-- text -->
+  <text x="129" y="114" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#1E1B4B">Long-running agents</text>
+  <text x="129" y="136" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#6B7280">Survive crashes, restarts,</text>
+  <text x="129" y="152" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#6B7280">and deploys.</text>
+  <text x="129" y="182" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="11" fill="#4F46E5">crash recovery · HITL · history</text>
+
+  <!-- ── Card 2: Plan-Execute ─────────────────────────────────────── -->
+  <rect x="271" y="10" width="238" height="210" rx="12" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <!-- icon background -->
+  <circle cx="390" cy="62" r="28" fill="#EEF2FF"/>
+  <!-- DAG icon: one root → two leaves -->
+  <circle cx="390" cy="49" r="6" fill="#4F46E5"/>
+  <circle cx="374" cy="75" r="6" fill="#4F46E5"/>
+  <circle cx="406" cy="75" r="6" fill="#4F46E5"/>
+  <line x1="387" y1="54" x2="377" y2="70" stroke="#4F46E5" stroke-width="1.8" stroke-linecap="round"/>
+  <line x1="393" y1="54" x2="403" y2="70" stroke="#4F46E5" stroke-width="1.8" stroke-linecap="round"/>
+  <!-- arrowheads -->
+  <polygon points="377,70 374,62 381,65" fill="#4F46E5"/>
+  <polygon points="403,70 409,65 406,62" fill="#4F46E5"/>
+  <!-- text -->
+  <text x="390" y="114" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#1E1B4B">Dynamic plan-execute</text>
+  <text x="390" y="136" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#6B7280">LLM plans; Conductor executes.</text>
+  <text x="390" y="152" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#6B7280">No LLM in the hot path.</text>
+  <text x="390" y="182" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="11" fill="#4F46E5">adaptive plans · replay-safe</text>
+
+  <!-- ── Card 3: Event-driven ─────────────────────────────────────── -->
+  <rect x="532" y="10" width="238" height="210" rx="12" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <!-- icon background -->
+  <circle cx="651" cy="62" r="28" fill="#EEF2FF"/>
+  <!-- lightning bolt icon -->
+  <path d="M656 44 L644 66 L652 66 L647 80 L663 58 L655 58 Z" fill="#4F46E5"/>
+  <!-- text -->
+  <text x="651" y="114" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#1E1B4B">Event-driven agents</text>
+  <text x="651" y="136" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#6B7280">Triggered by time or events.</text>
+  <text x="651" y="152" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#6B7280">Every execution recorded.</text>
+  <text x="651" y="182" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="11" fill="#4F46E5">cron · Kafka · webhooks</text>
+
+  <!-- ── Connector lines ──────────────────────────────────────────── -->
+  <line x1="129" y1="220" x2="129" y2="252" stroke="#D1D5DB" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <line x1="390" y1="220" x2="390" y2="252" stroke="#D1D5DB" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <line x1="651" y1="220" x2="651" y2="252" stroke="#D1D5DB" stroke-width="1.5" stroke-dasharray="4 3"/>
+
+  <!-- ── Agentspan Runtime base bar ─────────────────────────────── -->
+  <rect x="10" y="254" width="760" height="50" rx="10" fill="#4F46E5"/>
+  <!-- staggered bars motif (from logo) -->
+  <rect x="24"  y="268" width="22" height="6" rx="3" fill="white" opacity="0.45"/>
+  <rect x="30"  y="279" width="30" height="6" rx="3" fill="white" opacity="0.28"/>
+  <rect x="26"  y="290" width="16" height="6" rx="3" fill="white" opacity="0.16"/>
+  <!-- label -->
+  <text x="390" y="285" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" font-size="16" font-weight="700" fill="white" letter-spacing="0.3">Agentspan Runtime</text>
+</svg>

--- a/docs/concepts/plan-execute.md
+++ b/docs/concepts/plan-execute.md
@@ -3,14 +3,41 @@ title: Plan-Execute Strategy
 description: PLAN_EXECUTE compiles LLM-generated (or static) plans into deterministic Conductor sub-workflows — the planner reasons, the executor runs.
 ---
 
-# Plan-Execute Strategy
+# Plan-Execute
 
-`Strategy.PLAN_EXECUTE` (also called PAE; the server-side compiler is PAC, "PLAN_AND_COMPILE") splits a task into two phases:
+**The LLM decides *what* to do. Conductor handles *how* — no tokens on orchestration, retries, or branching.**
 
-1. **Plan** — a planner agent emits a JSON DAG of operations.
-2. **Execute** — the server compiles that JSON into a Conductor sub-workflow and runs it deterministically.
+Most agent frameworks route every decision through the LLM — retry logic, branch selection, parallelism. Tokens for every control flow operation. Nondeterminism throughout.
 
-The LLM is only invoked where it adds value (planning, per-op content generation). Orchestration, retries, parallelism, and validation are pure Conductor primitives — no token cost, no nondeterminism.
+Plan-Execute draws a hard line.
+
+![Plan-Execute deterministic boundary](../assets/plan-execute-boundary.svg)
+
+One planner call produces a JSON task graph. The Agentspan server compiles it into a deterministic Conductor sub-workflow. **After that single LLM call, the execution is pure Conductor** — crash-safe, replay-safe, and free of LLM randomness.
+
+!!! tip "The core insight"
+    Two identical plans produce two identical workflow definitions and two identical executions. Retries, parallelism (FORK_JOIN), branching (SWITCH), and validation are Conductor primitives — not LLM turns. The LLM is only invoked where it genuinely adds value: planning the shape of work, and generating per-step content.
+
+The two phases in detail:
+
+1. **Plan** — the planner agent emits a JSON DAG of operations once.
+2. **Execute** — the server compiles that JSON into an immutable Conductor sub-workflow and runs it deterministically.
+
+(The strategy is called `PLAN_EXECUTE` in the SDK. The server-side compiler is PAC, "PLAN_AND_COMPILE".)
+
+---
+
+## Why this wins against a plain LLM loop
+
+| | LLM-loop agent | Plan-Execute |
+|---|---|---|
+| Retries | LLM re-reasons | Conductor retry, no token cost |
+| Parallelism | Ask LLM to fan out | FORK_JOIN — deterministic, exact |
+| Branching | LLM decides each turn | SWITCH on JS expression |
+| Crash recovery | Restart from scratch | Resume at last completed step |
+| Replay two runs | Different each time | Identical — plan is a value |
+| Validation | LLM self-checks | Deterministic validator + SWITCH gate |
+| Testing | Non-deterministic | Pass a static plan — no LLM at all |
 
 ## The deterministic boundary
 

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,0 +1,399 @@
+/* ==========================================================================
+   Agentspan Docs — Zinc + Indigo Theme (Light + Dark)
+   Inter × IBM Plex Mono
+   ========================================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,300;14..32,400;14..32,500;14..32,600;14..32,700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
+/* ---------- Tokens — Light ---------- */
+:root {
+  --c-bg:           #ffffff;
+  --c-bg-secondary: #f4f4f5;
+  --c-bg-tertiary:  #e4e4e7;
+  --c-border:       #d4d4d8;
+  --c-border-dim:   #e4e4e7;
+  --c-text:         #09090b;
+  --c-text-muted:   #52525b;
+  --c-text-dim:     #71717a;
+  --c-accent:       #4f46e5;
+  --c-accent-hover: #4338ca;
+  --c-blue:         #3b82f6;
+  --c-green:        #22c55e;
+  --c-header-bg:    rgba(255,255,255,0.88);
+
+  --font-body: "Inter", -apple-system, "system-ui", sans-serif;
+  --font-mono: "IBM Plex Mono", "SF Mono", Menlo, monospace;
+
+  --r-sm:  6px;
+  --r-md:  8px;
+  --r-lg: 12px;
+  --r-xl: 16px;
+
+  --shadow-card:     0 4px 16px rgba(0,0,0,0.06);
+  --shadow-elevated: 0 12px 40px rgba(0,0,0,0.1);
+
+  /* MkDocs Material overrides */
+  --md-primary-fg-color:        var(--c-accent);
+  --md-primary-fg-color--light: #818cf8;
+  --md-primary-fg-color--dark:  var(--c-accent-hover);
+  --md-accent-fg-color:         var(--c-accent);
+  --md-typeset-font-size:       0.85rem;
+  --md-default-bg-color:        var(--c-bg);
+  --md-default-fg-color:        var(--c-text);
+  --md-default-fg-color--light: var(--c-text-muted);
+  --md-default-fg-color--lighter: var(--c-text-dim);
+  --md-default-fg-color--lightest: var(--c-border);
+}
+
+/* ---------- Tokens — Dark (slate) ---------- */
+[data-md-color-scheme="slate"] {
+  --c-bg:           #09090b;
+  --c-bg-secondary: #18181b;
+  --c-bg-tertiary:  #27272a;
+  --c-border:       #3f3f46;
+  --c-border-dim:   #27272a;
+  --c-text:         #fafafa;
+  --c-text-muted:   #a1a1aa;
+  --c-text-dim:     #71717a;
+  --c-header-bg:    rgba(9,9,11,0.88);
+
+  --shadow-card:     0 4px 16px rgba(0,0,0,0.3);
+  --shadow-elevated: 0 12px 40px rgba(0,0,0,0.4);
+
+  --md-default-bg-color:          var(--c-bg);
+  --md-default-fg-color:          var(--c-text);
+  --md-default-fg-color--light:   var(--c-text-muted);
+  --md-default-fg-color--lighter: var(--c-text-dim);
+  --md-default-fg-color--lightest: var(--c-border);
+  --md-typeset-color:             var(--c-text-muted);
+  --md-code-bg-color:             var(--c-bg-secondary);
+  --md-code-fg-color:             var(--c-text);
+  --md-typeset-a-color:           var(--c-blue);
+}
+
+/* ---------- Base ---------- */
+body {
+  font-family: var(--font-body) !important;
+  color: var(--c-text);
+  -webkit-font-smoothing: antialiased;
+  background: var(--c-bg) !important;
+}
+
+/* ---------- Header ---------- */
+.md-header {
+  background: var(--c-header-bg) !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  color: var(--c-text) !important;
+  border-bottom: 1px solid var(--c-border);
+  box-shadow: none !important;
+}
+.md-header[data-md-state="shadow"] {
+  box-shadow: 0 1px 8px rgba(0,0,0,0.12) !important;
+}
+.md-header__title {
+  font-family: var(--font-body) !important;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--c-text) !important;
+}
+.md-logo img { height: 30px !important; }
+[data-md-color-scheme="slate"] .md-logo img {
+  filter: brightness(0) invert(1);
+}
+
+/* Tabs */
+.md-tabs {
+  background: var(--c-header-bg) !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--c-border);
+}
+.md-tabs__link {
+  font-family: var(--font-body) !important;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--c-text-dim) !important;
+  opacity: 1 !important;
+}
+.md-tabs__link--active,
+.md-tabs__link:hover { color: var(--c-text) !important; }
+
+/* ---------- Typography ---------- */
+.md-typeset h1 {
+  font-family: var(--font-body) !important;
+  font-weight: 700 !important;
+  font-size: 28px !important;
+  color: var(--c-text) !important;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  margin-bottom: 10px !important;
+}
+.md-typeset h2 {
+  font-family: var(--font-body) !important;
+  font-weight: 600 !important;
+  font-size: 22px !important;
+  color: var(--c-text) !important;
+  line-height: 1.3;
+  margin-top: 28px;
+  margin-bottom: 10px;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+.md-typeset h3 {
+  font-family: var(--font-body) !important;
+  font-weight: 600 !important;
+  font-size: 18px !important;
+  color: var(--c-text) !important;
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+.md-typeset h4 {
+  font-family: var(--font-body) !important;
+  font-weight: 600 !important;
+  font-size: 15px !important;
+  letter-spacing: 0.02em;
+  color: var(--c-text-muted) !important;
+  margin-top: 18px;
+  margin-bottom: 6px;
+}
+.md-typeset {
+  line-height: 1.6;
+  color: var(--c-text-muted);
+  font-size: 15px;
+}
+.md-typeset p  { margin-top: 0; margin-bottom: 12px; }
+.md-typeset ul,
+.md-typeset ol { margin-top: 0; margin-bottom: 12px; }
+.md-typeset li + li { margin-top: 3px; }
+.md-typeset a {
+  color: var(--c-accent);
+  text-decoration-color: rgba(79,70,229,0.3);
+  text-underline-offset: 2px;
+  transition: color 0.15s, text-decoration-color 0.15s;
+}
+.md-typeset a:hover {
+  color: var(--c-accent-hover);
+  text-decoration-color: rgba(79,70,229,0.6);
+}
+
+/* ---------- Code ---------- */
+.md-typeset code {
+  font-family: var(--font-mono) !important;
+  background: var(--c-bg-secondary);
+  color: var(--c-text);
+  border: 1px solid var(--c-border-dim);
+  border-radius: var(--r-sm);
+  padding: 0.08em 0.25em;
+  letter-spacing: -0.01em;
+}
+.md-typeset pre {
+  border-radius: var(--r-md) !important;
+  border: 1px solid var(--c-border-dim);
+  box-shadow: none;
+  margin-top: 0.4rem !important;
+  margin-bottom: 0.65rem !important;
+  scrollbar-width: thin;
+  scrollbar-color: var(--c-border) transparent;
+}
+.md-typeset pre::-webkit-scrollbar { height: 6px; }
+.md-typeset pre::-webkit-scrollbar-thumb {
+  background: var(--c-border);
+  border-radius: 3px;
+}
+.md-typeset pre > code {
+  font-size: 14px !important;
+  line-height: 1.5 !important;
+  background: var(--c-bg-secondary) !important;
+  color: var(--c-text-muted) !important;
+  padding: 12px 16px !important;
+  border-radius: var(--r-md) !important;
+  border: none;
+  letter-spacing: 0 !important;
+}
+
+/* ---------- Tables ---------- */
+.md-typeset table:not([class]) {
+  border: 1px solid var(--c-border-dim);
+  border-radius: var(--r-sm);
+  overflow: hidden;
+  box-shadow: none;
+  font-size: 14px;
+  margin-top: 8px !important;
+  margin-bottom: 12px !important;
+}
+.md-typeset table:not([class]) th {
+  background: var(--c-bg-secondary);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-text-muted);
+  border-bottom: 1px solid var(--c-border-dim);
+  padding: 8px 12px;
+}
+.md-typeset table:not([class]) td {
+  border-color: var(--c-border-dim);
+  padding: 7px 12px;
+}
+
+/* ---------- Admonitions ---------- */
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: var(--r-sm) !important;
+  border-left: 3px solid;
+  box-shadow: none;
+  margin-top: 10px !important;
+  margin-bottom: 12px !important;
+  font-size: 14px !important;
+  background: var(--c-bg-secondary);
+}
+.md-typeset .admonition .admonition-title,
+.md-typeset details summary {
+  font-size: 14px !important;
+  padding: 8px 12px 8px 44px !important;
+}
+.md-typeset .admonition p,
+.md-typeset details p {
+  font-size: 14px !important;
+  margin-bottom: 8px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+/* ---------- Sidebar ---------- */
+.md-sidebar { background: var(--c-bg) !important; }
+.md-nav__link {
+  font-size: 13px;
+  font-family: var(--font-body) !important;
+  padding: 5px 9px;
+  line-height: 1.4;
+  color: var(--c-text-dim) !important;
+}
+.md-nav__link--active {
+  color: var(--c-text) !important;
+  font-weight: 600;
+  background: var(--c-bg-secondary) !important;
+  border-radius: var(--r-sm);
+}
+.md-nav__item--section > .md-nav__link {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-text-dim) !important;
+  background: transparent !important;
+}
+.md-nav__title,
+.md-nav--primary .md-nav__title,
+[data-md-level] > .md-nav__title {
+  background: transparent !important;
+  box-shadow: none !important;
+  color: var(--c-text-dim) !important;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-left: 10px !important;
+}
+
+/* ---------- TOC ---------- */
+.md-nav--secondary .md-nav__link {
+  font-size: 12px;
+  transition: color 0.15s;
+  padding: 3px 6px;
+  line-height: 1.4;
+}
+.md-nav--secondary > .md-nav__title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-text-dim) !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  border-bottom: 1px solid var(--c-border-dim);
+  padding: 0.3rem 0.6rem;
+}
+.md-nav--secondary .md-nav__link--active {
+  color: var(--c-accent) !important;
+  font-weight: 600;
+  background: transparent !important;
+}
+
+/* ---------- Search ---------- */
+.md-search__form {
+  border-radius: var(--r-md) !important;
+  background: var(--c-bg-secondary) !important;
+  border: 1px solid var(--c-border) !important;
+}
+.md-search__input {
+  font-family: var(--font-body) !important;
+  color: var(--c-text) !important;
+}
+.md-search__input::placeholder { color: var(--c-text-dim) !important; }
+
+/* ---------- Footer ---------- */
+.md-footer { background: var(--c-bg) !important; border-top: 1px solid var(--c-border-dim); }
+.md-footer-meta { background: var(--c-bg) !important; }
+.md-footer-nav__title { color: var(--c-text) !important; }
+.md-footer-nav__direction { color: var(--c-text-muted) !important; }
+.md-copyright { color: var(--c-text-dim) !important; }
+
+/* ---------- Clipboard button ---------- */
+.md-clipboard {
+  color: var(--c-text-dim) !important;
+  transition: color 0.15s, transform 0.15s;
+}
+.md-clipboard:hover {
+  color: var(--c-accent) !important;
+  transform: scale(1.1);
+}
+
+/* ---------- Content area ---------- */
+.md-main  { background: var(--c-bg) !important; }
+.md-content { background: var(--c-bg) !important; }
+.md-content__inner {
+  max-width: 48rem;
+  padding-top: 0.5rem;
+}
+
+/* ---------- Focus ---------- */
+:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}
+
+/* ==========================================================================
+   Dark mode syntax highlighting
+   ========================================================================== */
+[data-md-color-scheme="slate"] .md-typeset pre > code .k,
+[data-md-color-scheme="slate"] .md-typeset pre > code .kd,
+[data-md-color-scheme="slate"] .md-typeset pre > code .kn,
+[data-md-color-scheme="slate"] .md-typeset pre > code .kp,
+[data-md-color-scheme="slate"] .md-typeset pre > code .kr,
+[data-md-color-scheme="slate"] .md-typeset pre > code .kt { color: #c084fc !important; }
+
+[data-md-color-scheme="slate"] .md-typeset pre > code .s,
+[data-md-color-scheme="slate"] .md-typeset pre > code .s1,
+[data-md-color-scheme="slate"] .md-typeset pre > code .s2,
+[data-md-color-scheme="slate"] .md-typeset pre > code .sd,
+[data-md-color-scheme="slate"] .md-typeset pre > code .se { color: #22c55e !important; }
+
+[data-md-color-scheme="slate"] .md-typeset pre > code .m,
+[data-md-color-scheme="slate"] .md-typeset pre > code .mi,
+[data-md-color-scheme="slate"] .md-typeset pre > code .mf { color: #a5b4fc !important; }
+
+[data-md-color-scheme="slate"] .md-typeset pre > code .c,
+[data-md-color-scheme="slate"] .md-typeset pre > code .c1,
+[data-md-color-scheme="slate"] .md-typeset pre > code .cm { color: #71717a !important; font-style: italic; }
+
+[data-md-color-scheme="slate"] .md-typeset pre > code .na,
+[data-md-color-scheme="slate"] .md-typeset pre > code .nb,
+[data-md-color-scheme="slate"] .md-typeset pre > code .nf,
+[data-md-color-scheme="slate"] .md-typeset pre > code .nc { color: #60a5fa !important; }
+
+[data-md-color-scheme="slate"] .md-typeset pre > code .nn,
+[data-md-color-scheme="slate"] .md-typeset pre > code .nv,
+[data-md-color-scheme="slate"] .md-typeset pre > code .nt { color: #818cf8 !important; }

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,11 +1,11 @@
 ---
 title: SDK Overview
-description: Conductor agent SDK — coordinates, Agent 101, and framework integrations for Python, TypeScript, Java, and C#.
+description: Conductor Agent SDK — coordinates, Agent 101, and framework integrations for Python, TypeScript, Java, and C#.
 ---
 
 # SDK Overview
 
-The Conductor agent SDK lets you build and run Agentspan agents in four languages. Install the package, point it at an Agentspan server, and you're running agents in under 30 seconds.
+The Conductor Agent SDK lets you build and run Agentspan agents in four languages. Install the package, point it at an Agentspan server, and you're running agents in under 30 seconds.
 
 ## Quick reference
 
@@ -456,7 +456,7 @@ You don't have to rewrite agents authored in another framework. Pass the framewo
 
     **Option 1 — Use AI SDK tools on a native Agent (recommended):**
 
-    The Conductor agent SDK auto-detects Vercel AI SDK `tool()` objects — no wrapper needed.
+    The Conductor Agent SDK auto-detects Vercel AI SDK `tool()` objects — no wrapper needed.
 
     ```ts
     import { tool as aiTool } from 'ai';

--- a/docs/why-agentspan.md
+++ b/docs/why-agentspan.md
@@ -7,11 +7,11 @@ description: Why agents fail in production, and how Agentspan's server-side exec
 
 **Agentspan is a durable runtime for AI agents, built for Conductor. Your code runs in your process. Execution state lives on the server — so crashes, restarts, and deployments don't lose work.**
 
-This page covers why conventional agent frameworks fail in production, how Agentspan's server-side execution model addresses those failures, and when Agentspan is the right choice.
+![Agentspan three pillars: long-running agents, dynamic plan-execute, event-driven agents](assets/three-pillars.svg)
 
 ---
 
-## How most agent frameworks work
+## How most agent frameworks work (_and what could go wrong?_)
 
 Most agent frameworks — LangGraph, the OpenAI Agents SDK, Google ADK, and others — run the agent loop inside your process. Your code calls the LLM, receives a tool call, executes the tool, and loops. All of that happens in memory, in your process.
 
@@ -23,12 +23,9 @@ Your process
     ├── call LLM again
     └── ...until done
 ```
-
 This works fine on your laptop. In production, it breaks in predictable ways.
 
----
-
-## What can go wrong
+### What can go wrong
 
 **Process crash mid-run.** A long-running agent — one that searches the web, reads files, calls APIs across dozens of steps — can take minutes. If your process dies (OOM kill, deploy, network drop), the entire run is gone. There is no way to resume from where it stopped.
 
@@ -44,7 +41,7 @@ This works fine on your laptop. In production, it breaks in predictable ways.
 
 ---
 
-## How Agentspan works differently
+## How Agentspan separates orchestration from execution
 
 Agentspan separates where your code runs from where execution state lives.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,8 +9,27 @@ docs_dir: docs
 site_dir: site
 strict: true
 
+extra_css:
+  - css/custom.css
+
 theme:
   name: material
+  font:
+    text: false
+    code: false
+  palette:
+    - scheme: default
+      primary: custom
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: custom
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - navigation.instant
     - navigation.sections

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,9 @@ markdown_extensions:
   - toc:
       permalink: true
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.superfences:

--- a/sdk/python/examples/adk/README.md
+++ b/sdk/python/examples/adk/README.md
@@ -1,8 +1,8 @@
 # Google ADK Examples
 
-These examples demonstrate running agents written with [Google's Agent Development Kit (ADK)](https://github.com/google/adk-python) (`google-adk`) on the Conductor agent runtime.
+These examples demonstrate running agents written with [Google's Agent Development Kit (ADK)](https://github.com/google/adk-python) (`google-adk`) on the Agentspan runtime.
 
-The agents are defined using standard ADK classes — the Conductor runtime auto-detects the framework, serializes the agent generically, and the server normalizes the config into a Conductor agent execution. **Zero translation code in the SDK.**
+The agents are defined using standard ADK classes — Agentspan auto-detects the framework, serializes the agent generically, and the server normalizes the config into an agent execution. **Zero translation code in the SDK.**
 
 ## Prerequisites
 
@@ -66,7 +66,7 @@ Generic serializer → JSON dict + callable extraction
 Server GoogleADKNormalizer → AgentConfig → Conductor WorkflowDef
   │
   ▼
-Conductor runtime executes the agent
+Agentspan runtime executes the agent
 ```
 
 ## Key ADK Differences from OpenAI

--- a/sdk/python/examples/openai/README.md
+++ b/sdk/python/examples/openai/README.md
@@ -1,8 +1,8 @@
 # OpenAI Agent SDK Examples
 
-These examples demonstrate running agents written with the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) (`openai-agents`) on the Conductor agent runtime.
+These examples demonstrate running agents written with the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) (`openai-agents`) on the Agentspan runtime.
 
-The agents are defined using standard OpenAI SDK classes and decorators — the Conductor runtime auto-detects the framework, serializes the agent generically, and the server normalizes the config into a Conductor agent execution. **Zero translation code in the SDK.**
+The agents are defined using standard OpenAI SDK classes and decorators — Agentspan auto-detects the framework, serializes the agent generically, and the server normalizes the config into an agent execution. **Zero translation code in the SDK.**
 
 ## Prerequisites
 
@@ -66,5 +66,5 @@ Generic serializer → JSON dict + callable extraction
 Server OpenAINormalizer → AgentConfig → Conductor WorkflowDef
   │
   ▼
-Conductor runtime executes the agent
+Agentspan runtime executes the agent
 ```


### PR DESCRIPTION
## Summary

- **Naming fix**: Capitalize "Conductor Agent SDK" consistently across `README.md`, `docs/sdk.md`, and Python example READMEs (ADK + OpenAI) — was lowercase "Conductor agent SDK / runtime"
- **Three-pillar SVG diagram**: New `docs/assets/three-pillars.svg` — clock / DAG / bolt icons, Agentspan Runtime base bar — embedded at the top of the why-agentspan page
- **Page restructure**: Three-pillar grid cards moved above the fold on why-agentspan; pillar cards now appear immediately after the hero sentence
- **MkDocs fix**: Enable `pymdownx.emoji` extension so `:material-*:` icons render correctly