### PR TITLE
fix(agentspan): return 404 for missing execution id in getStatus (SuiteHttpApi404)

### DIFF
--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -1266,7 +1266,7 @@ public class AgentService {
      * Get the current status of an agent execution.
      */
     public Map<String, Object> getStatus(String executionId) {
-        Workflow workflow = executionService.getExecutionStatus(executionId, true);
+        Workflow workflow = requireExecution(executionId);
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("executionId", executionId);
         result.put("status", workflow.getStatus().name());
@@ -1313,6 +1313,43 @@ public class AgentService {
         }
 
         return result;
+    }
+
+    /**
+     * Fetch an execution or fail with a 404-mapped exception. Conductor engines differ on
+     * the missing-id contract:
+     * <ul>
+     *   <li>upstream {@code conductor-core} throws its own {@code NotFoundException} — let it propagate;</li>
+     *   <li>the orkes fork's facade returns {@code null} for a valid-but-missing id;</li>
+     *   <li>the orkes fork rejects a malformed (non-UUID) id with an {@code "Invalid UUID"} BACKEND_ERROR
+     *       before it can look it up.</li>
+     * </ul>
+     * All three are normalized to {@code NotFoundException} (HTTP 404). Any other backend
+     * failure is rethrown unchanged so real errors still surface as 500.
+     */
+    private Workflow requireExecution(String executionId) {
+        Workflow workflow;
+        try {
+            workflow = executionService.getExecutionStatus(executionId, true);
+        } catch (RuntimeException e) {
+            if (isMalformedIdError(e)) {
+                throw new NotFoundException("No execution found for id: " + executionId);
+            }
+            throw e;
+        }
+        if (workflow == null) {
+            throw new NotFoundException("No execution found for id: " + executionId);
+        }
+        return workflow;
+    }
+
+    /**
+     * The orkes engine surfaces a non-UUID execution id as an {@code "Invalid UUID"} BACKEND_ERROR
+     * rather than a not-found; scoped to that message so genuine backend errors still propagate.
+     */
+    private static boolean isMalformedIdError(RuntimeException e) {
+        String msg = e.getMessage();
+        return msg != null && msg.contains("Invalid UUID");
     }
 
     // ── Framework event push ─────────────────────────────────────────

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -1346,6 +1346,15 @@ public class AgentService {
     /**
      * The orkes engine surfaces a non-UUID execution id as an {@code "Invalid UUID"} BACKEND_ERROR
      * rather than a not-found; scoped to that message so genuine backend errors still propagate.
+     *
+     * <p>Matching on the message string is deliberate. A typed catch is impossible: the orkes
+     * {@code ApplicationException} is not on the compile classpath (agentspan builds against
+     * upstream conductor-core). Pre-validating the id as a UUID was rejected because execution ids
+     * are not guaranteed to be UUIDs — upstream engines may plug in a custom {@code IDGenerator},
+     * and orkes multi-tenant ids carry a 4-char org prefix ahead of the UUID — so a format guess
+     * here could 404 an execution that exists. Matching the engine's own malformed-id error makes
+     * no format assumption; at worst a reworded message falls through as a 500, which the
+     * SuiteHttpApi404 e2e catches.
      */
     private static boolean isMalformedIdError(RuntimeException e) {
         String msg = e.getMessage();


### PR DESCRIPTION
## Problem

`AgentService.getStatus` dereferences `executionService.getExecutionStatus(...)` with no null-check, so a **missing execution id** surfaces as a **500** instead of the **404** the SDK maps to `AgentNotFoundException`. This is exactly what `SuiteHttpApi404.getStatusOnMissingExecutionIdRaisesAgentNotFoundException` asserts.

Conductor engines disagree on the missing-id contract, and on the orkes embedded engine there are two failure shapes that both bypassed the intended 404:

- **valid-format UUID, missing** → the orkes facade returns `null` → `getStatus` NPEs → 500.
- **malformed (non-UUID) id** (what the test uses, `does-not-exist-<nanoTime>`) → orkes throws an `"Invalid UUID"` BACKEND_ERROR before the lookup → 500.

Upstream `conductor-core` instead throws its own `NotFoundException`, so upstream never hit this.

## Fix

Normalize **all three** shapes to conductor's `com.netflix.conductor.core.exception.NotFoundException` (which maps to HTTP 404) via a new `requireExecution(...)` helper:

- upstream's own `NotFoundException` → let it propagate;
- `null` facade result → throw `NotFoundException`;
- `"Invalid UUID"` BACKEND_ERROR → caught **scoped to that message** and mapped to `NotFoundException`.

Any other backend failure (e.g. `"HikariDataSource closed"`) is rethrown unchanged so genuine errors still surface as 500. No new exception type or handler is needed — the engine already maps `NotFoundException` → 404.

## Verification

Built into the embedded orkes-conductor server and ran the Java SDK e2e bundle:

```
GET /api/agent/does-not-exist-123/status                    → HTTP 404
GET /api/agent/00000000-0000-0000-0000-000000000000/status  → HTTP 404
SuiteHttpApi404.getStatusOnMissingExecutionIdRaisesAgentNotFoundException  PASSED
```

## Notes

Stacked on #295 (`export-sdk-e2e-release-bundles`); GitHub will retarget this to `main` once #295 merges. Scoped to `getStatus`; the sibling lookups (`getExecution`, `getExecutionTasks`) can adopt the same `requireExecution(...)` guard if they need the same 404 contract.
