### PR TITLE
feat(server): classifier-based agent filtering on list and executions search

### DIFF
--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/AgentController.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/AgentController.java
@@ -146,6 +146,10 @@ public class AgentController {
 
     /**
      * Search agent executions with optional filters.
+     *
+     * <p>{@code classifier} (comma-separated, e.g. {@code agent}) filters on the indexed
+     * execution classifier instead of enumerating agent workflow names. Requires a Conductor
+     * core whose search index supports the classifier field.
      */
     @GetMapping("/executions")
     public Map<String, Object> searchAgentExecutions(
@@ -155,8 +159,10 @@ public class AgentController {
             @RequestParam(required = false) String freeText,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String agentName,
-            @RequestParam(required = false) String sessionId) {
-        return agentService.searchAgentExecutions(start, size, sort, freeText, status, agentName, sessionId);
+            @RequestParam(required = false) String sessionId,
+            @RequestParam(required = false) String classifier) {
+        return agentService.searchAgentExecutions(
+                start, size, sort, freeText, status, agentName, sessionId, classifier);
     }
 
     @GetMapping("/{name}")
@@ -361,15 +367,20 @@ public class AgentController {
 
     // ── Search ──────────────────────────────────────────────────────
 
-    /** Search executions (pass-through to Conductor search, used by UI). */
+    /**
+     * Search executions (pass-through to Conductor search, used by UI). An optional
+     * {@code classifier} filter (comma-separated) is folded into the query as
+     * {@code classifier IN (...)}.
+     */
     @GetMapping("/executions/search")
     public SearchResult<WorkflowSummary> searchExecutionsRaw(
             @RequestParam(defaultValue = "0") int start,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "startTime:DESC") String sort,
             @RequestParam(required = false) String freeText,
-            @RequestParam(required = false) String query) {
-        return agentService.searchExecutionsRaw(start, size, sort, freeText, query);
+            @RequestParam(required = false) String query,
+            @RequestParam(required = false) String classifier) {
+        return agentService.searchExecutionsRaw(start, size, sort, freeText, query, classifier);
     }
 
     // ── Bulk operations ─────────────────────────────────────────────

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -511,7 +511,13 @@ public class AgentService {
      * cores silently drop the condition, so classifier filtering stays opt-in.
      */
     public Map<String, Object> searchAgentExecutions(
-            int start, int size, String sort, String freeText, String status, String agentName, String sessionId,
+            int start,
+            int size,
+            String sort,
+            String freeText,
+            String status,
+            String agentName,
+            String sessionId,
             String classifier) {
         String classifierList = classifier == null
                 ? ""

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/service/AgentService.java
@@ -50,6 +50,7 @@ import dev.agentspan.runtime.model.*;
 import dev.agentspan.runtime.normalizer.NormalizerRegistry;
 import dev.agentspan.runtime.util.ModelParser;
 import dev.agentspan.runtime.util.ProviderValidator;
+import dev.agentspan.runtime.util.WorkflowClassifiers;
 
 import lombok.RequiredArgsConstructor;
 
@@ -448,7 +449,11 @@ public class AgentService {
 
         for (WorkflowDef def : allDefs) {
             Map<String, Object> metadata = def.getMetadata();
-            if (metadata == null || !metadata.containsKey("agent_sdk")) {
+            // A def is an agent when its derived classifier resolves to "agent": either the
+            // AgentSpan stamp (agent_sdk/agentDef) is present, or the def carries an explicit
+            // metadata.classifier=agent tag. An explicit non-agent classifier excludes a def
+            // even if it still carries a stamp.
+            if (!WorkflowClassifiers.isAgent(metadata)) {
                 continue;
             }
 
@@ -493,25 +498,52 @@ public class AgentService {
      */
     public Map<String, Object> searchAgentExecutions(
             int start, int size, String sort, String freeText, String status, String agentName, String sessionId) {
-        // Determine which workflow types to query
-        List<String> workflowNames;
-        if (agentName != null && !agentName.isEmpty()) {
-            workflowNames = List.of(agentName);
+        return searchAgentExecutions(start, size, sort, freeText, status, agentName, sessionId, null);
+    }
+
+    /**
+     * Search agent executions with optional filters.
+     *
+     * <p>When {@code classifier} is provided (e.g. {@code agent}), the search filters on the
+     * indexed execution classifier ({@code classifier IN (...)}) instead of enumerating every
+     * agent workflow name into the query. This scales past name-list limits but requires a
+     * Conductor core whose index backend supports the {@code classifier} search field; older
+     * cores silently drop the condition, so classifier filtering stays opt-in.
+     */
+    public Map<String, Object> searchAgentExecutions(
+            int start, int size, String sort, String freeText, String status, String agentName, String sessionId,
+            String classifier) {
+        String classifierList = classifier == null
+                ? ""
+                : Arrays.stream(classifier.split(","))
+                        .map(String::trim)
+                        .filter(c -> !c.isEmpty())
+                        .collect(Collectors.joining(","));
+        StringBuilder query;
+        if (!classifierList.isEmpty()) {
+            query = new StringBuilder("classifier IN (").append(classifierList).append(")");
+            if (agentName != null && !agentName.isEmpty()) {
+                query.append(" AND workflowType = '").append(agentName).append("'");
+            }
         } else {
-            workflowNames = listAgents().stream().map(AgentSummary::getName).collect(Collectors.toList());
-        }
+            // Legacy path: enumerate agent workflow names into the query.
+            List<String> workflowNames;
+            if (agentName != null && !agentName.isEmpty()) {
+                workflowNames = List.of(agentName);
+            } else {
+                workflowNames = listAgents().stream().map(AgentSummary::getName).collect(Collectors.toList());
+            }
 
-        if (workflowNames.isEmpty()) {
-            Map<String, Object> empty = new LinkedHashMap<>();
-            empty.put("totalHits", 0L);
-            empty.put("results", List.of());
-            return empty;
-        }
+            if (workflowNames.isEmpty()) {
+                Map<String, Object> empty = new LinkedHashMap<>();
+                empty.put("totalHits", 0L);
+                empty.put("results", List.of());
+                return empty;
+            }
 
-        // Build query string
-        String nameList = workflowNames.stream().map(n -> "'" + n + "'").collect(Collectors.joining(","));
-        StringBuilder query =
-                new StringBuilder("workflowType IN (").append(nameList).append(")");
+            String nameList = workflowNames.stream().map(n -> "'" + n + "'").collect(Collectors.joining(","));
+            query = new StringBuilder("workflowType IN (").append(nameList).append(")");
+        }
         if (status != null && !status.isEmpty()) {
             query.append(" AND status = '").append(status).append("'");
         }
@@ -1574,7 +1606,32 @@ public class AgentService {
 
     public SearchResult<WorkflowSummary> searchExecutionsRaw(
             int start, int size, String sort, String freeText, String query) {
-        return workflowService.searchWorkflows(start, size, sort, freeText, query);
+        return searchExecutionsRaw(start, size, sort, freeText, query, null);
+    }
+
+    public SearchResult<WorkflowSummary> searchExecutionsRaw(
+            int start, int size, String sort, String freeText, String query, String classifier) {
+        return workflowService.searchWorkflows(start, size, sort, freeText, withClassifierFilter(query, classifier));
+    }
+
+    /**
+     * Folds an optional classifier filter (comma-separated values, e.g. {@code agent} or
+     * {@code agent,workflow}) into the structured search query as a
+     * {@code classifier IN (...)} clause, mirroring Conductor's own search endpoints.
+     */
+    static String withClassifierFilter(String query, String classifier) {
+        if (classifier == null || classifier.isBlank()) {
+            return query;
+        }
+        String values = Arrays.stream(classifier.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(","));
+        if (values.isEmpty()) {
+            return query;
+        }
+        String clause = "classifier IN (" + values + ")";
+        return (query == null || query.isBlank()) ? clause : query + " AND " + clause;
     }
 
     public WorkflowDef getAgentDefinition(String name, Integer version) {

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/util/WorkflowClassifiers.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/util/WorkflowClassifiers.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.util;
+
+import java.util.Map;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+/**
+ * Derives the <b>classifier</b> of a workflow definition from its {@code metadata} map.
+ *
+ * <p>The classifier distinguishes kinds of definitions/executions: an untagged def is a plain
+ * <b>workflow</b>; AgentSpan-compiled defs are tagged <b>agent</b>. A def may also carry any
+ * explicit {@code metadata.classifier} value, enabling future kinds without code changes.
+ *
+ * <p>Resolution order:
+ *
+ * <ol>
+ *   <li>explicit {@code metadata.classifier} (non-blank) — wins;
+ *   <li>otherwise {@code "agent"} when the AgentSpan stamp is present ({@code metadata.agent_sdk}
+ *       or {@code metadata.agentDef});
+ *   <li>otherwise {@code "workflow"} (a normal, untagged workflow).
+ * </ol>
+ *
+ * <p>This is a local mirror of Conductor's
+ * {@code com.netflix.conductor.common.metadata.workflow.WorkflowClassifier} so the library keeps
+ * working against Conductor cores that predate that class. Once the minimum supported
+ * {@code conductorVersion} ships it, this class can delegate to (or be replaced by) the Conductor
+ * one. The derivation logic must stay in sync.
+ */
+public final class WorkflowClassifiers {
+
+    /** Classifier value for AgentSpan agent definitions/executions. */
+    public static final String AGENT = "agent";
+
+    /** Classifier value for plain (untagged) workflow definitions/executions. */
+    public static final String WORKFLOW = "workflow";
+
+    private static final String META_CLASSIFIER = "classifier";
+    private static final String META_AGENT_SDK = "agent_sdk";
+    private static final String META_AGENT_DEF = "agentDef";
+
+    private WorkflowClassifiers() {}
+
+    /** Returns the classifier for {@code def}, never {@code null}. */
+    public static String classifierOf(WorkflowDef def) {
+        return def == null ? WORKFLOW : classifierOf(def.getMetadata());
+    }
+
+    /** Returns the classifier derived from a workflow def {@code metadata} map. */
+    public static String classifierOf(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return WORKFLOW;
+        }
+        Object explicit = metadata.get(META_CLASSIFIER);
+        if (explicit instanceof String s && !s.isBlank()) {
+            return s;
+        }
+        if (metadata.get(META_AGENT_SDK) != null || metadata.get(META_AGENT_DEF) != null) {
+            return AGENT;
+        }
+        return WORKFLOW;
+    }
+
+    /** Returns {@code true} when the def resolves to the {@link #AGENT} classifier. */
+    public static boolean isAgent(Map<String, Object> metadata) {
+        return AGENT.equalsIgnoreCase(classifierOf(metadata));
+    }
+}

--- a/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/service/AgentServiceClassifierFilterTest.java
+++ b/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/service/AgentServiceClassifierFilterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AgentService#withClassifierFilter(String, String)} — the folding of the
+ * optional classifier request parameter into Conductor's structured search query. Deterministic —
+ * pure string logic.
+ */
+class AgentServiceClassifierFilterTest {
+
+    @Test
+    void nullOrBlankClassifierLeavesQueryUntouched() {
+        assertThat(AgentService.withClassifierFilter("status = 'RUNNING'", null))
+                .isEqualTo("status = 'RUNNING'");
+        assertThat(AgentService.withClassifierFilter("status = 'RUNNING'", "  "))
+                .isEqualTo("status = 'RUNNING'");
+        assertThat(AgentService.withClassifierFilter(null, null)).isNull();
+    }
+
+    @Test
+    void classifierOnlyBecomesTheQuery() {
+        assertThat(AgentService.withClassifierFilter(null, "agent"))
+                .isEqualTo("classifier IN (agent)");
+        assertThat(AgentService.withClassifierFilter("", "agent"))
+                .isEqualTo("classifier IN (agent)");
+    }
+
+    @Test
+    void classifierIsAppendedToExistingQuery() {
+        assertThat(AgentService.withClassifierFilter("status = 'RUNNING'", "agent"))
+                .isEqualTo("status = 'RUNNING' AND classifier IN (agent)");
+    }
+
+    @Test
+    void commaSeparatedValuesAreTrimmed() {
+        assertThat(AgentService.withClassifierFilter(null, " agent , workflow "))
+                .isEqualTo("classifier IN (agent,workflow)");
+    }
+
+    @Test
+    void degenerateClassifierValueIsIgnored() {
+        assertThat(AgentService.withClassifierFilter("status = 'RUNNING'", " , ,"))
+                .isEqualTo("status = 'RUNNING'");
+    }
+}

--- a/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/service/AgentServiceClassifierFilterTest.java
+++ b/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/service/AgentServiceClassifierFilterTest.java
@@ -27,10 +27,8 @@ class AgentServiceClassifierFilterTest {
 
     @Test
     void classifierOnlyBecomesTheQuery() {
-        assertThat(AgentService.withClassifierFilter(null, "agent"))
-                .isEqualTo("classifier IN (agent)");
-        assertThat(AgentService.withClassifierFilter("", "agent"))
-                .isEqualTo("classifier IN (agent)");
+        assertThat(AgentService.withClassifierFilter(null, "agent")).isEqualTo("classifier IN (agent)");
+        assertThat(AgentService.withClassifierFilter("", "agent")).isEqualTo("classifier IN (agent)");
     }
 
     @Test

--- a/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/util/WorkflowClassifiersTest.java
+++ b/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/util/WorkflowClassifiersTest.java
@@ -22,16 +22,14 @@ class WorkflowClassifiersTest {
 
     @Test
     void nullDefResolvesToWorkflow() {
-        assertThat(WorkflowClassifiers.classifierOf((WorkflowDef) null))
-                .isEqualTo(WorkflowClassifiers.WORKFLOW);
+        assertThat(WorkflowClassifiers.classifierOf((WorkflowDef) null)).isEqualTo(WorkflowClassifiers.WORKFLOW);
     }
 
     @Test
     void nullOrEmptyMetadataResolvesToWorkflow() {
         assertThat(WorkflowClassifiers.classifierOf((Map<String, Object>) null))
                 .isEqualTo(WorkflowClassifiers.WORKFLOW);
-        assertThat(WorkflowClassifiers.classifierOf(new HashMap<>()))
-                .isEqualTo(WorkflowClassifiers.WORKFLOW);
+        assertThat(WorkflowClassifiers.classifierOf(new HashMap<>())).isEqualTo(WorkflowClassifiers.WORKFLOW);
     }
 
     @Test
@@ -62,8 +60,7 @@ class WorkflowClassifiersTest {
     void blankExplicitClassifierIsIgnored() {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("classifier", "  ");
-        assertThat(WorkflowClassifiers.classifierOf(metadata))
-                .isEqualTo(WorkflowClassifiers.WORKFLOW);
+        assertThat(WorkflowClassifiers.classifierOf(metadata)).isEqualTo(WorkflowClassifiers.WORKFLOW);
     }
 
     @Test

--- a/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/util/WorkflowClassifiersTest.java
+++ b/server/conductor-agentspan/src/test/java/dev/agentspan/runtime/util/WorkflowClassifiersTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+/**
+ * Unit tests for {@link WorkflowClassifiers}. Deterministic — pure derivation logic. Must stay in
+ * sync with Conductor's {@code WorkflowClassifier}.
+ */
+class WorkflowClassifiersTest {
+
+    @Test
+    void nullDefResolvesToWorkflow() {
+        assertThat(WorkflowClassifiers.classifierOf((WorkflowDef) null))
+                .isEqualTo(WorkflowClassifiers.WORKFLOW);
+    }
+
+    @Test
+    void nullOrEmptyMetadataResolvesToWorkflow() {
+        assertThat(WorkflowClassifiers.classifierOf((Map<String, Object>) null))
+                .isEqualTo(WorkflowClassifiers.WORKFLOW);
+        assertThat(WorkflowClassifiers.classifierOf(new HashMap<>()))
+                .isEqualTo(WorkflowClassifiers.WORKFLOW);
+    }
+
+    @Test
+    void agentSdkStampResolvesToAgent() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agent_sdk", "python");
+        assertThat(WorkflowClassifiers.classifierOf(metadata)).isEqualTo(WorkflowClassifiers.AGENT);
+        assertThat(WorkflowClassifiers.isAgent(metadata)).isTrue();
+    }
+
+    @Test
+    void agentDefStampResolvesToAgent() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agentDef", Map.of("name", "my-agent"));
+        assertThat(WorkflowClassifiers.classifierOf(metadata)).isEqualTo(WorkflowClassifiers.AGENT);
+    }
+
+    @Test
+    void explicitClassifierWinsOverStamp() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agent_sdk", "python");
+        metadata.put("classifier", "pipeline");
+        assertThat(WorkflowClassifiers.classifierOf(metadata)).isEqualTo("pipeline");
+        assertThat(WorkflowClassifiers.isAgent(metadata)).isFalse();
+    }
+
+    @Test
+    void blankExplicitClassifierIsIgnored() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("classifier", "  ");
+        assertThat(WorkflowClassifiers.classifierOf(metadata))
+                .isEqualTo(WorkflowClassifiers.WORKFLOW);
+    }
+
+    @Test
+    void explicitAgentClassifierWithoutStampIsAgent() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("classifier", "agent");
+        assertThat(WorkflowClassifiers.isAgent(metadata)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Adds workflow **classifier** support to the runtime server, aligned with the classifier concept being added to OSS Conductor (`WorkflowClassifier` in conductor-common). The classifier is derived from `WorkflowDef.metadata`:

1. explicit `metadata.classifier` (non-blank) wins;
2. otherwise `agent` when the AgentSpan stamp (`agent_sdk` / `agentDef`) is present;
3. otherwise `workflow` (plain untagged def).

## Changes

- **New `WorkflowClassifiers` util** — local mirror of Conductor's `WorkflowClassifier`, since the library is `compileOnly` against a `conductorVersion` that predates the class. Can delegate to the Conductor class once the minimum supported version ships it.
- **`AgentService.listAgents()`** now derives agent-ness via the classifier instead of a raw `metadata.containsKey("agent_sdk")` check, so explicit `metadata.classifier` tags are honored both ways (a def tagged `classifier=agent` without a stamp is listed; a stamped def explicitly tagged something else is excluded).
- **`GET /api/agent/executions` accepts `&classifier=`** (comma-separated). When provided, the search filters on the indexed execution classifier (`classifier IN (...)`) instead of enumerating every agent workflow name into the query — scales past name-list limits. Opt-in: older Conductor cores silently drop unknown search fields, so the name-enumeration path remains the default.
- **`GET /api/agent/executions/search` accepts `&classifier=`**, folded into the pass-through query as `classifier IN (...)` — mirrors Conductor's own search endpoints.

## Testing

- New unit tests: `WorkflowClassifiersTest` (derivation rules) and `AgentServiceClassifierFilterTest` (query folding).
- Full `./gradlew test` in `server/` passes.
- Not yet verified against a live server with a real SDK example — the classifier-filtered execution search requires a Conductor core containing the companion change (conductor PR to follow); the legacy name-enumeration path is unchanged and covered by existing tests.

## Companion change

OSS Conductor branch `feature/workflow-classifier` adds the `WorkflowClassifier` util, a `classifier` field on `WorkflowSummary`, index storage/filtering across Postgres/SQLite/ES7/ES8/OS2/OS3, and `classifier` params on the metadata and workflow search endpoints.