### PR TITLE
ci: export SDK e2e suites as a release bundle for downstream reuse

### DIFF
--- a/.github/workflows/export-e2e-bundle.yml
+++ b/.github/workflows/export-e2e-bundle.yml
@@ -1,0 +1,74 @@
+name: Export E2E Bundle
+
+# Builds the SDK e2e bundle (all four SDKs + CLI + e2e/TEST_SETUP.md) and
+# attaches it to the GitHub release as:
+#   - agentspan-e2e-bundle.tar.gz
+#   - agentspan-e2e-bundle.manifest.txt
+#
+# Tying the bundle to the release tag lets downstream hosts pin ONE tag for both
+# the published `conductor-agentspan` lib and the matching e2e suites. The
+# consumer is orkes-conductor's .github/workflows/agentspan-sdk-e2e.yaml, which
+# downloads these assets (optionally for a pinned tag) and runs each SDK suite
+# against its embedded server.
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach the bundle to (blank = current ref / latest release)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write # upload release assets
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Export the release tag's commit. On a release event github.ref is
+          # refs/tags/<tag>; on manual dispatch use the provided tag (or the
+          # dispatched branch when blank). fetch-depth 0 so git archive +
+          # git describe see full history/tags.
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Build e2e bundle
+        run: |
+          chmod +x e2e/export-e2e-bundle.sh
+          e2e/export-e2e-bundle.sh dist
+
+      - name: Resolve release tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+          elif [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="$(gh release view --json tagName -q .tagName)"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Attaching bundle to release: $TAG"
+
+      - name: Upload bundle to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            dist/agentspan-e2e-bundle.tar.gz \
+            dist/agentspan-e2e-bundle.manifest.txt \
+            --clobber
+
+      - name: Upload bundle as workflow artifact (inspection / fallback)
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentspan-e2e-bundle
+          path: dist/agentspan-e2e-bundle.*
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ obj/
 # Editor / tooling local config
 .vscode/
 .claude/
+
+# e2e bundle export output
+/dist/

--- a/e2e/export-e2e-bundle.sh
+++ b/e2e/export-e2e-bundle.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Export the SDK e2e suites as a self-contained bundle that downstream hosts
+# (e.g. orkes-conductor) download from an agentspan release and run against
+# their own embedded server — so the e2e suites stay single-source-of-truth
+# here and are pinned by release tag there.
+#
+# Consumed by orkes-conductor's .github/workflows/agentspan-sdk-e2e.yaml, which
+# downloads the two release assets this produces:
+#   - agentspan-e2e-bundle.tar.gz        (top-level dir: agentspan-e2e/)
+#   - agentspan-e2e-bundle.manifest.txt  (provenance)
+#
+# Layout inside the tarball (consumer sets BUNDLE=.../agentspan-e2e):
+#   sdk/java/        standalone gradle project -> ./gradlew test -Pe2e
+#   sdk/python/      uv project                -> uv run pytest e2e/
+#   sdk/typescript/  npm project               -> npx vitest run tests/e2e/
+#   sdk/csharp/      dotnet solution           -> dotnet test tests/AgentspanE2eTests/...
+#   cli/             go module                 -> go build -o agentspan .
+#   e2e/TEST_SETUP.md
+#
+# Uses `git archive`, so the bundle contains exactly the tracked files at REF
+# (no build/, node_modules/, .venv/, bin/, obj/ — those are gitignored). That
+# keeps it reproducible and tied to the release commit.
+#
+# Usage: e2e/export-e2e-bundle.sh [OUT_DIR] [REF]
+#   OUT_DIR  directory for the output assets (default: dist)
+#   REF      git ref to export             (default: HEAD)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT_DIR="${1:-dist}"
+REF="${2:-HEAD}"
+
+# Paths included in the bundle. Each must be tracked in git at REF.
+PATHS=(sdk/java sdk/python sdk/typescript sdk/csharp cli e2e/TEST_SETUP.md)
+
+# Provenance.
+VERSION="$(sed -n 's/^version=//p' sdk/java/gradle.properties 2>/dev/null | head -1)"
+COMMIT="$(git rev-parse "$REF")"
+SHORT="$(git rev-parse --short "$REF")"
+DESCRIBE="$(git describe --tags --always "$REF" 2>/dev/null || echo "$SHORT")"
+BUILT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+STAGING="$(mktemp -d)"
+DEST="$STAGING/agentspan-e2e"
+mkdir -p "$DEST"
+trap 'rm -rf "$STAGING"' EXIT
+
+echo "Exporting tracked files at $REF ($SHORT) into bundle ..."
+# git archive preserves full paths (sdk/java/..., cli/..., e2e/TEST_SETUP.md).
+git archive --format=tar "$REF" -- "${PATHS[@]}" | tar -x -C "$DEST"
+
+# Fail loud if anything the consumer relies on is missing.
+for p in sdk/java sdk/python sdk/typescript sdk/csharp cli e2e/TEST_SETUP.md; do
+  if [[ ! -e "$DEST/$p" ]]; then
+    echo "ERROR: '$p' is missing from the bundle (not tracked at $REF?)." >&2
+    exit 1
+  fi
+done
+
+TARBALL="$OUT_DIR/agentspan-e2e-bundle.tar.gz"
+MANIFEST="$OUT_DIR/agentspan-e2e-bundle.manifest.txt"
+
+tar -czf "$TARBALL" -C "$STAGING" agentspan-e2e
+
+cat > "$MANIFEST" <<EOF
+AgentSpan SDK E2E Bundle
+repo:     agentspan-ai/agentspan
+ref:      $REF
+describe: $DESCRIBE
+commit:   $COMMIT
+version:  ${VERSION:-unknown}
+built:    $BUILT
+sdks:     java, python, typescript, csharp
+cli:      included
+layout:   agentspan-e2e/{sdk/<lang>, cli, e2e/TEST_SETUP.md}
+EOF
+
+echo "Wrote:"
+echo "  $TARBALL ($(du -h "$TARBALL" | cut -f1))"
+echo "  $MANIFEST"
+echo "--- manifest ---"
+cat "$MANIFEST"


### PR DESCRIPTION
## What

Adds the **producer** side of the agentspan → orkes-conductor e2e contract: a workflow + script that package the SDK e2e suites into a release bundle so downstream hosts (orkes-conductor) can run the exact same suites against their own server, pinned by release tag.

orkes-conductor's `agentspan-sdk-e2e.yaml` **already consumes** this: it `gh release download`s `agentspan-e2e-bundle.tar.gz` + `agentspan-e2e-bundle.manifest.txt` from this repo, extracts to `agentspan-e2e/`, and runs each SDK from `$BUNDLE/sdk/<lang>` (+ builds the CLI from `$BUNDLE/cli`). Only the producer was missing here.

## Changes

- **`e2e/export-e2e-bundle.sh`** — assembles the bundle via `git archive` (tracked files only → reproducible, no `build/`/`node_modules/`/`.venv/`/`obj/`). Top-level `agentspan-e2e/` containing self-contained `sdk/{java,python,typescript,csharp}` + `cli/` + `e2e/TEST_SETUP.md`, plus a provenance manifest (tag, commit, lib version, date). Runs locally: `e2e/export-e2e-bundle.sh [OUT_DIR] [REF]`.
- **`.github/workflows/export-e2e-bundle.yml`** — `on: release [created]` + manual dispatch; uploads both assets to the release. Same trigger as `release-server-maven.yml` (which publishes `conductor-agentspan`), so **bundle and lib share the release tag** → orkes pins one tag for both lib and tests.
- **`.gitignore`** — ignore `/dist/` (bundle output).

`e2e/TEST_SETUP.md` already existed and is included as-is.

## Verification

- Extracted layout matches the consumer's `BUNDLE=/tmp/agentspan/agentspan-e2e`; all 4 SDK trees self-contained (gradlew / pyproject+uv.lock / package.json+lock / sln+csproj→`../../src/Conductor.AI` / go.mod); 26 Java suites; **zero** build-artifact leakage.
- Asset names + bundle root match orkes' `agentspan-sdk-e2e.yaml` exactly.
- YAML + bash syntax valid; negative test (a required path absent → exits 1 with "is missing from the bundle").

## Notes

- This **bundle/source** approach is what orkes actually consumes. The Maven test-jar / package-move work on `export-java-e2e-conformance` is an orthogonal, unused approach — worth retiring.
- The bundle workflow auto-attaches on release; can also be dispatched manually against a specific tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)