### PR TITLE
Server is the source of truth for LLM provider status; fix Ollama base-URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ agentspan doctor
 | Grok / xAI | `XAI_API_KEY` | `grok/grok-3` |
 | HuggingFace | `HUGGINGFACE_API_KEY` | `hugging_face/meta-llama/Llama-3-70b` |
 | Stability AI | `STABILITY_API_KEY` | `stabilityai/sd3.5-large` |
-| Ollama (local) | `OLLAMA_HOST` | `ollama/llama3` |
+| Ollama (local) | `OLLAMA_BASE_URL` | `ollama/llama3` |
 
 </details>
 

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -298,6 +298,36 @@ type AgentSummary struct {
 	Checksum    string   `json:"checksum"`
 }
 
+// ProviderStatus is one provider's configuration state as reported by the server.
+type ProviderStatus struct {
+	Name       string `json:"name"`
+	Configured bool   `json:"configured"`
+	BaseURL    string `json:"baseUrl,omitempty"`
+	Reachable  *bool  `json:"reachable,omitempty"`
+}
+
+// ProviderStatusReport is the server's authoritative view of LLM provider
+// configuration. Providers are configured on and dialed by the server, so
+// only the server can answer what is usable.
+type ProviderStatusReport struct {
+	ManagedByHost bool             `json:"managedByHost"`
+	Providers     []ProviderStatus `json:"providers"`
+}
+
+// GetProviderStatus asks the server which LLM providers it has configured.
+func (c *Client) GetProviderStatus() (*ProviderStatusReport, error) {
+	resp, err := c.doRequest("GET", "/api/providers/status", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var result ProviderStatusReport
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &result, nil
+}
+
 // ListAgents returns all registered agents
 func (c *Client) ListAgents() ([]AgentSummary, error) {
 	resp, err := c.doRequest("GET", "/api/agent/list", nil)

--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -12,157 +12,111 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/agentspan-ai/agentspan/cli/client"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
-type aiProvider struct {
-	name    string
-	envVars []string          // all must be set for the provider to be "configured"
-	warns   []providerWarning // conditional warnings (checked even if not fully configured)
-	models  []string          // example models available with this provider
+// providerReportLine is one rendered row of the AI Providers section.
+type providerReportLine struct {
+	level string // "ok" | "warn" | "fail" | "skip" | "info"
+	text  string
+	extra []string
 }
 
-type providerWarning struct {
-	condition func() bool
-	message   string
-	fix       string
+// serverProviderInfo maps the server's provider names to display names and the
+// API-key env var used only for shell/server mismatch hints.
+var serverProviderInfo = map[string]struct {
+	display string
+	envVar  string
+}{
+	"openai":      {"OpenAI", "OPENAI_API_KEY"},
+	"anthropic":   {"Anthropic", "ANTHROPIC_API_KEY"},
+	"gemini":      {"Google Gemini", "GEMINI_API_KEY"},
+	"azureopenai": {"Azure OpenAI", "AZURE_OPENAI_API_KEY"},
+	"aws_bedrock": {"AWS Bedrock", "AWS_ACCESS_KEY_ID"},
+	"mistral":     {"Mistral", "MISTRAL_API_KEY"},
+	"cohere":      {"Cohere", "COHERE_API_KEY"},
+	"grok":        {"Grok", "XAI_API_KEY"},
+	"perplexity":  {"Perplexity", "PERPLEXITY_API_KEY"},
+	"huggingface": {"Hugging Face", "HUGGINGFACE_API_KEY"},
+	"ollama":      {"Ollama", ""},
 }
 
-const ollamaDefaultURL = "http://localhost:11434"
+// buildProviderReport turns the server's provider status into display lines.
+// The client shell's env is consulted only to flag mismatches ("key set here
+// but not on the server") — never as evidence that a provider works.
+func buildProviderReport(report *client.ProviderStatusReport, getenv func(string) string) []providerReportLine {
+	if report.ManagedByHost {
+		return []providerReportLine{{
+			level: "info",
+			text:  "Provider configuration is managed by the host platform",
+		}}
+	}
 
-var aiProviders = []aiProvider{
-	{
-		name:    "OpenAI",
-		envVars: []string{"OPENAI_API_KEY"},
-		models: []string{
-			"openai/gpt-4o",
-			"openai/gpt-4o-mini",
-			"openai/o1",
-			"openai/o3-mini",
-		},
-	},
-	{
-		name:    "Anthropic",
-		envVars: []string{"ANTHROPIC_API_KEY"},
-		models: []string{
-			"anthropic/claude-opus-4-20250514",
-			"anthropic/claude-sonnet-4-20250514",
-			"anthropic/claude-3-5-sonnet-20241022",
-		},
-	},
-	{
-		name:    "Google Gemini",
-		envVars: []string{"GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"},
-		warns: []providerWarning{
-			{
-				condition: func() bool {
-					return os.Getenv("GEMINI_API_KEY") != "" && os.Getenv("GOOGLE_CLOUD_PROJECT") == ""
+	var lines []providerReportLine
+	for _, p := range report.Providers {
+		display := p.Name
+		info, known := serverProviderInfo[p.Name]
+		if known {
+			display = info.display
+		}
+
+		if p.Name == "ollama" {
+			if p.Reachable != nil && !*p.Reachable {
+				lines = append(lines, providerReportLine{
+					level: "fail",
+					text:  fmt.Sprintf("%s — server resolved %s, unreachable from the server", display, p.BaseURL),
+					extra: []string{
+						"The URL must be reachable from the AgentSpan server, which makes the LLM calls.",
+						"Fix: agentspan credentials set OLLAMA_BASE_URL <url>  (or set OLLAMA_BASE_URL in the server environment)",
+					},
+				})
+			} else {
+				lines = append(lines, providerReportLine{
+					level: "ok",
+					text:  fmt.Sprintf("%s (%s — reachable from server)", display, p.BaseURL),
+				})
+			}
+			continue
+		}
+
+		switch {
+		case p.Configured:
+			lines = append(lines, providerReportLine{level: "ok", text: display + " — configured on server"})
+		case known && info.envVar != "" && getenv(info.envVar) != "":
+			lines = append(lines, providerReportLine{
+				level: "warn",
+				text:  fmt.Sprintf("%s — %s is set in this shell but the server is not configured", display, info.envVar),
+				extra: []string{
+					fmt.Sprintf("Fix: agentspan credentials set %s <value>  (or restart a local server from this shell)", info.envVar),
 				},
-				message: "GEMINI_API_KEY is set but GOOGLE_CLOUD_PROJECT is missing",
-				fix:     "export GOOGLE_CLOUD_PROJECT=your-gcp-project-id",
-			},
-		},
-		models: []string{
-			"google_gemini/gemini-2.0-flash",
-			"google_gemini/gemini-1.5-pro",
-			"google_gemini/gemini-1.5-flash",
-		},
-	},
-	{
-		name:    "Azure OpenAI",
-		envVars: []string{"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"},
-		warns: []providerWarning{
-			{
-				condition: func() bool {
-					return os.Getenv("AZURE_OPENAI_API_KEY") != "" && os.Getenv("AZURE_OPENAI_ENDPOINT") == ""
-				},
-				message: "AZURE_OPENAI_API_KEY is set but AZURE_OPENAI_ENDPOINT is missing",
-				fix:     "export AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com",
-			},
-			{
-				condition: func() bool {
-					return os.Getenv("AZURE_OPENAI_API_KEY") != "" && os.Getenv("AZURE_OPENAI_DEPLOYMENT") == ""
-				},
-				message: "AZURE_OPENAI_DEPLOYMENT is not set (required to route requests)",
-				fix:     "export AZURE_OPENAI_DEPLOYMENT=your-deployment-name",
-			},
-		},
-		models: []string{
-			"azure_openai/gpt-4o",
-			"azure_openai/gpt-4",
-		},
-	},
-	{
-		name:    "AWS Bedrock",
-		envVars: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
-		warns: []providerWarning{
-			{
-				condition: func() bool {
-					return os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_DEFAULT_REGION") == "" && os.Getenv("AWS_REGION") == ""
-				},
-				message: "No AWS region set — defaults to us-east-1",
-				fix:     "export AWS_DEFAULT_REGION=us-east-1  # or your preferred region",
-			},
-		},
-		models: []string{
-			"aws_bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
-			"aws_bedrock/meta.llama3-70b-instruct-v1:0",
-			"aws_bedrock/amazon.titan-text-express-v1",
-		},
-	},
-	{
-		name:    "Mistral",
-		envVars: []string{"MISTRAL_API_KEY"},
-		models: []string{
-			"mistral/mistral-large-latest",
-			"mistral/mistral-small-latest",
-			"mistral/open-mixtral-8x7b",
-		},
-	},
-	{
-		name:    "Cohere",
-		envVars: []string{"COHERE_API_KEY"},
-		models: []string{
-			"cohere/command-r-plus",
-			"cohere/command-r",
-		},
-	},
-	{
-		name:    "Grok",
-		envVars: []string{"XAI_API_KEY"},
-		models: []string{
-			"grok/grok-3",
-			"grok/grok-3-mini",
-		},
-	},
-	{
-		name:    "Perplexity",
-		envVars: []string{"PERPLEXITY_API_KEY"},
-		models: []string{
-			"perplexity/sonar-pro",
-			"perplexity/sonar",
-		},
-	},
-	{
-		name:    "Hugging Face",
-		envVars: []string{"HUGGINGFACE_API_KEY"},
-		models: []string{
-			"hugging_face/meta-llama/Llama-3-70b-chat-hf",
-		},
-	},
-	{
-		name:    "Stability AI",
-		envVars: []string{"STABILITY_API_KEY"},
-		models: []string{
-			"stabilityai/sd3.5-large",
-			"stabilityai/stable-image-core",
-		},
-	},
+			})
+		default:
+			lines = append(lines, providerReportLine{level: "skip", text: display + " — not configured"})
+		}
+	}
+	return lines
+}
+
+// shellProviderKeys lists provider API-key env vars set in this shell (names only).
+func shellProviderKeys() []string {
+	var keys []string
+	for _, info := range serverProviderInfo {
+		if info.envVar != "" && os.Getenv(info.envVar) != "" {
+			keys = append(keys, info.envVar)
+		}
+	}
+	if os.Getenv("OLLAMA_BASE_URL") != "" {
+		keys = append(keys, "OLLAMA_BASE_URL")
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 var doctorCmd = &cobra.Command{
@@ -268,76 +222,54 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	bold.Println("AI Providers")
 	fmt.Println()
 
+	// Providers are configured on and dialed by the SERVER. Ask it; never
+	// present this shell's env as provider status.
+	cfg := getConfig()
 	configured := 0
-	for _, p := range aiProviders {
-		allSet := isProviderConfigured(p)
-
-		if allSet {
-			configured++
-			green.Printf("  ✓ %s", p.name)
-			dim.Printf("  (%s)\n", strings.Join(p.envVars, ", "))
-
-			// Check for warnings on this provider
-			for _, w := range p.warns {
-				if w.condition() {
-					yellow.Printf("    ⚠ %s\n", w.message)
-					fmt.Printf("      %s\n", w.fix)
-					issues++
-				}
+	providerStatusGap := "" // non-empty when the server's provider status is unavailable
+	report, perr := newClient(cfg).GetProviderStatus()
+	switch {
+	case perr == nil:
+		for _, l := range buildProviderReport(report, os.Getenv) {
+			switch l.level {
+			case "ok":
+				configured++
+				green.Printf("  ✓ %s\n", l.text)
+			case "warn":
+				yellow.Printf("  ⚠ %s\n", l.text)
+				issues++
+			case "fail":
+				red.Printf("  ✗ %s\n", l.text)
+				issues++
+			case "skip":
+				dim.Printf("  - %s\n", l.text)
+			case "info":
+				configured++ // host-managed counts as configured
+				dim.Printf("  %s\n", l.text)
 			}
-
-			// Print available models
-			for _, m := range p.models {
-				dim.Printf("    %s\n", m)
-			}
-		} else {
-			dim.Printf("  - %s", p.name)
-			dim.Printf("  (%s)\n", strings.Join(p.envVars, ", "))
-
-			// Only show warnings for partially configured providers — i.e. at least
-			// one required env var is set, meaning the user is trying to use this
-			// provider. Skip entirely if no vars are set (provider not opted in).
-			partiallyConfigured := false
-			for _, env := range p.envVars {
-				if os.Getenv(env) != "" {
-					partiallyConfigured = true
-					break
-				}
-			}
-			if partiallyConfigured {
-				for _, w := range p.warns {
-					if w.condition() {
-						yellow.Printf("    ⚠ %s\n", w.message)
-						fmt.Printf("      %s\n", w.fix)
-						issues++
-					}
-				}
+			for _, e := range l.extra {
+				fmt.Printf("      %s\n", e)
 			}
 		}
-	}
-
-	// Ollama — special case, no API key, check connectivity
-	ollamaURL := os.Getenv("OLLAMA_BASE_URL")
-	if ollamaURL == "" {
-		ollamaURL = ollamaDefaultURL
-	}
-	ollamaOk := checkOllama(ollamaURL)
-	if ollamaOk {
-		configured++
-		green.Printf("  ✓ Ollama")
-		dim.Printf("  (%s)\n", ollamaURL)
-		dim.Println("    ollama/llama3, ollama/mistral, ollama/phi3, ollama/codellama")
-	} else if os.Getenv("OLLAMA_BASE_URL") != "" {
-		yellow.Printf("  ⚠ Ollama  (not reachable at %s)\n", ollamaURL)
-		fmt.Println("    Check that Ollama is running at the configured URL.")
-		fmt.Printf("    OLLAMA_BASE_URL=%s\n", ollamaURL)
+	case strings.Contains(perr.Error(), "HTTP 404"):
+		// Older server without the status endpoint — be explicit that the
+		// shell env below is NOT the server's view.
+		providerStatusGap = "this server version does not report provider status"
+		dim.Println("  - Server does not report provider status (older server).")
+		if keys := shellProviderKeys(); len(keys) > 0 {
+			dim.Printf("    Keys set in this shell (may not reflect the server): %s\n", strings.Join(keys, ", "))
+		}
+	default:
+		providerStatusGap = "server not reachable"
+		yellow.Printf("  ⚠ Provider status unknown — server not reachable at %s\n", cfg.ServerURL)
+		fmt.Println("    Providers are configured on the server; doctor cannot check them from this machine.")
+		if cfg.IsLocalhost() {
+			if keys := shellProviderKeys(); len(keys) > 0 {
+				dim.Printf("    Keys set in this shell (seeded into a local server at its next start): %s\n",
+					strings.Join(keys, ", "))
+			}
+		}
 		issues++
-	} else {
-		dim.Println("  - Ollama  (not running)")
-		dim.Println("    To use a local Ollama instance:")
-		dim.Println("      Install: https://ollama.com/download")
-		dim.Println("      Default: http://localhost:11434")
-		dim.Println("      Custom:  export OLLAMA_BASE_URL=http://your-host:11434")
 	}
 
 	fmt.Println()
@@ -346,7 +278,6 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	bold.Println("Server")
 	fmt.Println()
 
-	cfg := getConfig()
 	serverAddr := cfg.ServerURL
 	serverOk := checkServer(serverAddr)
 	if serverOk {
@@ -362,19 +293,20 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	bold.Println("Summary")
 	fmt.Println()
 
-	if configured == 0 {
-		red.Println("  ✗ No AI providers configured")
+	if providerStatusGap != "" {
+		yellow.Printf("  ⚠ Provider status unknown (%s)\n", providerStatusGap)
+	} else if configured == 0 {
+		red.Println("  ✗ No AI providers configured on the server")
 		fmt.Println()
-		fmt.Println("  Set at least one provider's API key to get started:")
+		fmt.Println("  Configure at least one provider on the server:")
 		fmt.Println()
-		fmt.Println("    export OPENAI_API_KEY=sk-...")
-		fmt.Println("    export ANTHROPIC_API_KEY=sk-ant-...")
-		fmt.Println("    export GEMINI_API_KEY=AI...")
-		fmt.Println("    export GOOGLE_CLOUD_PROJECT=your-gcp-project-id")
+		fmt.Println("    agentspan credentials set OPENAI_API_KEY sk-...")
+		fmt.Println("    agentspan credentials set ANTHROPIC_API_KEY sk-ant-...")
+		fmt.Println("    # or export the variable in the server's environment before it starts")
 		fmt.Println()
 		issues++
 	} else {
-		green.Printf("  %d AI provider(s) configured\n", configured)
+		green.Printf("  %d AI provider(s) configured on the server\n", configured)
 	}
 
 	if issues == 0 {
@@ -387,15 +319,6 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\n  Docs: %s\n\n", aiModelsDocURL)
 
 	return nil
-}
-
-func isProviderConfigured(p aiProvider) bool {
-	for _, env := range p.envVars {
-		if os.Getenv(env) == "" {
-			return false
-		}
-	}
-	return true
 }
 
 // javaExe returns the java binary path, preferring $JAVA_HOME/bin/java when set.
@@ -478,16 +401,6 @@ func isPortAvailable(port string) bool {
 	}
 	ln.Close()
 	return true
-}
-
-func checkOllama(baseURL string) bool {
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get(baseURL)
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
 }
 
 func checkServer(baseURL string) bool {

--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentspan-ai/agentspan/cli/client"
+)
+
+// The server is the source of truth for provider configuration. Doctor renders
+// the server's report; the client shell's env is only used to detect mismatches
+// ("key set here but not on the server").
+func TestBuildProviderReport(t *testing.T) {
+	reachableFalse := false
+	reachableTrue := true
+
+	report := &client.ProviderStatusReport{
+		Providers: []client.ProviderStatus{
+			{Name: "openai", Configured: true},
+			{Name: "anthropic", Configured: false},
+			{Name: "mistral", Configured: false},
+			{Name: "ollama", Configured: true, BaseURL: "http://gpu-box:11434", Reachable: &reachableFalse},
+		},
+	}
+	env := map[string]string{"ANTHROPIC_API_KEY": "sk-ant-local-only"}
+	getenv := func(k string) string { return env[k] }
+
+	lines := buildProviderReport(report, getenv)
+
+	byName := map[string]providerReportLine{}
+	for _, l := range lines {
+		for _, p := range []string{"OpenAI", "Anthropic", "Mistral", "Ollama"} {
+			if strings.Contains(l.text, p) {
+				byName[p] = l
+			}
+		}
+	}
+
+	// Configured on server → ok
+	if byName["OpenAI"].level != "ok" {
+		t.Fatalf("OpenAI should be ok (server-configured), got %+v", byName["OpenAI"])
+	}
+	// Not configured on server, but key in this shell → mismatch warning pointing at credentials set
+	anthropic := byName["Anthropic"]
+	if anthropic.level != "warn" || !strings.Contains(strings.Join(anthropic.extra, " "), "credentials set") {
+		t.Fatalf("Anthropic should warn about shell/server mismatch with credentials-set hint, got %+v", anthropic)
+	}
+	// Not configured anywhere → informational skip
+	if byName["Mistral"].level != "skip" {
+		t.Fatalf("Mistral should be skip, got %+v", byName["Mistral"])
+	}
+	// Ollama unreachable FROM THE SERVER → fail, message names the URL and the server vantage
+	ollama := byName["Ollama"]
+	if ollama.level != "fail" || !strings.Contains(ollama.text+strings.Join(ollama.extra, " "), "gpu-box") {
+		t.Fatalf("Ollama should fail with server-side unreachable detail, got %+v", ollama)
+	}
+
+	// Reachable ollama → ok
+	report.Providers[3].Reachable = &reachableTrue
+	lines = buildProviderReport(report, getenv)
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l.text, "Ollama") && l.level == "ok" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("reachable Ollama should be ok, got %+v", lines)
+	}
+}
+
+func TestBuildProviderReport_ManagedByHost(t *testing.T) {
+	report := &client.ProviderStatusReport{ManagedByHost: true}
+	lines := buildProviderReport(report, func(string) string { return "" })
+	if len(lines) != 1 || lines[0].level != "info" || !strings.Contains(lines[0].text, "host") {
+		t.Fatalf("managed-by-host should produce a single info line, got %+v", lines)
+	}
+}

--- a/cli/cmd/main_test.go
+++ b/cli/cmd/main_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 AgentSpan
+// Licensed under the MIT License. See LICENSE file in the project root for details.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain sandboxes HOME for the whole package. getConfig persists the
+// package-level serverURL flag to ~/.agentspan/config.json, so any test that
+// sets serverURL (most httptest-based command tests do) would otherwise
+// overwrite the developer's real config with an ephemeral test port.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "agentspan-cmd-test-home-*")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", dir)
+	os.Setenv("USERPROFILE", dir)
+	if vol := filepath.VolumeName(dir); vol != "" {
+		os.Setenv("HOMEDRIVE", vol)
+		os.Setenv("HOMEPATH", dir[len(vol):])
+	}
+	os.Unsetenv("AGENTSPAN_SERVER_URL")
+	os.Unsetenv("AGENT_SERVER_URL")
+	os.Unsetenv("AGENTSPAN_API_KEY")
+
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/cli/cmd/server.go
+++ b/cli/cmd/server.go
@@ -531,6 +531,162 @@ func downloadJAR(downloadURL, destPath string) error {
 
 // --- AI provider check ---
 
+// Local-server preflight: `agentspan server start` launches the server from
+// THIS shell, so its environment genuinely is what the server (and the
+// credential env-seeder) will see. This is the one place a client-side env
+// check is the correct vantage point — doctor asks the running server instead.
+type aiProvider struct {
+	name    string
+	envVars []string          // all must be set for the provider to be "configured"
+	warns   []providerWarning // conditional warnings (checked even if not fully configured)
+	models  []string          // example models available with this provider
+}
+
+type providerWarning struct {
+	condition func() bool
+	message   string
+	fix       string
+}
+
+var aiProviders = []aiProvider{
+	{
+		name:    "OpenAI",
+		envVars: []string{"OPENAI_API_KEY"},
+		models: []string{
+			"openai/gpt-4o",
+			"openai/gpt-4o-mini",
+			"openai/o1",
+			"openai/o3-mini",
+		},
+	},
+	{
+		name:    "Anthropic",
+		envVars: []string{"ANTHROPIC_API_KEY"},
+		models: []string{
+			"anthropic/claude-opus-4-20250514",
+			"anthropic/claude-sonnet-4-20250514",
+			"anthropic/claude-3-5-sonnet-20241022",
+		},
+	},
+	{
+		name:    "Google Gemini",
+		envVars: []string{"GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"},
+		warns: []providerWarning{
+			{
+				condition: func() bool {
+					return os.Getenv("GEMINI_API_KEY") != "" && os.Getenv("GOOGLE_CLOUD_PROJECT") == ""
+				},
+				message: "GEMINI_API_KEY is set but GOOGLE_CLOUD_PROJECT is missing",
+				fix:     "export GOOGLE_CLOUD_PROJECT=your-gcp-project-id",
+			},
+		},
+		models: []string{
+			"google_gemini/gemini-2.0-flash",
+			"google_gemini/gemini-1.5-pro",
+			"google_gemini/gemini-1.5-flash",
+		},
+	},
+	{
+		name:    "Azure OpenAI",
+		envVars: []string{"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"},
+		warns: []providerWarning{
+			{
+				condition: func() bool {
+					return os.Getenv("AZURE_OPENAI_API_KEY") != "" && os.Getenv("AZURE_OPENAI_ENDPOINT") == ""
+				},
+				message: "AZURE_OPENAI_API_KEY is set but AZURE_OPENAI_ENDPOINT is missing",
+				fix:     "export AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com",
+			},
+			{
+				condition: func() bool {
+					return os.Getenv("AZURE_OPENAI_API_KEY") != "" && os.Getenv("AZURE_OPENAI_DEPLOYMENT") == ""
+				},
+				message: "AZURE_OPENAI_DEPLOYMENT is not set (required to route requests)",
+				fix:     "export AZURE_OPENAI_DEPLOYMENT=your-deployment-name",
+			},
+		},
+		models: []string{
+			"azure_openai/gpt-4o",
+			"azure_openai/gpt-4",
+		},
+	},
+	{
+		name:    "AWS Bedrock",
+		envVars: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
+		warns: []providerWarning{
+			{
+				condition: func() bool {
+					return os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_DEFAULT_REGION") == "" && os.Getenv("AWS_REGION") == ""
+				},
+				message: "No AWS region set — defaults to us-east-1",
+				fix:     "export AWS_DEFAULT_REGION=us-east-1  # or your preferred region",
+			},
+		},
+		models: []string{
+			"aws_bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+			"aws_bedrock/meta.llama3-70b-instruct-v1:0",
+			"aws_bedrock/amazon.titan-text-express-v1",
+		},
+	},
+	{
+		name:    "Mistral",
+		envVars: []string{"MISTRAL_API_KEY"},
+		models: []string{
+			"mistral/mistral-large-latest",
+			"mistral/mistral-small-latest",
+			"mistral/open-mixtral-8x7b",
+		},
+	},
+	{
+		name:    "Cohere",
+		envVars: []string{"COHERE_API_KEY"},
+		models: []string{
+			"cohere/command-r-plus",
+			"cohere/command-r",
+		},
+	},
+	{
+		name:    "Grok",
+		envVars: []string{"XAI_API_KEY"},
+		models: []string{
+			"grok/grok-3",
+			"grok/grok-3-mini",
+		},
+	},
+	{
+		name:    "Perplexity",
+		envVars: []string{"PERPLEXITY_API_KEY"},
+		models: []string{
+			"perplexity/sonar-pro",
+			"perplexity/sonar",
+		},
+	},
+	{
+		name:    "Hugging Face",
+		envVars: []string{"HUGGINGFACE_API_KEY"},
+		models: []string{
+			"hugging_face/meta-llama/Llama-3-70b-chat-hf",
+		},
+	},
+	{
+		name:    "Stability AI",
+		envVars: []string{"STABILITY_API_KEY"},
+		models: []string{
+			"stabilityai/sd3.5-large",
+			"stabilityai/stable-image-core",
+		},
+	},
+}
+
+func isProviderConfigured(p aiProvider) bool {
+	for _, env := range p.envVars {
+		if os.Getenv(env) == "" {
+			return false
+		}
+	}
+	return true
+}
+
 const aiModelsDocURL = "https://github.com/agentspan-ai/agentspan/blob/main/docs/ai-models.md"
 
 func checkAIProviderKeys() {

--- a/cli/tui/views/doctor.go
+++ b/cli/tui/views/doctor.go
@@ -2,7 +2,6 @@ package views
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,24 +50,6 @@ type DoctorModel struct {
 	tick     int
 	sections map[string][]CheckResult
 	order    []string
-}
-
-var aiProviders = []struct {
-	Name    string
-	EnvVars []string
-	Example string
-}{
-	{"OpenAI", []string{"OPENAI_API_KEY"}, "gpt-4o"},
-	{"Anthropic", []string{"ANTHROPIC_API_KEY"}, "claude-opus-4"},
-	{"Google Gemini", []string{"GEMINI_API_KEY"}, "gemini-2.0-flash"},
-	{"Azure OpenAI", []string{"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"}, "gpt-4o"},
-	{"AWS Bedrock", []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}, "claude-3-5-sonnet"},
-	{"Mistral", []string{"MISTRAL_API_KEY"}, "mistral-large"},
-	{"Cohere", []string{"COHERE_API_KEY"}, "command-r-plus"},
-	{"Grok", []string{"XAI_API_KEY"}, "grok-3"},
-	{"Perplexity", []string{"PERPLEXITY_API_KEY"}, "sonar-pro"},
-	{"Hugging Face", []string{"HUGGINGFACE_API_KEY"}, "llama-3.1"},
-	{"Stability AI", []string{"STABILITY_API_KEY"}, "sd3.5-large"},
 }
 
 func NewDoctor(c *client.Client) DoctorModel {
@@ -222,8 +203,6 @@ func renderCheckResult(r CheckResult) string {
 	return style.Render(line)
 }
 
-
-
 // ─── Check Commands ──────────────────────────────────────────────────────────
 
 func (m DoctorModel) runSystemChecks() tea.Cmd {
@@ -301,41 +280,67 @@ func (m DoctorModel) runProviderChecks() tea.Cmd {
 	return func() tea.Msg {
 		var results []CheckResult
 
-		for _, p := range aiProviders {
-			allSet := true
-			for _, env := range p.EnvVars {
-				if os.Getenv(env) == "" {
-					allSet = false
-					break
-				}
-			}
-			if allSet {
-				results = append(results, CheckResult{
-					p.Name, CheckPass,
-					p.EnvVars[0] + " set  →  " + p.Example,
-				})
-			} else {
-				results = append(results, CheckResult{
-					p.Name, CheckSkip,
-					"not configured  →  " + p.Example,
-				})
-			}
+		// Providers are configured on and dialed by the SERVER — ask it.
+		// This shell's env vars are not provider status.
+		report, err := m.client.GetProviderStatus()
+		if err != nil {
+			results = append(results, CheckResult{
+				"Providers", CheckWarn,
+				"status unknown — server not reachable (providers are configured on the server)",
+			})
+			return DoctorResultMsg{Section: "AI Providers", Results: results}
+		}
+		if report.ManagedByHost {
+			results = append(results, CheckResult{"Providers", CheckSkip, "managed by the host platform"})
+			return DoctorResultMsg{Section: "AI Providers", Results: results}
 		}
 
-		// Ollama
-		ollamaURL := os.Getenv("OLLAMA_BASE_URL")
-		if ollamaURL == "" {
-			ollamaURL = "http://localhost:11434"
+		for _, p := range report.Providers {
+			name := providerDisplayName(p.Name)
+			switch {
+			case p.Name == "ollama" && p.Reachable != nil && !*p.Reachable:
+				results = append(results, CheckResult{
+					name, CheckFail,
+					"server resolved " + p.BaseURL + " — unreachable from the server",
+				})
+			case p.Name == "ollama":
+				results = append(results, CheckResult{name, CheckPass, "reachable from server at " + p.BaseURL})
+			case p.Configured:
+				results = append(results, CheckResult{name, CheckPass, "configured on server"})
+			default:
+				results = append(results, CheckResult{name, CheckSkip, "not configured"})
+			}
 		}
-		hc := &http.Client{Timeout: 2 * time.Second}
-		if _, err := hc.Get(ollamaURL); err == nil {
-			results = append(results, CheckResult{"Ollama", CheckPass, "connected at " + ollamaURL})
-		} else {
-			results = append(results, CheckResult{"Ollama", CheckSkip, "not running (optional)"})
-		}
-
 		return DoctorResultMsg{Section: "AI Providers", Results: results}
 	}
+}
+
+func providerDisplayName(name string) string {
+	switch name {
+	case "openai":
+		return "OpenAI"
+	case "anthropic":
+		return "Anthropic"
+	case "gemini":
+		return "Google Gemini"
+	case "azureopenai":
+		return "Azure OpenAI"
+	case "aws_bedrock":
+		return "AWS Bedrock"
+	case "mistral":
+		return "Mistral"
+	case "cohere":
+		return "Cohere"
+	case "grok":
+		return "Grok"
+	case "perplexity":
+		return "Perplexity"
+	case "huggingface":
+		return "Hugging Face"
+	case "ollama":
+		return "Ollama"
+	}
+	return name
 }
 
 func (m DoctorModel) runServerChecks() tea.Cmd {
@@ -370,6 +375,6 @@ func min(a, b int) int {
 
 // ─── Test accessors ───────────────────────────────────────────────────────────
 
-func (m DoctorModel) Running() bool                    { return m.running }
-func (m DoctorModel) Sections() map[string][]CheckResult { return m.sections }
+func (m DoctorModel) Running() bool                           { return m.running }
+func (m DoctorModel) Sections() map[string][]CheckResult      { return m.sections }
 func (m *DoctorModel) SetSections(s map[string][]CheckResult) { m.sections = s; m.running = false }

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -709,7 +709,7 @@ Set at least one API key. The server auto-detects and enables providers when the
 | **`COHERE_API_KEY`** | Cohere |
 | **`XAI_API_KEY`** | Grok / xAI |
 | **`PERPLEXITY_API_KEY`** | Perplexity |
-| `OLLAMA_HOST` | Ollama (e.g. `http://localhost:11434`) |
+| `OLLAMA_BASE_URL` | Ollama (e.g. `http://localhost:11434`) |
 
 ### Observability
 

--- a/server/README.md
+++ b/server/README.md
@@ -312,7 +312,7 @@ Providers are auto-enabled when their API key env var is set. No manual integrat
 | Perplexity | `PERPLEXITY_API_KEY` | Sonar Pro, Sonar |
 | HuggingFace | `HUGGINGFACE_API_KEY` | Llama 3, Mistral, Zephyr |
 | Stability AI | `STABILITY_API_KEY` | SD3.5-large, Stable Image Core |
-| Ollama (local) | `OLLAMA_HOST` | llama3, mistral, phi3, codellama |
+| Ollama (local) | `OLLAMA_BASE_URL` | llama3, mistral, phi3, codellama |
 
 ### Metrics
 

--- a/server/conductor-agentspan-server/src/main/resources/application.properties
+++ b/server/conductor-agentspan-server/src/main/resources/application.properties
@@ -121,7 +121,10 @@ conductor.ai.gemini.location=${GOOGLE_CLOUD_LOCATION:us-central1}
 conductor.ai.gemini.api-key=${GEMINI_API_KEY:}
 
 # Ollama (local inference server)
-conductor.ai.ollama.base-url=${OLLAMA_HOST:http://localhost:11434}
+# OLLAMA_BASE_URL is the documented variable (docs/ai-models.md). OLLAMA_HOST
+# is Ollama's native bind-address variable (often 0.0.0.0:11434, not a
+# callable URL) and is deliberately not read.
+conductor.ai.ollama.base-url=${OLLAMA_BASE_URL:http://localhost:11434}
 
 
 #

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/ai/AgentspanAIModelProviderOllamaTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/ai/AgentspanAIModelProviderOllamaTest.java
@@ -52,8 +52,7 @@ class AgentspanAIModelProviderOllamaTest {
         Environment env = mock(Environment.class);
         when(env.getProperty(anyString(), anyString())).thenAnswer(i -> i.getArgument(1));
 
-        provider = new AgentspanAIModelProvider(
-                List.of(), env, new OkHttpClient(), credentialService, tokenService);
+        provider = new AgentspanAIModelProvider(List.of(), env, new OkHttpClient(), credentialService, tokenService);
     }
 
     @AfterEach
@@ -70,8 +69,7 @@ class AgentspanAIModelProviderOllamaTest {
 
     private static String baseUrlOf(AIModel model) {
         assertThat(model).isInstanceOf(Ollama.class);
-        OllamaConfiguration config =
-                (OllamaConfiguration) ReflectionTestUtils.getField(model, "config");
+        OllamaConfiguration config = (OllamaConfiguration) ReflectionTestUtils.getField(model, "config");
         return config.getBaseURL();
     }
 

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/ai/AgentspanAIModelProviderOllamaTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/ai/AgentspanAIModelProviderOllamaTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License.
+ */
+package dev.agentspan.runtime.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.AIModel;
+import org.conductoross.conductor.ai.model.LLMWorkerInput;
+import org.conductoross.conductor.ai.providers.ollama.Ollama;
+import org.conductoross.conductor.ai.providers.ollama.OllamaConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
+
+import dev.agentspan.runtime.credentials.CredentialResolutionService;
+import dev.agentspan.runtime.credentials.ExecutionTokenService;
+
+import okhttp3.OkHttpClient;
+
+/**
+ * Ollama base-URL resolution through the per-user provider path.
+ *
+ * <p>The server is the source of truth for provider configuration. An
+ * {@code OLLAMA_BASE_URL} credential in the store (set via UI or
+ * {@code agentspan credentials set} — the no-restart prod path) and a
+ * per-agent {@code base_url} must reach the model the agent calls, not
+ * silently fall back to the startup default of {@code localhost:11434}.</p>
+ */
+class AgentspanAIModelProviderOllamaTest {
+
+    private static final String ANON_USER = "00000000-0000-0000-0000-000000000000";
+    private static final String REMOTE_URL = "http://gpu-box:11434";
+
+    private CredentialResolutionService credentialService;
+    private AgentspanAIModelProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        credentialService = mock(CredentialResolutionService.class);
+        ExecutionTokenService tokenService = mock(ExecutionTokenService.class);
+        Environment env = mock(Environment.class);
+        when(env.getProperty(anyString(), anyString())).thenAnswer(i -> i.getArgument(1));
+
+        provider = new AgentspanAIModelProvider(
+                List.of(), env, new OkHttpClient(), credentialService, tokenService);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        TaskContext.clear();
+    }
+
+    private static LLMWorkerInput ollamaInput() {
+        LLMWorkerInput input = new LLMWorkerInput();
+        input.setLlmProvider("ollama");
+        input.setModel("llama3");
+        return input;
+    }
+
+    private static String baseUrlOf(AIModel model) {
+        assertThat(model).isInstanceOf(Ollama.class);
+        OllamaConfiguration config =
+                (OllamaConfiguration) ReflectionTestUtils.getField(model, "config");
+        return config.getBaseURL();
+    }
+
+    @Test
+    void getModel_ollama_usesCredentialStoreBaseUrl() {
+        when(credentialService.resolve(ANON_USER, "OLLAMA_BASE_URL")).thenReturn(REMOTE_URL);
+
+        AIModel model = provider.getModel(ollamaInput());
+
+        assertThat(baseUrlOf(model)).isEqualTo(REMOTE_URL);
+    }
+
+    @Test
+    void getModel_ollama_usesPerAgentBaseUrlFromTaskInput() {
+        when(credentialService.resolve(anyString(), anyString())).thenReturn(null);
+        Task task = new Task();
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setInputData(Map.of("baseUrl", "http://per-agent-host:11434"));
+        TaskContext.set(task);
+
+        AIModel model = provider.getModel(ollamaInput());
+
+        assertThat(baseUrlOf(model)).isEqualTo("http://per-agent-host:11434");
+    }
+}

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/ProviderControllerEmbeddedTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/ProviderControllerEmbeddedTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import dev.agentspan.runtime.ai.AgentspanAIModelProvider;
+
+import okhttp3.OkHttpClient;
+
+/**
+ * Embedded-mode contract of {@code GET /api/providers/status}.
+ *
+ * <p>When embedded ({@code agentspan.embedded=true}), the host platform (e.g.
+ * orkes-conductor) owns provider integrations and credentials, so the endpoint
+ * must defer — {@code managedByHost: true}, no per-provider claims, and no
+ * probes — rather than report agentspan's own (wrong there) view. Delegating
+ * real status to the host is tracked in
+ * <a href="https://github.com/agentspan-ai/agentspan/issues/310">#310</a>;
+ * the wire contract here is forward-compatible with it.</p>
+ */
+class ProviderControllerEmbeddedTest {
+
+    private ProviderController controller(boolean embedded, AgentspanAIModelProvider modelProvider) {
+        Environment env = mock(Environment.class);
+        when(env.getProperty(anyString(), anyString())).thenAnswer(i -> i.getArgument(1));
+        ProviderController controller = new ProviderController(modelProvider, new OkHttpClient(), env);
+        ReflectionTestUtils.setField(controller, "embedded", embedded);
+        return controller;
+    }
+
+    @Test
+    void embedded_reportsManagedByHost_withoutQueryingProviderMachinery() {
+        AgentspanAIModelProvider modelProvider = mock(AgentspanAIModelProvider.class);
+
+        Map<String, Object> body = controller(true, modelProvider).status();
+
+        assertThat(body.get("managedByHost")).isEqualTo(true);
+        assertThat((List<?>) body.get("providers")).isEmpty();
+        // The host owns provider config — agentspan's own view must not leak in.
+        verifyNoInteractions(modelProvider);
+    }
+
+    @Test
+    void standalone_reportsProviders_notManagedByHost() {
+        AgentspanAIModelProvider modelProvider = mock(AgentspanAIModelProvider.class);
+        when(modelProvider.isProviderConfigured(anyString())).thenReturn(false);
+        // Loopback discard port — connection refused instantly, probe returns false.
+        when(modelProvider.resolveConfiguredBaseUrl("ollama")).thenReturn("http://127.0.0.1:9");
+
+        Map<String, Object> body = controller(false, modelProvider).status();
+
+        assertThat(body.get("managedByHost")).isEqualTo(false);
+        assertThat((List<?>) body.get("providers")).isNotEmpty();
+        verify(modelProvider, atLeastOnce()).isProviderConfigured(anyString());
+    }
+}

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/ProviderStatusEndpointTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/ProviderStatusEndpointTest.java
@@ -71,9 +71,12 @@ class ProviderStatusEndpointTest {
     }
 
     private Map<String, JsonNode> providersByName(JsonNode body) {
-        assertThat(body.has("providers")).as("body has providers array: %s", body).isTrue();
+        assertThat(body.has("providers"))
+                .as("body has providers array: %s", body)
+                .isTrue();
         List<JsonNode> list = body.get("providers").findParents("name");
-        return list.stream().collect(java.util.stream.Collectors.toMap(n -> n.get("name").asText(), n -> n));
+        return list.stream()
+                .collect(java.util.stream.Collectors.toMap(n -> n.get("name").asText(), n -> n));
     }
 
     @Test

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/ProviderStatusEndpointTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/controller/ProviderStatusEndpointTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.controller;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.agentspan.runtime.AgentRuntime;
+import dev.agentspan.runtime.spi.CredentialStoreProvider;
+
+/**
+ * GET /api/providers/status — the server is the source of truth for provider
+ * configuration. Doctor (and the UI) must be able to ask the server what it
+ * has, instead of guessing from the client shell's environment, which is
+ * meaningless for remote/Docker/K8s deployments.
+ */
+@SpringBootTest(classes = AgentRuntime.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ProviderStatusEndpointTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String ANON = "00000000-0000-0000-0000-000000000000";
+    // 127.0.0.1:9 (discard port) — connection refused immediately, so the
+    // reachability probe fails fast without a real Ollama.
+    private static final String UNREACHABLE_URL = "http://127.0.0.1:9";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private CredentialStoreProvider store;
+
+    private String savedOllamaUrl;
+
+    @BeforeEach
+    void setUp() {
+        savedOllamaUrl = store.get(ANON, "OLLAMA_BASE_URL");
+        store.set(ANON, "OLLAMA_BASE_URL", UNREACHABLE_URL);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        store.delete(ANON, "OLLAMA_BASE_URL");
+        if (savedOllamaUrl != null) store.set(ANON, "OLLAMA_BASE_URL", savedOllamaUrl);
+    }
+
+    private JsonNode getStatus() throws Exception {
+        URI uri = URI.create("http://localhost:" + port + "/api/providers/status");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        conn.setRequestMethod("GET");
+        assertThat(conn.getResponseCode()).isEqualTo(200);
+        return MAPPER.readTree(conn.getInputStream());
+    }
+
+    private Map<String, JsonNode> providersByName(JsonNode body) {
+        assertThat(body.has("providers")).as("body has providers array: %s", body).isTrue();
+        List<JsonNode> list = body.get("providers").findParents("name");
+        return list.stream().collect(java.util.stream.Collectors.toMap(n -> n.get("name").asText(), n -> n));
+    }
+
+    @Test
+    void status_reportsKnownProvidersWithConfiguredFlag() throws Exception {
+        Map<String, JsonNode> providers = providersByName(getStatus());
+
+        assertThat(providers).containsKey("openai");
+        assertThat(providers).containsKey("anthropic");
+        assertThat(providers).containsKey("ollama");
+        assertThat(providers.get("openai").has("configured")).isTrue();
+    }
+
+    @Test
+    void status_ollamaReportsResolvedUrlAndServerSideReachability() throws Exception {
+        Map<String, JsonNode> providers = providersByName(getStatus());
+        JsonNode ollama = providers.get("ollama");
+
+        // URL resolved from the credential store (the no-restart prod path)
+        assertThat(ollama.get("baseUrl").asText()).isEqualTo(UNREACHABLE_URL);
+        // Probed from the SERVER's network — the thing no client can know
+        assertThat(ollama.get("reachable").asBoolean()).isFalse();
+        // Credential store means it is configured
+        assertThat(ollama.get("configured").asBoolean()).isTrue();
+    }
+
+    @Test
+    void status_notManagedByHost_inStandaloneMode() throws Exception {
+        JsonNode body = getStatus();
+        assertThat(body.get("managedByHost").asBoolean()).isFalse();
+    }
+}

--- a/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/credentials/CredentialEnvSeederTest.java
+++ b/server/conductor-agentspan-server/src/test/java/dev/agentspan/runtime/credentials/CredentialEnvSeederTest.java
@@ -228,6 +228,24 @@ class CredentialEnvSeederTest {
     }
 
     @Test
+    void seeder_seedsOllamaBaseUrl_inRealDb() throws Exception {
+        // OLLAMA_BASE_URL is the documented Ollama variable and what the
+        // provider resolves from the credential store — it must be seeded.
+        storeProvider.delete(ANONYMOUS_USER_ID, "OLLAMA_BASE_URL");
+
+        Function<String, String> envLookup = name -> "OLLAMA_BASE_URL".equals(name) ? "http://gpu-box:11434" : null;
+
+        CredentialEnvSeeder seeder = new CredentialEnvSeeder(storeProvider, envLookup);
+        var field = CredentialEnvSeeder.class.getDeclaredField("credentialsStore");
+        field.setAccessible(true);
+        field.set(seeder, "built-in");
+
+        seeder.run(new org.springframework.boot.DefaultApplicationArguments());
+
+        assertThat(storeProvider.get(ANONYMOUS_USER_ID, "OLLAMA_BASE_URL")).isEqualTo("http://gpu-box:11434");
+    }
+
+    @Test
     void seeder_storesGitHubCredentials_inRealDb() throws Exception {
         Function<String, String> envLookup = name -> switch (name) {
             case "GH_TOKEN" -> "ghp-test-gh-token";

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/ai/AgentspanAIModelProvider.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/ai/AgentspanAIModelProvider.java
@@ -6,6 +6,7 @@ package dev.agentspan.runtime.ai;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.conductoross.conductor.ai.AIModel;
 import org.conductoross.conductor.ai.AIModelProvider;
@@ -18,6 +19,7 @@ import org.conductoross.conductor.ai.providers.gemini.GeminiVertexConfiguration;
 import org.conductoross.conductor.ai.providers.grok.GrokAIConfiguration;
 import org.conductoross.conductor.ai.providers.huggingface.HuggingFaceConfiguration;
 import org.conductoross.conductor.ai.providers.mistral.MistralAIConfiguration;
+import org.conductoross.conductor.ai.providers.ollama.OllamaConfiguration;
 import org.conductoross.conductor.ai.providers.openai.OpenAIConfiguration;
 import org.conductoross.conductor.ai.providers.perplexity.PerplexityAIConfiguration;
 import org.slf4j.Logger;
@@ -74,7 +76,11 @@ public class AgentspanAIModelProvider extends AIModelProvider {
             Map.entry("cohere", "COHERE_BASE_URL"),
             Map.entry("grok", "GROK_BASE_URL"),
             Map.entry("perplexity", "PERPLEXITY_BASE_URL"),
-            Map.entry("azureopenai", "AZURE_OPENAI_BASE_URL"));
+            Map.entry("azureopenai", "AZURE_OPENAI_BASE_URL"),
+            Map.entry("ollama", "OLLAMA_BASE_URL"));
+
+    /** Providers that need no API key; a base URL alone is enough to build a model. */
+    private static final Set<String> KEYLESS_PROVIDERS = Set.of("ollama");
 
     private final CredentialResolutionService resolutionService;
     private final ExecutionTokenService tokenService;
@@ -106,14 +112,15 @@ public class AgentspanAIModelProvider extends AIModelProvider {
         log.debug("getModel called for provider='{}' model='{}'", provider, input.getModel());
         String userApiKey = resolveUserApiKey(provider);
         log.debug("resolveUserApiKey('{}') returned: {}", provider, userApiKey != null ? "key found" : "null");
+        boolean keyless = KEYLESS_PROVIDERS.contains(provider.toLowerCase());
         if (userApiKey != null || baseUrl != null) {
             try {
                 // If we have a base URL but no user key, try the server-wide key
-                if (userApiKey == null) {
+                if (userApiKey == null && !keyless) {
                     String envVar = PROVIDER_TO_ENV_VAR.get(provider.toLowerCase());
                     userApiKey = envVar != null ? System.getenv(envVar) : null;
                 }
-                if (userApiKey != null) {
+                if (userApiKey != null || keyless) {
                     AIModel model = createModelWithKey(provider, userApiKey, baseUrl);
                     if (model != null) {
                         log.debug("Per-user AIModel created for provider '{}' baseUrl='{}'", provider, baseUrl);
@@ -202,6 +209,18 @@ public class AgentspanAIModelProvider extends AIModelProvider {
     }
 
     /**
+     * Resolve the credential-store base URL for a provider (e.g. {@code OLLAMA_BASE_URL}
+     * for ollama), or null when none is stored. Used by the provider-status endpoint —
+     * the server-side source of truth that doctor and the UI query.
+     */
+    public String resolveConfiguredBaseUrl(String provider) {
+        String envVarName = PROVIDER_TO_BASE_URL_ENV.get(provider.toLowerCase());
+        if (envVarName == null) return null;
+        String value = resolveUserCredential(envVarName);
+        return (value != null && !value.isBlank()) ? value : null;
+    }
+
+    /**
      * Resolve any named credential for the current user.
      */
     private String resolveUserCredential(String credentialName) {
@@ -271,6 +290,7 @@ public class AgentspanAIModelProvider extends AIModelProvider {
                     case "azureopenai" -> new AzureOpenAIConfiguration(
                             apiKey, baseUrl, null, null, conductorAiHttpClient);
                     case "mistral" -> new MistralAIConfiguration(apiKey, baseUrl, conductorAiHttpClient);
+                    case "ollama" -> new OllamaConfiguration(baseUrl, null, null, conductorAiHttpClient);
                     case "cohere" -> new CohereAIConfiguration(apiKey, baseUrl, conductorAiHttpClient);
                     case "grok" -> new GrokAIConfiguration(apiKey, baseUrl, conductorAiHttpClient);
                     case "huggingface" -> {

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/ProviderController.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/ProviderController.java
@@ -85,8 +85,7 @@ public class ProviderController {
             if ("ollama".equals(name)) {
                 String baseUrl = modelProvider.resolveConfiguredBaseUrl("ollama");
                 if (baseUrl == null) {
-                    baseUrl = environment.getProperty(
-                            "conductor.ai.ollama.base-url", "http://localhost:11434");
+                    baseUrl = environment.getProperty("conductor.ai.ollama.base-url", "http://localhost:11434");
                 }
                 entry.put("baseUrl", baseUrl);
                 entry.put("reachable", probe(baseUrl));
@@ -99,7 +98,8 @@ public class ProviderController {
     /** Reachability from the server's own network — the fact no client can observe. */
     private boolean probe(String baseUrl) {
         try {
-            OkHttpClient client = conductorAiHttpClient.newBuilder()
+            OkHttpClient client = conductorAiHttpClient
+                    .newBuilder()
                     .connectTimeout(PROBE_TIMEOUT)
                     .readTimeout(PROBE_TIMEOUT)
                     .callTimeout(PROBE_TIMEOUT.plusSeconds(1))

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/ProviderController.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/ProviderController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 AgentSpan
+ * Licensed under the MIT License. See LICENSE file in the project root for details.
+ */
+
+package dev.agentspan.runtime.controller;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.agentspan.runtime.ai.AgentspanAIModelProvider;
+
+import lombok.RequiredArgsConstructor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Provider configuration status — the server-side source of truth.
+ *
+ * <p>Providers are configured on and dialed by the <b>server</b> (env at startup,
+ * credential store, application.properties). Client-side tools like
+ * {@code agentspan doctor} cannot know this from their own environment — a client
+ * shell's {@code OPENAI_API_KEY} means nothing to a remote or containerized server.
+ * This endpoint lets clients ask instead of guess.</p>
+ *
+ * <ul>
+ *   <li>{@code GET /api/providers/status} — per-provider {@code configured} flag;
+ *       for URL-based providers (ollama) also the resolved {@code baseUrl} and
+ *       {@code reachable}, probed from the <b>server's</b> network.</li>
+ * </ul>
+ *
+ * <p>When embedded in a host (e.g. orkes-conductor) the host owns provider
+ * configuration, so the endpoint reports {@code managedByHost: true} and no
+ * per-provider detail (mirrors {@code ProviderValidator}'s deference).</p>
+ */
+@RestController
+@RequestMapping("/api/providers")
+@RequiredArgsConstructor
+public class ProviderController {
+
+    /** Providers surfaced in status, aligned with the docs' provider list. */
+    private static final List<String> KNOWN_PROVIDERS = List.of(
+            "openai",
+            "anthropic",
+            "gemini",
+            "azureopenai",
+            "aws_bedrock",
+            "mistral",
+            "cohere",
+            "grok",
+            "perplexity",
+            "huggingface",
+            "ollama");
+
+    private static final Duration PROBE_TIMEOUT = Duration.ofSeconds(2);
+
+    private final AgentspanAIModelProvider modelProvider;
+    private final OkHttpClient conductorAiHttpClient;
+    private final Environment environment;
+
+    @Value("${agentspan.embedded:false}")
+    private boolean embedded;
+
+    @GetMapping("/status")
+    public Map<String, Object> status() {
+        if (embedded) {
+            return Map.of("managedByHost", true, "providers", List.of());
+        }
+
+        List<Map<String, Object>> providers = new ArrayList<>();
+        for (String name : KNOWN_PROVIDERS) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("name", name);
+            entry.put("configured", modelProvider.isProviderConfigured(name));
+            if ("ollama".equals(name)) {
+                String baseUrl = modelProvider.resolveConfiguredBaseUrl("ollama");
+                if (baseUrl == null) {
+                    baseUrl = environment.getProperty(
+                            "conductor.ai.ollama.base-url", "http://localhost:11434");
+                }
+                entry.put("baseUrl", baseUrl);
+                entry.put("reachable", probe(baseUrl));
+            }
+            providers.add(entry);
+        }
+        return Map.of("managedByHost", false, "providers", providers);
+    }
+
+    /** Reachability from the server's own network — the fact no client can observe. */
+    private boolean probe(String baseUrl) {
+        try {
+            OkHttpClient client = conductorAiHttpClient.newBuilder()
+                    .connectTimeout(PROBE_TIMEOUT)
+                    .readTimeout(PROBE_TIMEOUT)
+                    .callTimeout(PROBE_TIMEOUT.plusSeconds(1))
+                    .build();
+            Request request = new Request.Builder().url(baseUrl).get().build();
+            try (Response ignored = client.newCall(request).execute()) {
+                return true; // any HTTP response counts — the host is dialable
+            }
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/ProviderController.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/controller/ProviderController.java
@@ -41,7 +41,12 @@ import okhttp3.Response;
  *
  * <p>When embedded in a host (e.g. orkes-conductor) the host owns provider
  * configuration, so the endpoint reports {@code managedByHost: true} and no
- * per-provider detail (mirrors {@code ProviderValidator}'s deference).</p>
+ * per-provider detail (mirrors {@code ProviderValidator}'s deference).
+ * Delegating real per-provider status to the host via a
+ * {@code ProviderStatusSource} SPI is tracked in
+ * <a href="https://github.com/agentspan-ai/agentspan/issues/310">#310</a>;
+ * the wire contract is forward-compatible ({@code managedByHost} stays,
+ * {@code providers} fills in).</p>
  */
 @RestController
 @RequestMapping("/api/providers")

--- a/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/KnownProviderEnvVars.java
+++ b/server/conductor-agentspan/src/main/java/dev/agentspan/runtime/credentials/KnownProviderEnvVars.java
@@ -73,6 +73,8 @@ public final class KnownProviderEnvVars {
             "AWS_SECRET_ACCESS_KEY",
             "AWS_REGION",
             "BEDROCK_API_KEY",
-            // Ollama (local inference)
-            "OLLAMA_HOST");
+            // Ollama (local inference) — OLLAMA_BASE_URL is the documented
+            // variable; OLLAMA_HOST is Ollama's bind-address variable and is
+            // deliberately not read (often 0.0.0.0:11434, not a callable URL)
+            "OLLAMA_BASE_URL");
 }


### PR DESCRIPTION
## Problem

User report: *"agentspan doctor connects to my remote Ollama just fine, but when I run my agent it tries to connect to localhost."*

Root cause: `agentspan doctor` validated **server-side** provider configuration (all provider API keys + the Ollama URL) against the **client shell's** environment. That's only meaningful when the client and server share one shell (same-machine local dev); for remote, Docker/K8s, daemonized, UI-configured, or embedded deployments it produces false ✓/✗ with authority. Two server bugs compounded it:

1. `conductor.ai.ollama.base-url` read `OLLAMA_HOST`, while the public docs (and doctor) say `OLLAMA_BASE_URL` — a user configuring the server exactly per docs got localhost.
2. `ollama` was missing from `AgentspanAIModelProvider`'s resolution paths, so an `OLLAMA_BASE_URL` credential (UI / `agentspan credentials set` — the no-restart prod path) and a per-agent `base_url` were silently ignored.

## Fix — the server answers, the client asks

**Server**
- Property reads `${OLLAMA_BASE_URL:http://localhost:11434}` per the documented contract. `OLLAMA_HOST` is never read — it's Ollama's native *bind-address* variable (commonly `0.0.0.0:11434`), not a callable URL.
- Ollama resolves like every other provider: per-agent `baseUrl` → `OLLAMA_BASE_URL` credential → property → localhost, with a keyless model-creation path. The env-seeder seeds `OLLAMA_BASE_URL`.
- New `GET /api/providers/status`: per-provider `configured` flag (existing `isProviderConfigured`, so UI-added credentials count immediately), and for Ollama the resolved URL plus `reachable` probed **from the server's network** — the fact no client can observe. Returns `managedByHost: true` when embedded (mirrors `ProviderValidator`).

**CLI**
- doctor (CLI + TUI) renders the server's report. Example output for the original bug:
  `✗ Ollama — server resolved http://localhost:11434, unreachable from the server`
  with the fix command. Client env is used only for mismatch hints (*"OPENAI_API_KEY is set in this shell but the server is not configured → agentspan credentials set …"*) and, when no local server is running, seeding hints. Labeled fallbacks for older servers (404) and unreachable servers.
- The env-table preflight moved to `agentspan server start` — the one place where the current shell genuinely is the server's future environment.
- `TestMain` sandboxes HOME for the `cmd` test package: tests setting the `serverURL` flag were overwriting the developer's real `~/.agentspan/config.json` with ephemeral httptest ports. (The `cli/tui` package tests still have this pollution bug — pre-existing, not addressed here.)

## Verification

- Test-first throughout: provider resolution (2), env-seeder (1), status endpoint (3, failed 404 before the controller existed), doctor report builder (2, failed on stub) — each confirmed red before its change, green after. Full `conductor-agentspan`/`conductor-agentspan-server` suites and `cli` packages pass.
- End-to-end against a live built server: doctor renders server-reported status; `agentspan credentials set OLLAMA_BASE_URL http://gpu-box:11434` changed the server's resolved URL immediately (no restart), delete reverted it.
- Backward-compat path exercised against a real 0.4.0 release jar: doctor reports "server does not report provider status (older server)" instead of guessing.


## Follow-up

- #310 — embedded mode currently returns `{"managedByHost": true, "providers": []}` (correct: the host owns provider config there). Real per-provider status in embedded deployments will come from a `ProviderStatusSource` SPI that the orkes embed implements, alongside the embed's agentspan version bump. The wire contract shipped here is forward-compatible with that.
